### PR TITLE
feat: rich find page + gs symbol bodies + STOP-GUESSING menu + CLI search hooks & skill

### DIFF
--- a/hooks/canonical-find-key.mjs
+++ b/hooks/canonical-find-key.mjs
@@ -1,0 +1,68 @@
+/**
+ * canonical-find-key.mjs — the ONE canonical key for a `coldstart find` term-set.
+ *
+ * SHARED, byte-identical contract between the PreToolUse guard (find-preguard)
+ * and the PostToolUse nudge (find-nudge): the guard DENIES a re-run of a key the
+ * nudge REGISTERED. If the two computed different keys, the guard would block the
+ * wrong calls (or none). Keep this the single source of truth — never inline a
+ * second copy.
+ *
+ * `coldstart find` is a PURE function of its term-SET: reordering terms, changing
+ * case, or repeating a term yields byte-identical output (every ranking stage is
+ * set/sum based, sort is deterministic). So the key normalizes term order, case,
+ * and dups, and folds in the significant flags (scope changes the result).
+ *
+ * Ported 1:1 from the Python `canonical_find_key` (find-nudge.py / find-preguard.py).
+ */
+
+const FIND_RE = /coldstart\s+find\b|index\.js\s+find\b/;
+const TERM_SPLIT_RE = /[\s[\]|,()'".]+/;
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const FLAGS_WITH_VALUE = new Set(["--path", "--max", "-p", "-m"]);
+
+/**
+ * Stable key for a `coldstart find` term-set (+ significant flags), or null if
+ * `cmd` is not a coldstart-find command (or carries no usable terms).
+ * @param {string} cmd
+ * @returns {string|null}
+ */
+export function canonicalFindKey(cmd) {
+  const m = FIND_RE.exec(cmd);
+  if (!m) return null;
+  // everything after the `find` keyword (strip a trailing pipe/redirect)
+  let tail = cmd.slice(m.index + m[0].length);
+  tail = tail.split(/[|;&><]/)[0];
+  const toks = tail.trim() ? tail.trim().split(/\s+/) : [];
+
+  const terms = [];
+  const flags = [];
+  let i = 0;
+  while (i < toks.length) {
+    const t = toks[i];
+    if (t.startsWith("-")) {
+      // --json / --tests are valueless; --path / --max take the next token
+      flags.push(t);
+      if (FLAGS_WITH_VALUE.has(t) && i + 1 < toks.length) {
+        flags.push(toks[i + 1]);
+        i += 1;
+      }
+    } else {
+      // parseTerms: identifiers >= 3 chars, lowercased, deduped
+      for (const w of t.split(TERM_SPLIT_RE)) {
+        if (w.length >= 3 && IDENT_RE.test(w)) terms.push(w.toLowerCase());
+      }
+    }
+    i += 1;
+  }
+
+  const seen = new Set();
+  const dedup = [];
+  for (const w of terms) {
+    if (!seen.has(w)) {
+      seen.add(w);
+      dedup.push(w);
+    }
+  }
+  if (dedup.length === 0) return null;
+  return "T:" + dedup.slice().sort().join(",") + "|F:" + flags.slice().sort().join(",");
+}

--- a/hooks/find-nudge.mjs
+++ b/hooks/find-nudge.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * find-nudge.mjs — PostToolUse entry. Emits search-behaviour nudges + registers
+ * successful find keys for the PreToolUse guard.
+ * Wire as: node <abs>/find-nudge.mjs   (matcher: *, PostToolUse)
+ *
+ * Top-level imports stay node:-builtin-only (via run-hook); the real handler is
+ * dynamic-imported inside the thunk so its parse-time errors are caught + fail-open.
+ */
+import { runHook } from "./run-hook.mjs";
+
+await runHook(async (input) => {
+  const { default: handle } = await import("./nudge-handler.mjs");
+  return handle(input);
+});

--- a/hooks/find-preguard.mjs
+++ b/hooks/find-preguard.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * find-preguard.mjs — PreToolUse entry. DENIES an exact `coldstart find` re-run.
+ * Wire as: node <abs>/find-preguard.mjs   (matcher: Bash, PreToolUse)
+ *
+ * Top-level imports stay node:-builtin-only (via run-hook); the real handler is
+ * dynamic-imported inside the thunk so its parse-time errors are caught + fail-open.
+ */
+import { runHook } from "./run-hook.mjs";
+
+await runHook(async (input) => {
+  const { default: handle } = await import("./preguard-handler.mjs");
+  return handle(input);
+});

--- a/hooks/nudge-handler.mjs
+++ b/hooks/nudge-handler.mjs
@@ -1,0 +1,313 @@
+/**
+ * nudge-handler.mjs — PostToolUse nudge for the `coldstart find` CLI.
+ *
+ * Fires advisory nudges (additionalContext) at the moments the agent's search
+ * behaviour goes wrong. Detectors, each fires sparingly:
+ *
+ *   1. READ-AFTER-2-FINDS  — ran `coldstart find` twice with no Read/gs in between
+ *                            => stop searching, open a candidate.
+ *   2. EMPTY-SEARCH        — a grep/glob/shell-find returned nothing
+ *                            => empty != absent; refine find or read what you have.
+ *   3. NONFIND-SHELL-3     — 3 non-find search/shell calls since last find/Read/gs
+ *                            => the spiral; go back to find or read.
+ *   3b. NO-NEW-EVIDENCE    — a grep/find CONFINED to files already in context
+ *                            => re-checks surfaced data, can't reveal a new file.
+ *                            Recall-safe: any call surfacing a new file is silent.
+ *   4. CHECKPOINT          — every CHECKPOINT_EVERY tool calls
+ *                            => can you answer from what you've read? name the gap.
+ *   5. GS-OVER-SLICE       — sliced the SAME file with `gs` >= GS_SLICE_CAP times
+ *                            => you have its bodies + pointers; answer or move on.
+ *   6. GS-REGUESS          — re-called `gs --symbol` on a file that just returned
+ *                            the method-menu fallback => pick from the menu.
+ *
+ * Also REGISTERS the canonical key of every SUCCESSFUL (non-empty) find into
+ * `seen_find_queries` — the PreToolUse guard (find-preguard) denies a re-run of
+ * a registered key. The key fn is shared (canonical-find-key.mjs); it MUST match
+ * the guard exactly or the deny-key and registration-key drift.
+ *
+ * State per (session,agent) in /tmp. Fail-open: any error → null (runHook swallows).
+ *
+ * Ported 1:1 from find-nudge.py. Thresholds below are the same defaults.
+ */
+
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { canonicalFindKey } from "./canonical-find-key.mjs";
+
+// ---- detector thresholds (tune freely) ----
+const FINDS_BEFORE_READ = 2; // (1) nudge to read after this many finds w/o a Read/gs
+const NONFIND_SHELL_STREAK = 3; // (3) nudge after this many non-find search/shell calls
+const CHECKPOINT_EVERY = 12; // (4) checkpoint nudge cadence, in tool calls
+const GS_SLICE_CAP = 3; // (5) nudge once gs has sliced the SAME file this many times
+const EMPTY_NUDGE_CAP = 3; // (2) max empty-search nudges per session
+const REDUNDANT_CAP = 6; // (3b) max no-new-evidence nudges per session
+
+// coldstart find (the GOOD locator)
+const FIND_RE = /coldstart\s+find\b|index\.js\s+find\b/;
+// coldstart gs (the GOOD reader — slices symbol bodies): read-equivalent for the
+// spiral, but with its own abuse modes (over-slice, re-guess after a menu fallback).
+const GS_RE = /coldstart\s+gs\b|index\.js\s+gs\b/;
+// the gs menu-fallback marker (printed when --symbol isn't a declared symbol)
+const GS_FALLBACK_RE = /NOT a declared symbol here|no declared symbol matches/;
+// search/shell that ISN'T coldstart find/gs — the spiral surface
+const SEARCH_RE =
+  /(^|[;&|]|\s)(grep|egrep|fgrep|rg)\b|git\s+grep|git\s+log|(^|[;&|]|\s)find\s|(^|[;&|]|\s)ls\b|(^|[;&|]|\s)cat\b/;
+const GS_FILE_RE = /(?:coldstart|index\.js)\s+gs\s+(\S+)/;
+
+// Evidence store regexes — paths printed in ANY output, and files named as ARGS.
+const PATH_RE = /[\w./-]+\.(?:py|js|jsx|ts|tsx|htm|html|vue|json|scss|css|rb|java)/g;
+const FILE_ARG_RE =
+  /(?<![\w/])([\w][\w./-]*\.(?:py|js|jsx|ts|tsx|htm|html|vue|json|scss|css|rb|java))\b/g;
+
+/** Mirror of find-nudge.py result_text: extract the raw text payload of a tool
+ * response, collapsing a present-but-empty stdout to "" (NOT to the JSON of the
+ * whole envelope, which would hide emptiness). */
+function resultText(input) {
+  let r = input.tool_response;
+  if (r === undefined) r = input.tool_output;
+  if (r === undefined || r === null) return null;
+  if (typeof r === "string") return r;
+  if (Array.isArray(r)) {
+    return r
+      .map((x) => (x && typeof x === "object" ? x.text || "" : String(x)))
+      .join(" ");
+  }
+  if (typeof r === "object") {
+    const KEYS = ["stdout", "stderr", "content", "output", "result"];
+    if (KEYS.some((k) => k in r)) {
+      return KEYS.map((k) => String(r[k] ?? "")).join("");
+    }
+    return JSON.stringify(r);
+  }
+  return String(r);
+}
+
+function matchAllGroup(re, s, group) {
+  const found = new Set();
+  if (!s) return found;
+  for (const m of s.matchAll(re)) found.add(group ? m[group] : m[0]);
+  return found;
+}
+
+/**
+ * @param {any} input parsed PostToolUse stdin payload
+ * @returns {object|null} an additionalContext envelope, or null for no nudge
+ */
+export default function handle(input) {
+  const sid = input.session_id || "default";
+  const aid = input.agent_id || ""; // set when inside a subagent
+  const tool = input.tool_name || "";
+  const tin = input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {};
+  const cmd = typeof tin.command === "string" ? tin.command : "";
+  const out = resultText(input);
+
+  const key = aid ? `${sid}_${aid}` : sid;
+  const stateFile = `/tmp/find_nudge_${key}.json`;
+  const st = {
+    seen_find: false,
+    total: 0,
+    finds_since_read: 0,
+    nonfind_streak: 0,
+    empty_fired: 0,
+    last_checkpoint: 0,
+    read_fired: false,
+    shell_fired: false,
+    gs_counts: {},
+    gs_slice_fired: [],
+    last_gs_fallback: "",
+    gs_reguess_fired: false,
+    held_files: [],
+    redundant_fired: 0,
+    seen_find_queries: [],
+  };
+  try {
+    Object.assign(st, JSON.parse(readFileSync(stateFile, "utf8")));
+  } catch {
+    /* defaults */
+  }
+
+  // classify this call
+  const isFind = tool === "Bash" && FIND_RE.test(cmd);
+  const isGs = tool === "Bash" && GS_RE.test(cmd);
+  let gsFile = "";
+  if (isGs) {
+    const gm = GS_FILE_RE.exec(cmd);
+    gsFile = gm ? gm[1] : "";
+  }
+  const prevFallback = st.last_gs_fallback || ""; // set by the PREVIOUS gs call's output
+  const isRead = tool === "Read";
+  // gs/find are tools, not the grep-spiral, even when piped to head/grep
+  const isSearch =
+    tool === "Grep" ||
+    tool === "Glob" ||
+    (tool === "Bash" && !isFind && !isGs && SEARCH_RE.test(cmd));
+  const isNonfindShell = isSearch;
+
+  const _ob = out !== null && out !== undefined ? out.trim().toLowerCase() : null;
+  const outEmpty =
+    _ob !== null &&
+    (_ob === "" ||
+      _ob.includes("completed with no output") ||
+      _ob === "no matches found" ||
+      _ob === "no files found");
+
+  st.total += 1;
+  const msgs = []; // [priority, text]; lower priority number = more urgent, wins
+
+  // --- evidence: what files THIS call touched, and which are genuinely NEW ---
+  const held = new Set(st.held_files || []);
+  const outFiles = matchAllGroup(PATH_RE, out, 0);
+  const cmdFiles = matchAllGroup(FILE_ARG_RE, cmd, 1);
+  if (isRead) {
+    const rp = typeof tin.file_path === "string" ? tin.file_path : "";
+    if (rp) cmdFiles.add(rp);
+  }
+  const scope = new Set([...outFiles, ...cmdFiles]);
+  const novel = [...scope].filter((f) => !held.has(f)); // files newly in context
+
+  if (isFind) {
+    st.seen_find = true;
+    st.finds_since_read += 1;
+    st.nonfind_streak = 0;
+    st.shell_fired = false;
+    // register the canonical key ONLY on a successful (non-empty) result, so the
+    // PreToolUse guard never blocks a retry of a find that errored/returned nothing.
+    if (out && !outEmpty) {
+      const ck = canonicalFindKey(cmd);
+      if (ck && !st.seen_find_queries.includes(ck)) {
+        st.seen_find_queries = st.seen_find_queries.concat([ck]);
+      }
+    }
+    if (st.finds_since_read >= FINDS_BEFORE_READ && !st.read_fired) {
+      st.read_fired = true;
+      msgs.push([
+        2,
+        `You've run \`coldstart find\` ${st.finds_since_read}× without opening a file. ` +
+          "The page already ranks candidates and shows symbol + body lines WITH line numbers — " +
+          "stop searching and READ the 1–2 most promising now. Refine the query only if a file's " +
+          "actual contents send you elsewhere.",
+      ]);
+    }
+  } else if (isRead) {
+    st.finds_since_read = 0;
+    st.nonfind_streak = 0;
+    st.read_fired = false;
+    st.shell_fired = false;
+  } else if (isGs) {
+    // gs opens file content — credit it like a Read for the spiral/find counters.
+    st.finds_since_read = 0;
+    st.nonfind_streak = 0;
+    st.read_fired = false;
+    st.shell_fired = false;
+    const counts = st.gs_counts || {};
+    counts[gsFile] = (counts[gsFile] || 0) + 1;
+    st.gs_counts = counts;
+    const fired = st.gs_slice_fired || [];
+    // (6) GS-REGUESS — the previous gs on THIS file returned the method menu, and
+    // the agent is slicing it again instead of picking a name from that menu.
+    if (gsFile && prevFallback === gsFile && !st.gs_reguess_fired) {
+      st.gs_reguess_fired = true;
+      msgs.push([
+        2,
+        `\`${gsFile}\` just returned its method MENU — the \`--symbol\` name you passed isn't declared ` +
+          "there. Pick a name from that menu, or `Read` the file. Re-calling `gs --symbol` with another " +
+          "guessed name on the same file is the single most common wasted call — you already have the menu.",
+      ]);
+    } else if (gsFile && counts[gsFile] >= GS_SLICE_CAP && !fired.includes(gsFile)) {
+      // (5) GS-OVER-SLICE — sliced one file enough times; you have it.
+      fired.push(gsFile);
+      st.gs_slice_fired = fired;
+      msgs.push([
+        2,
+        `You've sliced \`${gsFile}\` ${counts[gsFile]}× with \`gs\` — you have its bodies plus the ` +
+          "`calls:`/`callers:` pointers, so you almost certainly have enough of THIS file. Answer from " +
+          "what you have, `Read` it whole if you need lines BETWEEN symbols, or follow a pointer to a " +
+          "DIFFERENT file. Stop re-slicing this one.",
+      ]);
+    }
+  } else if (isNonfindShell && st.seen_find) {
+    st.nonfind_streak += 1;
+    // (3b) NO-NEW-EVIDENCE — per-call: this grep/find is confined to files the
+    // agent ALREADY has in context, so it surfaced nothing new.
+    const confined = scope.size > 0 && novel.length === 0 && !outEmpty;
+    if (confined && (st.redundant_fired || 0) < REDUNDANT_CAP) {
+      st.redundant_fired = (st.redundant_fired || 0) + 1;
+      const heldHits = [...scope].sort().slice(0, 3);
+      const names = heldHits.map((f) => "`" + f + "`").join(", ");
+      msgs.push([
+        1,
+        `This search only touched files you ALREADY have in context — ${names}. You surfaced or read ` +
+          "them earlier, so re-grepping them returns lines you already hold; it cannot reveal a new file. " +
+          "The answer is in the results already in your context — RE-READ those (the find/gs page, the " +
+          "files you opened) and answer the task now. Only search if you can name a genuinely NEW file, " +
+          "identifier, or directory you have not yet covered.",
+      ]);
+    } else if (st.nonfind_streak >= NONFIND_SHELL_STREAK && !st.shell_fired) {
+      // (3) generic spiral fallback — non-find streak, but nothing was re-checked
+      st.shell_fired = true;
+      msgs.push([
+        3,
+        `${st.nonfind_streak} non-find search/shell calls since your last \`coldstart find\`/Read — ` +
+          "this is the spiral. `coldstart find` already body-scans the top files and ranks on filenames " +
+          "and symbols, not just body text. Add the missing term and re-run it, or Read a candidate you " +
+          "already have. Reserve grep for a literal body string you KNOW exists.",
+      ]);
+    }
+  }
+
+  // (2) empty search result — independent, capped
+  if (isSearch && outEmpty && st.empty_fired < EMPTY_NUDGE_CAP) {
+    st.empty_fired += 1;
+    msgs.push([
+      4,
+      "That search returned nothing. An empty result means the term or path is WRONG, not that the " +
+        "thing is absent — don't repeat the same shape or guess spelling variants. If you're grepping a " +
+        "specific FILE for an identifier, run `coldstart gs <file> --symbol <token>` instead: it returns " +
+        "the body lines where the token appears (it greps in-tool), so you stop guessing. Otherwise re-run " +
+        "`coldstart find` with a different salient term, or Read a candidate you already have.",
+    ]);
+  }
+
+  // record whether THIS gs call hit the menu fallback, so the NEXT call can detect a re-guess
+  if (isGs) {
+    st.last_gs_fallback = out && GS_FALLBACK_RE.test(out) ? gsFile : "";
+  }
+
+  // (4) checkpoint — periodic, lowest urgency
+  if (st.total - st.last_checkpoint >= CHECKPOINT_EVERY) {
+    st.last_checkpoint = st.total;
+    msgs.push([
+      5,
+      `Checkpoint (${st.total} tool calls). Stop and think before the next call — answer these in order:\n` +
+        "1. Restate the task in one sentence — what is the ONE thing it asks for?\n" +
+        "2. List the files you have already surfaced or read that bear on it.\n" +
+        "3. Can you answer (1) from (2)? If YES — write the answer now and stop searching; you almost " +
+        "certainly have enough.\n" +
+        "4. Only if NO — name the single specific fact still missing, and make the next call target ONLY " +
+        "that. Do not re-run a search whose results are already in your context.",
+    ]);
+  }
+
+  // merge THIS call's evidence into the store (after novelty was computed above)
+  if (scope.size > 0) {
+    st.held_files = [...new Set([...held, ...scope])];
+  }
+
+  try {
+    const tmp = stateFile + ".tmp";
+    writeFileSync(tmp, JSON.stringify(st));
+    renameSync(tmp, stateFile);
+  } catch {
+    /* never fail on state write */
+  }
+
+  if (msgs.length) {
+    msgs.sort((a, b) => a[0] - b[0]);
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: msgs[0][1],
+      },
+    };
+  }
+  return null;
+}

--- a/hooks/preguard-handler.mjs
+++ b/hooks/preguard-handler.mjs
@@ -1,0 +1,71 @@
+/**
+ * preguard-handler.mjs — PreToolUse guard for the `coldstart find` CLI.
+ *
+ * `coldstart find` is a PURE function of its term-SET: reordering terms, changing
+ * case, or repeating a term yields byte-identical output (every ranking stage is
+ * set/sum based, sort is deterministic by score then unique path). So an exact
+ * re-query is PROVABLY redundant on a static index: its result is already in the
+ * agent's context. This handler canonicalizes a PROPOSED find (lowercase → dedup
+ * → SORT terms, + significant flags) and, if that canonical key was already run
+ * SUCCESSFULLY this session, DENIES the call before it costs a generation.
+ *
+ * Safety:
+ *   - Only EXACT term-set+flag matches are blocked. Add/drop a term, or change
+ *     --path/--tests, and it's a different query that legitimately differs → allowed.
+ *   - Registration happens in the PostToolUse hook (find-nudge) and ONLY on a
+ *     successful, non-empty result — so retrying a FAILED/empty find is never blocked.
+ *   - Flags are folded into the key, so a scoped re-query (`--path ...`) never
+ *     collides with the unscoped one. Bias is toward specificity: a missed dup just
+ *     falls back to the PostToolUse late-catch; a false block is the error we avoid.
+ *   - Fail-open: any error → return null and the call proceeds (runHook swallows).
+ *
+ * State is shared with find-nudge: /tmp/find_nudge_{session}_{agent}.json,
+ * list key `seen_find_queries`.
+ *
+ * Ported 1:1 from find-preguard.py.
+ */
+
+import { readFileSync } from "node:fs";
+import { canonicalFindKey } from "./canonical-find-key.mjs";
+
+const REASON =
+  "You have ALREADY run this exact `coldstart find` earlier in this session — same " +
+  "terms (order/case/repeats don't change the result), same scope. `find` is deterministic " +
+  "on a static index, so re-running it returns the IDENTICAL ranked page you already have in " +
+  "context. Re-read that earlier find result and answer, or search a GENUINELY different " +
+  "term-set (add/drop a salient identifier, or add `--path` to scope it). Do not re-run the " +
+  "same query.";
+
+/**
+ * @param {any} input parsed PreToolUse stdin payload
+ * @returns {object|null} a permissionDecision:"deny" envelope, or null to allow
+ */
+export default function handle(input) {
+  if ((input.tool_name || "") !== "Bash") return null;
+  const tin = input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {};
+  const cmd = typeof tin.command === "string" ? tin.command : "";
+  const key = canonicalFindKey(cmd);
+  if (!key) return null;
+
+  const sid = input.session_id || "default";
+  const aid = input.agent_id || "";
+  const skey = aid ? `${sid}_${aid}` : sid;
+  const stateFile = `/tmp/find_nudge_${skey}.json`;
+
+  let st = {};
+  try {
+    st = JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    st = {};
+  }
+  const seen = Array.isArray(st.seen_find_queries) ? st.seen_find_queries : [];
+  if (!seen.includes(key)) return null; // never run before → allow
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: REASON,
+    },
+  };
+}

--- a/hooks/run-hook.mjs
+++ b/hooks/run-hook.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * run-hook.mjs — crash-resilient wrapper for coldstart Claude Code hook entries.
+ *
+ * Adapted from context-mode's run-hook.mjs (MIT). The whole point: a coldstart
+ * hook must NEVER block a tool call or spam the user, no matter what breaks —
+ * a parse error, a missing dep, a malformed stdin payload, a thrown handler.
+ * Claude Code surfaces a non-zero hook exit as a "non-blocking hook error" on
+ * EVERY matching tool call, so a single bad deploy would nag the user forever.
+ * This wrapper guarantees exit 0 and fail-open (no output = no decision = the
+ * tool proceeds normally) on any failure.
+ *
+ * Three layers of protection:
+ *   1. This file imports ONLY node: built-ins, so it cannot fail at parse time.
+ *   2. process-level uncaughtException / unhandledRejection nets, installed
+ *      before any handler runs, catch async throws the try/catch would miss.
+ *   3. The handler is invoked inside a try; any throw is logged and we exit 0.
+ *      Load your real handler via dynamic import INSIDE the handler thunk so its
+ *      own parse-time import errors are caught here too (see usage below).
+ *
+ * Failures log to <configDir>/coldstart/hook-errors.log, where configDir honors
+ * $CLAUDE_CONFIG_DIR (incl. a leading ~) and falls back to ~/.claude.
+ *
+ * Usage — keep the entry file's top-level imports to node: built-ins only:
+ *     #!/usr/bin/env node
+ *     import { runHook } from "./run-hook.mjs";
+ *     await runHook(async (input) => {
+ *       const { default: handle } = await import("./pretooluse-handler.mjs");
+ *       return handle(input); // return an object → printed as JSON to stdout
+ *     });
+ *
+ * The handler receives the parsed stdin payload (or {} if stdin was empty/bad)
+ * and may return:
+ *   - undefined / null  → no stdout (fail-open: tool proceeds)
+ *   - a string          → written to stdout verbatim
+ *   - an object         → JSON.stringify'd to stdout (e.g. a PreToolUse
+ *                         permissionDecision, or PostToolUse additionalContext)
+ */
+
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+
+// Inlined so this wrapper stays dependency-free (parse-time-proof).
+function resolveClaudeConfigDir() {
+  const envVal = process.env.CLAUDE_CONFIG_DIR;
+  if (envVal) {
+    if (envVal.startsWith("~")) return join(homedir(), envVal.replace(/^~[/\\]?/, ""));
+    return envVal;
+  }
+  return resolve(homedir(), ".claude");
+}
+
+function logError(err) {
+  try {
+    const dir = resolve(resolveClaudeConfigDir(), "coldstart");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const line = `[${new Date().toISOString()}] pid=${process.pid} ${err?.stack || err?.message || String(err)}\n`;
+    appendFileSync(resolve(dir, "hook-errors.log"), line);
+  } catch {
+    /* never fail logging */
+  }
+}
+
+// Safety nets BEFORE any handler code runs. Static top-level imports in the
+// ENTRY file would bypass these, which is why the entry must dynamic-import its
+// real handler from inside the thunk.
+process.on("uncaughtException", (err) => {
+  logError(err);
+  process.exit(0);
+});
+process.on("unhandledRejection", (err) => {
+  logError(err);
+  process.exit(0);
+});
+
+/** Read all of stdin. Resolves to "" if stdin is closed/empty. */
+function readStdin() {
+  return new Promise((res) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      res(data);
+    };
+    try {
+      if (process.stdin.isTTY) return done();
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (c) => (data += c));
+      process.stdin.on("end", done);
+      process.stdin.on("error", done);
+      // Hard ceiling so a wedged pipe can never hang the tool call.
+      setTimeout(done, 2000).unref?.();
+    } catch {
+      done();
+    }
+  });
+}
+
+/**
+ * Run a hook handler with full crash-resilience. Reads + parses stdin, invokes
+ * the handler, prints its return value, and ALWAYS exits 0.
+ *
+ * @param {(input: any) => Promise<unknown> | unknown} handler
+ */
+export async function runHook(handler) {
+  let input = {};
+  try {
+    const raw = await readStdin();
+    if (raw && raw.trim()) input = JSON.parse(raw);
+  } catch (e) {
+    // Malformed/absent payload is non-fatal — hand the handler {} and let it
+    // decide. Most handlers no-op without the fields they need.
+    logError(e);
+  }
+
+  try {
+    const out = await handler(input);
+    if (out == null) {
+      // fail-open / no-op: emit nothing, tool proceeds normally.
+    } else if (typeof out === "string") {
+      process.stdout.write(out);
+    } else {
+      process.stdout.write(JSON.stringify(out));
+    }
+  } catch (e) {
+    logError(e);
+    // Swallow: no stdout means no hook decision → the tool is not blocked.
+  }
+  process.exit(0);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Local MCP server for AI agent codebase navigation — domain mapping, dependency tracing, file structure lookup",
   "type": "module",
   "bin": {
-    "coldstart-mcp": "./dist/index.js"
+    "coldstart-mcp": "./dist/index.js",
+    "coldstart": "./dist/index.js"
   },
   "main": "./dist/index.js",
   "files": [

--- a/skills/coldstart/SKILL.md
+++ b/skills/coldstart/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: coldstart
+description: Find which files are relevant to a task BEFORE reading or grepping. Use coldstart whenever you need to locate code by concept (a feature, symbol, model, route, config), trace who uses/calls/imports a file, or map an unfamiliar codebase. Reach for it first instead of Grep/Glob/find — it matches concepts against indexed filenames, path segments, and exported symbols across the whole repo in one fast local call, and tells you who depends on a file. Two commands: `coldstart go` (locate files) and `coldstart gs` (drill into one file).
+---
+
+# coldstart
+
+A static codebase navigator. It answers two questions fast and locally (no model call):
+- **`go`** — which files are relevant to this concept?
+- **`gs`** — for one file: its symbols, who imports it, who calls each symbol, and name-related neighbors.
+
+Use it BEFORE Read/Grep/Glob when you're orienting in a codebase or finding where something lives. It's ~10× cheaper than bash-grep for concept lookups and it sees the import graph, which grep cannot.
+
+## The flow
+
+1. `coldstart go <concept>` → pick the best path from the result.
+2. `coldstart gs <that file>` → see its shape + who uses it.
+3. `Read` only when you need the actual implementation inside a method body.
+
+## Commands
+
+```
+coldstart go <query...> [--path GLOB] [--tests] [--max N] [--json]
+coldstart gs <file>     [--match TERM] [--view full|symbols|imports|importers|callers] [--json]
+```
+
+Load-bearing flags:
+- **`--path`** (`go`) — scope to a glob, e.g. `--path 'arches/app/**/*.py'`. Comma-combine; `!` to exclude. Sharper than a broad query.
+- **`--tests`** (`go`) — include test files (excluded by default).
+- **`--match`** (`gs`) — on a big/god-file, filter to one area: `coldstart gs models.py --match tile`. Substring (case-insensitive); `a|b` to OR; `/regex/` for regex.
+- **`--view`** (`gs`) — narrow the output: `symbols` / `imports` / `importers` / `callers` instead of the default `full`.
+
+Run `coldstart go --help` for the rest.
+
+## Use ONE bash call for independent lookups
+
+Don't serialize lookups that don't depend on each other — batch them in a single command so they cost one turn:
+
+```
+coldstart go authentication; coldstart go 'session cookie'; coldstart gs src/auth/service.ts
+```
+
+## Pipe to trim before output enters context
+
+A god-file's full structure is large. If you only need one area, filter or slice:
+
+```
+coldstart gs arches/app/models/models.py --match tile | head -40
+coldstart go payment --max 5
+```
+
+Don't pull a whole god-file's structure when you need one slice of it.
+
+## Reading the output
+
+**`go` results** are grouped into sections by WHERE the query matched (file/dir names; code/symbol names; both). **Sections are categories, NOT a ranking** — the best match can sit in any section, so scan all of them. Each line is `<path> matched: [tok1, tok2, ...]` — the matched name tokens, rarest-first (leftmost = strongest signal).
+
+Annotations carry real relations:
+- `← imported by X (also listed)` — an import edge between two shown results.
+- `~ shares \`token\` with X (also listed)` — the two share a rare identifier/string the import graph can't see (migration↔model twins, config-by-name, cross-language pairs). **Treat a linked pair as one unit: if one is worth reading, fetch the other in the same step.**
+
+**Content presence:** if a query word matches no declared name, `go` reports where that word lives in file *bodies* — naming the files (rare word), giving a count (common word), or stating it appears **NOWHERE**. Trust the nowhere line: the identifier doesn't exist in this repo — don't grep spelling variants of it.
+
+**`gs` Importers with `--match`** additionally lists EVERY indexed file (any language) whose content references the matched term. That subsection IS the complete "who uses X" answer — it is exhaustive over indexed content, so a subsystem absent from it does NOT use the symbol. Don't grep to re-enumerate or re-verify use-sites.
+
+**`gs` Related** = files sharing rare tokens with this one when no import edge connects them. First-class neighbors (Django migrations↔models, cross-language pairs); the shared token shown is the reason.
+
+## Stop rule
+
+If you've run `gs` on 5+ files for one question, you're enumerating — go back to `go` with a sharper `--path` or a different concept token instead of drilling further.
+
+## When NOT to use it
+
+- Searching for a literal string/phrase/regex inside file bodies (comments, templates, SQL) → that's Grep. (But check `go`'s Content-presence line first — it may already tell you the file or that the string is absent.)
+- Reading an implementation → that's Read, after `gs` gives you the shape.

--- a/src/cache/disk-cache.ts
+++ b/src/cache/disk-cache.ts
@@ -2,8 +2,9 @@ import { readFile, writeFile, mkdir, access, readdir, rm } from 'node:fs/promise
 import { join, resolve, basename } from 'node:path';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
-import type { CodebaseIndex, CacheMeta } from '../types.js';
+import type { CodebaseIndex, CacheMeta, IndexedFile } from '../types.js';
 import { CACHE_VERSION, CACHE_TTL_MS } from '../constants.js';
+import { buildContentTokenPostings, buildContentPresenceIndex } from '../indexer/content-tokens.js';
 
 const DEFAULT_CACHE_DIR = join(homedir(), '.coldstart', 'indexes');
 const FILES_CHUNK_SIZE = 5000;
@@ -267,6 +268,14 @@ function deserializeIndex(plain: SerializedIndex): CodebaseIndex {
   const outEdges = new Map<string, string[]>(Object.entries(plain.outEdges));
   const inEdges = new Map<string, string[]>(Object.entries(plain.inEdges));
   const tokenDocFreq = new Map<string, number>(Object.entries(plain.tokenDocFreq ?? {}));
+  // Derived, not serialized: per-file contentTokens round-trip through the
+  // files chunks; rebuilding the postings here is a cheap single pass.
+  const contentTokenPostings = buildContentTokenPostings(
+    files.values() as Iterable<IndexedFile>,
+  );
+  const contentPresenceIndex = buildContentPresenceIndex(
+    files.values() as Iterable<IndexedFile>,
+  );
 
   return {
     rootDir: plain.rootDir,
@@ -278,5 +287,7 @@ function deserializeIndex(plain: SerializedIndex): CodebaseIndex {
     outEdges,
     inEdges,
     tokenDocFreq,
+    contentTokenPostings,
+    contentPresenceIndex,
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,201 @@
+/**
+ * coldstart CLI query surface — `go` / `gs` / `index`.
+ *
+ * Design rule (see docs/cli-skill-spec.md): the query path is a PURE READER.
+ * It loads the on-disk cache and runs the SAME handlers the MCP server uses
+ * (handleGetOverview / handleGetStructure), printing their `__rawText` to
+ * stdout so output is byte-identical to the MCP tool and pipeable.
+ *
+ * Cache miss is the one exception: `go`/`gs` will lazily build + save so the
+ * tool is usable without an explicit prep step. This build+save is NOT
+ * concurrency-safe (no lock) — fine for sequential CLI use; the product-grade
+ * single-writer prep is `coldstart index` (and, later, the write-only daemon).
+ * Diagnostics go to stderr; stdout carries only the answer.
+ */
+import { resolve } from 'node:path';
+import { loadCachedIndex, saveCachedIndex } from './cache/disk-cache.js';
+import { getGitHead } from './indexer/git.js';
+import { handleGetOverview, handleGetStructure } from './server/tools.js';
+import type { CodebaseIndex } from './types.js';
+
+type BuildFn = (
+  rootDir: string,
+  excludes: string[],
+  includes: string[],
+  quiet: boolean,
+) => Promise<CodebaseIndex>;
+
+type HandlerResult = { __rawText?: string; error?: string } & Record<string, unknown>;
+
+function err(...args: unknown[]): void {
+  process.stderr.write(args.join(' ') + '\n');
+}
+
+interface ParsedArgs {
+  positional: string[];
+  flags: {
+    path?: string;
+    match?: string;
+    symbol?: string;
+    view?: string;
+    max?: string;
+    page?: string;
+    root?: string;
+    cacheDir?: string;
+    tests?: boolean;
+    json?: boolean;
+    via?: boolean;
+  };
+}
+
+function parseQueryArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: ParsedArgs['flags'] = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--path': flags.path = argv[++i]; break;
+      case '--match': flags.match = argv[++i]; break;
+      case '--symbol': flags.symbol = argv[++i]; break;
+      case '--view': flags.view = argv[++i]; break;
+      case '--max': flags.max = argv[++i]; break;
+      case '--page': flags.page = argv[++i]; break;
+      case '--root': flags.root = argv[++i]; break;
+      case '--cache-dir': flags.cacheDir = argv[++i]; break;
+      case '--tests': flags.tests = true; break;
+      case '--json': flags.json = true; break;
+      case '--via': flags.via = true; break;
+      default:
+        if (a.startsWith('--')) err(`[coldstart] unknown flag: ${a}`);
+        else positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+/**
+ * Load the index from cache (pure read). On cache miss or git-HEAD drift,
+ * lazily build + save. Returns null only on hard failure.
+ */
+async function getIndex(
+  root: string,
+  cacheDir: string | undefined,
+  buildIndex: BuildFn,
+): Promise<CodebaseIndex | null> {
+  const t0 = Date.now();
+  let index = await loadCachedIndex(root, cacheDir);
+  if (index) {
+    const head = await getGitHead(root);
+    if (head && index.gitHead && head !== index.gitHead) {
+      err('[coldstart] cache stale (git HEAD changed) — rebuilding');
+      index = null;
+    } else {
+      err(`[coldstart] cache hit (${Date.now() - t0}ms, ${index.files.size} files)`);
+      return index;
+    }
+  }
+
+  // Lazy build+save. Run `coldstart index` once to avoid paying this per query.
+  if (!index) err('[coldstart] cache miss — building (run `coldstart index` once to prep)');
+  index = await buildIndex(root, [], [], true);
+  try {
+    await saveCachedIndex(index, cacheDir);
+  } catch (e) {
+    err(`[coldstart] warn: could not save cache: ${e}`);
+  }
+  err(`[coldstart] built ${index.files.size} files in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  return index;
+}
+
+function stripRaw(result: HandlerResult): Record<string, unknown> {
+  const { __rawText, ...rest } = result;
+  void __rawText;
+  return rest;
+}
+
+function emit(result: HandlerResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify(stripRaw(result), null, 2) + '\n');
+    return;
+  }
+  process.stdout.write((result.__rawText ?? result.error ?? '') + '\n');
+}
+
+export async function runGo(argv: string[], buildIndex: BuildFn): Promise<number> {
+  const { positional, flags } = parseQueryArgs(argv);
+  const query = positional.join(' ').trim();
+  if (!query) {
+    err('usage: coldstart go <query...> [--path GLOB] [--tests] [--max N] [--page N] [--json]');
+    return 1;
+  }
+  const root = resolve(flags.root ?? '.');
+  const index = await getIndex(root, flags.cacheDir, buildIndex);
+  if (!index) { err('[coldstart] no index available'); return 1; }
+
+  const result = handleGetOverview(index, {
+    query,
+    max_results: flags.max ? Number(flags.max) : undefined,
+    include_tests: flags.tests === true,
+    path: flags.path,
+    page: flags.page ? Number(flags.page) : undefined,
+  }) as HandlerResult;
+
+  emit(result, flags.json === true);
+  return 0;
+}
+
+export async function runGs(argv: string[], buildIndex: BuildFn): Promise<number> {
+  const { positional, flags } = parseQueryArgs(argv);
+  const file = positional[0];
+  if (!file) {
+    err('usage: coldstart gs <file> [--symbol NAME[,NAME]] [--match TERM] [--view full|symbols|imports|importers|callers] [--json]');
+    return 1;
+  }
+  const root = resolve(flags.root ?? '.');
+  const index = await getIndex(root, flags.cacheDir, buildIndex);
+  if (!index) { err('[coldstart] no index available'); return 1; }
+
+  const result = handleGetStructure(index, {
+    file_path: file,
+    match: flags.match,
+    symbol: flags.symbol,
+    view: flags.view as 'full' | 'symbols' | 'imports' | 'importers' | 'callers' | undefined,
+  }) as HandlerResult;
+
+  emit(result, flags.json === true);
+  // file-not-found (no __rawText, only error) → exit 2
+  return result.error && result.__rawText === undefined ? 2 : 0;
+}
+
+export async function runFind(argv: string[], buildIndex: BuildFn): Promise<number> {
+  const { positional, flags } = parseQueryArgs(argv);
+  const query = positional.join(' ').trim();
+  if (!query) {
+    err('usage: coldstart find <terms...>  — pass every salient identifier from the task, not one distilled keyword');
+    return 1;
+  }
+  const root = resolve(flags.root ?? '.');
+  const index = await getIndex(root, flags.cacheDir, buildIndex);
+  if (!index) { err('[coldstart] no index available'); return 1; }
+
+  const { buildRichPage } = await import('./server/find.js');
+  process.stdout.write(buildRichPage(index, root, query, flags.json, flags.via === true) + '\n');
+  return 0;
+}
+
+/** Single-writer prep step: build the index and persist it to cache. */
+export async function runIndexPrep(argv: string[], buildIndex: BuildFn): Promise<number> {
+  const { flags } = parseQueryArgs(argv);
+  const root = resolve(flags.root ?? '.');
+  const t0 = Date.now();
+  err(`[coldstart] building index for ${root}...`);
+  const index = await buildIndex(root, [], [], false); // progress to stderr
+  try {
+    await saveCachedIndex(index, flags.cacheDir);
+  } catch (e) {
+    err(`[coldstart] error: could not save cache: ${e}`);
+    return 1;
+  }
+  err(`[coldstart] indexed ${index.files.size} files, saved to cache in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  return 0;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,7 +95,7 @@ export const DEFAULT_EXCLUDES = new Set([
 ]);
 
 // Cache version — bump when index schema changes to force re-index
-export const CACHE_VERSION = "16.6.0";
+export const CACHE_VERSION = "17.0.0";
 
 // IDF threshold for "rare" token: log(20) ≈ 3.0 — tokens appearing in < 5% of files
 export const IDF_RARITY_THRESHOLD = Math.log(20);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { addCSharpSyntheticEdges } from './indexer/csharp-synthetic.js';
 import { addDjangoSyntheticEdges } from './indexer/django-synthetic.js';
 import { buildGraph } from './indexer/graph.js';
 import { buildFileDomains, isTestPath } from './indexer/tokenize.js';
+import { buildContentTokenPostings, buildContentPresenceIndex } from './indexer/content-tokens.js';
 import { buildSymbolEdges } from './indexer/symbol-edges.js';
 import { getGitHead } from './indexer/git.js';
 import { loadCachedIndex, saveCachedIndex } from './cache/disk-cache.js';
@@ -166,6 +167,7 @@ export async function buildIndex(
             containerResolutions: parsed.containerResolutions,
             djangoConventionRefs: parsed.djangoConventionRefs,
             submoduleImportCandidates: parsed.submoduleImportCandidates,
+            contentTokens: parsed.contentTokens,
           };
           indexedFiles.push(file);
           langCount[wf.language] = (langCount[wf.language] ?? 0) + 1;
@@ -249,6 +251,9 @@ export async function buildIndex(
     }
   }
 
+  const contentTokenPostings = buildContentTokenPostings(indexedFiles);
+  const contentPresenceIndex = buildContentPresenceIndex(indexedFiles);
+
   const gitHead = await getGitHead(rootDir);
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
   log(quiet, `[coldstart] Indexed ${indexedFiles.length} files in ${elapsed}s`);
@@ -270,6 +275,8 @@ export async function buildIndex(
     outEdges,
     inEdges,
     tokenDocFreq,
+    contentTokenPostings,
+    contentPresenceIndex,
     indexedAt: Date.now(),
     gitHead,
   };
@@ -643,6 +650,26 @@ async function main(): Promise<void> {
     const { runRestart } = await import('./restart.js');
     await runRestart();
     return;
+  }
+
+  // CLI query surface — pure-reader `go`/`gs`, plus single-writer `index` prep.
+  // These bypass the daemon entirely: load the on-disk cache, run the same
+  // handlers the MCP server uses, print, exit. (docs/cli-skill-spec.md)
+  if (process.argv[2] === 'go') {
+    const { runGo } = await import('./cli.js');
+    process.exit(await runGo(process.argv.slice(3), buildIndex));
+  }
+  if (process.argv[2] === 'gs') {
+    const { runGs } = await import('./cli.js');
+    process.exit(await runGs(process.argv.slice(3), buildIndex));
+  }
+  if (process.argv[2] === 'find') {
+    const { runFind } = await import('./cli.js');
+    process.exit(await runFind(process.argv.slice(3), buildIndex));
+  }
+  if (process.argv[2] === 'index') {
+    const { runIndexPrep } = await import('./cli.js');
+    process.exit(await runIndexPrep(process.argv.slice(3), buildIndex));
   }
 
   const { root: cliRoot, rootExplicit, excludes, includes, cacheDir, quiet, noCache, daemon, noDaemon, probe } = parseArgs(process.argv);

--- a/src/indexer/content-tokens.ts
+++ b/src/indexer/content-tokens.ts
@@ -1,0 +1,519 @@
+/**
+ * Content-token link channel.
+ *
+ * Extracts rare, identifier-shaped tokens from full file bodies (case
+ * preserved) and derives relations between files that share them. This is the
+ * display-side twin of the implicit-reference resolver gap: literal-name
+ * references that produce NO import edge (Django migrations ↔ models,
+ * config-by-name registration, JS ↔ Python pairs) still co-mention the same
+ * rare identifiers. Evidence, not classification: we show the shared token
+ * and let the agent infer the relation. Ranking is never touched.
+ *
+ * Token gates (each empirically backed — see docs/token-link-enrichment-spec.md):
+ * - shape: multi-word snake_case / camelCase / PascalCase / ALL_CAPS only
+ *   (kills prose: 'preference', 'ideally'). Case is PRESERVED — lowercasing
+ *   hid SEARCH_ITEMS_PER_PAGE and false-killed real camelCase links.
+ * - provenance: comment-derived occurrences dropped at extraction;
+ *   string-literal occurrences flagged (highest-precision class).
+ * - corpus df ∈ [2, DF_MAX]: df=1 links nothing, df>MAX is vocabulary.
+ * - vendored/minified assets and markdown excluded at extraction;
+ *   test files and barrels excluded from postings.
+ */
+import type { CodebaseIndex, IndexedFile } from '../types.js';
+
+// Provenance bit flags per token (OR of all occurrences in the file)
+export const TOKEN_IN_CODE = 1;
+export const TOKEN_IN_STRING = 2;
+
+export const CONTENT_TOKEN_DF_MIN = 2;
+export const CONTENT_TOKEN_DF_MAX = 5;
+// Per-file unique-token safety cap (generated monsters)
+const MAX_TOKENS_PER_FILE = 3000;
+const MIN_TOKEN_LENGTH = 4;
+
+// ---------------------------------------------------------------------------
+// Shape gate — identifier-shaped multi-word tokens only, case preserved
+// ---------------------------------------------------------------------------
+const SHAPE_SNAKE = /^[a-z][a-z0-9]*(?:_+[a-z0-9]+)+$/;
+const SHAPE_CAMEL = /^[a-z][a-z0-9]*(?:[A-Z][a-zA-Z0-9]*)+$/;
+const SHAPE_PASCAL = /^(?:[A-Z][a-z0-9]+){2,}$/;
+const SHAPE_ALL_CAPS = /^[A-Z][A-Z0-9]*(?:_+[A-Z0-9]+)+$/;
+
+export function isShapedToken(t: string): boolean {
+  return (
+    t.length >= MIN_TOKEN_LENGTH &&
+    (SHAPE_SNAKE.test(t) || SHAPE_CAMEL.test(t) || SHAPE_PASCAL.test(t) || SHAPE_ALL_CAPS.test(t))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Vendored / minified asset exclusion (jquery.min.js polluted real pages with
+// browser-API tokens). The walker already skips vendor/node_modules dirs;
+// this catches checked-in copies living under media/static/assets paths.
+// ---------------------------------------------------------------------------
+const VENDORED_SEGMENT = /(?:^|\/)(?:vendor|vendors|third[-_]party|external|packages?\/lib)(?:\/|$)/i;
+
+export function isVendoredAssetPath(relativePath: string): boolean {
+  const lower = relativePath.toLowerCase();
+  if (/\.(?:min|bundle|pack)\.(?:js|css)$/.test(lower)) return true;
+  if (/-min\.(?:js|css)$/.test(lower)) return true;
+  return VENDORED_SEGMENT.test(lower);
+}
+
+// ---------------------------------------------------------------------------
+// Extraction — per line: pull string-literal spans first (their tokens get
+// TOKEN_IN_STRING), truncate at a comment marker, scan the rest as code.
+// Line-based comment handling is deliberately heuristic-generic (no
+// per-language tree-sitter pass in v1); the shape gate kills most prose that
+// slips through (e.g. multi-line docstrings).
+// ---------------------------------------------------------------------------
+const STRING_SPAN = /(["'`])(?:\\.|(?!\1).)*?\1/g;
+const WORD = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+function commentStart(line: string): number {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith('*') || trimmed.startsWith('<!--')) return 0;
+  let cut = -1;
+  const consider = (idx: number): void => {
+    if (idx !== -1 && (cut === -1 || idx < cut)) cut = idx;
+  };
+  consider(line.indexOf('//'));
+  consider(line.indexOf('/*'));
+  consider(line.indexOf('#'));
+  consider(line.indexOf('<!--'));
+  // SQL/Lua-style `--` only when it reads as a comment (start or space-delimited)
+  const dashes = line.match(/(?:^|\s)--(?:\s|$)/);
+  if (dashes && dashes.index !== undefined) consider(dashes.index);
+  return cut;
+}
+
+function addToken(out: Record<string, number>, count: { n: number }, token: string, bit: number): void {
+  if (!isShapedToken(token)) return;
+  const existing = out[token];
+  if (existing === undefined) {
+    if (count.n >= MAX_TOKENS_PER_FILE) return;
+    out[token] = bit;
+    count.n++;
+  } else {
+    out[token] = existing | bit;
+  }
+}
+
+/**
+ * Extract shaped content tokens with provenance bits from a file body.
+ * Returns undefined for excluded files (vendored assets, markdown) so the
+ * field stays absent rather than empty.
+ */
+export function extractContentTokens(
+  content: string,
+  relativePath: string,
+): Record<string, number> | undefined {
+  if (isVendoredAssetPath(relativePath)) return undefined;
+  if (/\.(?:md|markdown)$/i.test(relativePath)) return undefined;
+
+  const out: Record<string, number> = {};
+  const count = { n: 0 };
+
+  for (const rawLine of content.split('\n')) {
+    if (rawLine.length > 2000) continue; // minified/generated line — skip
+    // 1. String literals → TOKEN_IN_STRING, then blank them out
+    let line = rawLine;
+    STRING_SPAN.lastIndex = 0;
+    line = line.replace(STRING_SPAN, span => {
+      WORD.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = WORD.exec(span)) !== null) addToken(out, count, m[0], TOKEN_IN_STRING);
+      return ' ';
+    });
+
+    // 2. Truncate at comment marker — comment-derived tokens are a measured
+    //    noise class, dropped entirely
+    const cut = commentStart(line);
+    if (cut === 0) continue;
+    if (cut > 0) line = line.slice(0, cut);
+
+    // 3. Remaining identifiers → TOKEN_IN_CODE
+    WORD.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = WORD.exec(line)) !== null) addToken(out, count, m[0], TOKEN_IN_CODE);
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Postings — token → fileIds, kept only for df ∈ [DF_MIN, DF_MAX].
+// Test files and barrels are excluded: links to tests are noise on GO pages
+// (tests are excluded from results by default) and barrels are excluded from
+// results entirely.
+// ---------------------------------------------------------------------------
+export function buildContentTokenPostings(
+  files: Iterable<IndexedFile>,
+): Map<string, string[]> {
+  const postings = new Map<string, string[]>();
+  for (const file of files) {
+    if (file.isTestFile || file.isBarrel || !file.contentTokens) continue;
+    for (const token of Object.keys(file.contentTokens)) {
+      const list = postings.get(token);
+      if (list === undefined) postings.set(token, [file.id]);
+      else if (list.length <= CONTENT_TOKEN_DF_MAX) list.push(file.id);
+    }
+  }
+  for (const [token, list] of postings) {
+    if (list.length < CONTENT_TOKEN_DF_MIN || list.length > CONTENT_TOKEN_DF_MAX) {
+      postings.delete(token);
+    }
+  }
+  return postings;
+}
+
+// ---------------------------------------------------------------------------
+// Content-presence index — lowercased token → where it lives in file bodies.
+// Backs GO's content-presence fallback for query tokens that match zero
+// declared names: name the files (small df), give a count (flood), or assert
+// absence (df 0 — valid ONLY for shaped tokens, since unshaped words never
+// enter contentTokens and their absence here proves nothing).
+// Posting lists are capped: past the cap only the count matters for display.
+// ---------------------------------------------------------------------------
+export const CONTENT_PRESENCE_LIST_CAP = 8;
+
+export interface ContentPresenceEntry {
+  n: number; // full document frequency (non-test, non-barrel)
+  files: string[]; // first CONTENT_PRESENCE_LIST_CAP fileIds only
+}
+
+export function buildContentPresenceIndex(
+  files: Iterable<IndexedFile>,
+): Map<string, ContentPresenceEntry> {
+  const out = new Map<string, ContentPresenceEntry>();
+  for (const file of files) {
+    if (file.isTestFile || file.isBarrel || !file.contentTokens) continue;
+    const seenLower = new Set<string>(); // SpatialView + spatialView in one file = one df
+    for (const token of Object.keys(file.contentTokens)) {
+      const lower = token.toLowerCase();
+      if (seenLower.has(lower)) continue;
+      seenLower.add(lower);
+      const entry = out.get(lower);
+      if (entry === undefined) {
+        out.set(lower, { n: 1, files: [file.id] });
+      } else {
+        entry.n++;
+        if (entry.files.length < CONTENT_PRESENCE_LIST_CAP) entry.files.push(file.id);
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Link derivation
+// ---------------------------------------------------------------------------
+export interface TokenLink {
+  a: string; // fileId, page-rank order (a before b)
+  b: string;
+  alsoB?: string[]; // twin-cluster members merged into this link (near-identical token sets)
+  tokens: string[];
+  hasStringProvenance: boolean;
+  minDf: number;
+}
+
+// Two token sets are "twins" when they are mostly the SAME set (Jaccard) —
+// the signature of boilerplate siblings (migration twins share the same SQL
+// trigger body). Twin links from the same host collapse into one display
+// line so a twin cluster consumes ONE cap slot, not all of them (measured
+// failure: three SQL-twin links squeezed the q16 gold link off the page).
+// Jaccard, not overlap-of-smaller: a 2-token link whose tokens happen to
+// appear inside a 6-token twin body is a DIFFERENT relation, not a twin.
+function tokenOverlap(x: string[], y: string[]): number {
+  const xs = new Set(x);
+  let common = 0;
+  for (const t of y) if (xs.has(t)) common++;
+  return common / (x.length + y.length - common);
+}
+const TWIN_OVERLAP_THRESHOLD = 0.6;
+
+function dirOf(fileId: string): string {
+  const i = fileId.lastIndexOf('/');
+  return i === -1 ? '' : fileId.slice(0, i);
+}
+
+function hasImportEdge(index: CodebaseIndex, a: string, b: string): boolean {
+  return (
+    (index.outEdges.get(a)?.includes(b) ?? false) ||
+    (index.outEdges.get(b)?.includes(a) ?? false)
+  );
+}
+
+function tokenHasStringBit(index: CodebaseIndex, fileId: string, token: string): boolean {
+  const bits = index.files.get(fileId)?.contentTokens?.[token];
+  return bits !== undefined && (bits & TOKEN_IN_STRING) !== 0;
+}
+
+// Strength gate. ≥2 shared tokens or string-literal provenance qualifies
+// outright. A single code-provenance token qualifies only when it is BOTH
+// ultra-rare (df ≤ 3) and ≥3 words — replay-derived: the q16 gold link is
+// exactly `limit_choices_to` (df 3, 3 words, code provenance) while the
+// measured weak-single noise class was all 2-word generics (new_ids,
+// child_node, settings_utils).
+function tokenWordCount(t: string): number {
+  const parts = t.split(/_+/).filter(Boolean);
+  let count = 0;
+  for (const p of parts) {
+    count += Math.max(1, (p.match(/[A-Z]/g)?.length ?? 0) + (/^[a-z]/.test(p) ? 1 : 0));
+  }
+  return count;
+}
+
+function linkIsStrong(
+  tokens: string[],
+  hasStringProvenance: boolean,
+  index: CodebaseIndex,
+): boolean {
+  if (tokens.length >= 2 || hasStringProvenance) return true;
+  const t = tokens[0];
+  const df = index.contentTokenPostings.get(t)?.length ?? CONTENT_TOKEN_DF_MAX + 1;
+  return df <= 3 && tokenWordCount(t) >= 3;
+}
+
+function compareLinkStrength(x: TokenLink, y: TokenLink): number {
+  if (x.hasStringProvenance !== y.hasStringProvenance) return x.hasStringProvenance ? -1 : 1;
+  if (x.tokens.length !== y.tokens.length) return y.tokens.length - x.tokens.length;
+  return x.minDf - y.minDf;
+}
+
+/**
+ * Derive token links among a page of GO results.
+ *
+ * Gates, in order: query-stem suppression (a token containing a query word
+ * links by construction), cross-directory only (same-dir pairs are
+ * boilerplate twins), import-edge redundancy (an in-page edge is already
+ * rendered as `← imported by`), strength (≥2 shared tokens OR string-literal
+ * provenance), triangle dedupe (a link transitively implied by two stronger
+ * links is dropped), per-page cap.
+ */
+export const TOKEN_LINKS_PER_PAGE = 3;
+
+export function deriveInPageTokenLinks(
+  pageIds: string[],
+  index: CodebaseIndex,
+  queryTokens: string[] = [],
+): TokenLink[] {
+  if (pageIds.length < 2 || index.contentTokenPostings.size === 0) return [];
+  const rankOf = new Map(pageIds.map((id, i) => [id, i]));
+  const stems = queryTokens.map(t => t.toLowerCase()).filter(t => t.length >= 3);
+
+  // token → page members, each token visited once
+  const seen = new Set<string>();
+  const pairTokens = new Map<string, string[]>(); // "a b" → tokens
+
+  for (const id of pageIds) {
+    const tokens = index.files.get(id)?.contentTokens;
+    if (!tokens) continue;
+    for (const token of Object.keys(tokens)) {
+      if (seen.has(token)) continue;
+      seen.add(token);
+      const lower = token.toLowerCase();
+      if (stems.some(s => lower.includes(s))) continue;
+      const postings = index.contentTokenPostings.get(token);
+      if (!postings) continue;
+      const members = postings
+        .filter(p => rankOf.has(p))
+        .sort((x, y) => rankOf.get(x)! - rankOf.get(y)!);
+      if (members.length < 2) continue;
+      for (let i = 0; i < members.length; i++) {
+        for (let j = i + 1; j < members.length; j++) {
+          const a = members[i];
+          const b = members[j];
+          if (dirOf(a) === dirOf(b)) continue;
+          if (hasImportEdge(index, a, b)) continue;
+          const key = a + ' ' + b;
+          const list = pairTokens.get(key);
+          if (list === undefined) pairTokens.set(key, [token]);
+          else list.push(token);
+        }
+      }
+    }
+  }
+
+  const links: TokenLink[] = [];
+  for (const [key, tokens] of pairTokens) {
+    const [a, b] = key.split(' ');
+    const hasStringProvenance = tokens.some(
+      t => tokenHasStringBit(index, a, t) || tokenHasStringBit(index, b, t),
+    );
+    if (!linkIsStrong(tokens, hasStringProvenance, index)) continue;
+    const minDf = Math.min(
+      ...tokens.map(t => index.contentTokenPostings.get(t)?.length ?? CONTENT_TOKEN_DF_MAX),
+    );
+    // Rarest token first in display
+    tokens.sort(
+      (x, y) =>
+        (index.contentTokenPostings.get(x)?.length ?? CONTENT_TOKEN_DF_MAX) -
+        (index.contentTokenPostings.get(y)?.length ?? CONTENT_TOKEN_DF_MAX),
+    );
+    links.push({ a, b, tokens, hasStringProvenance, minDf });
+  }
+
+  links.sort(compareLinkStrength);
+
+  // Triangle dedupe: drop A–C when stronger links A–B and B–C exist and
+  // jointly carry all of A–C's tokens (the third side is transitively implied)
+  const byPair = new Map<string, TokenLink>();
+  const adjacency = new Map<string, Set<string>>();
+  const kept: TokenLink[] = [];
+  for (const link of links) {
+    const neighborsA = adjacency.get(link.a);
+    const neighborsB = adjacency.get(link.b);
+    let implied = false;
+    if (neighborsA && neighborsB) {
+      for (const mid of neighborsA) {
+        if (!neighborsB.has(mid)) continue;
+        const ab = byPair.get(pairKey(link.a, mid));
+        const bc = byPair.get(pairKey(mid, link.b));
+        if (!ab || !bc) continue;
+        const union = new Set([...ab.tokens, ...bc.tokens]);
+        if (link.tokens.every(t => union.has(t))) {
+          implied = true;
+          break;
+        }
+      }
+    }
+    if (implied) continue;
+    kept.push(link);
+    byPair.set(pairKey(link.a, link.b), link);
+    if (!adjacency.has(link.a)) adjacency.set(link.a, new Set());
+    if (!adjacency.has(link.b)) adjacency.set(link.b, new Set());
+    adjacency.get(link.a)!.add(link.b);
+    adjacency.get(link.b)!.add(link.a);
+  }
+
+  // Twin-cluster merge: same host, near-identical token sets → one link line
+  const grouped: TokenLink[] = [];
+  for (const link of kept) {
+    const host = grouped.find(
+      g => g.a === link.a && tokenOverlap(g.tokens, link.tokens) >= TWIN_OVERLAP_THRESHOLD,
+    );
+    if (host) {
+      (host.alsoB ??= []).push(link.b);
+      continue;
+    }
+    grouped.push(link);
+  }
+
+  return grouped.slice(0, TOKEN_LINKS_PER_PAGE);
+}
+
+function pairKey(x: string, y: string): string {
+  return x < y ? x + ' ' + y : y + ' ' + x;
+}
+
+// ---------------------------------------------------------------------------
+// GS-side: files related to a source token set (file-level or match-region)
+// ---------------------------------------------------------------------------
+export interface RelatedFile {
+  fileId: string;
+  alsoFileIds?: string[]; // twin-cluster members merged into this entry
+  tokens: string[]; // shared rare tokens (rarest first), empty for pure name-echo
+  viaName?: string; // name-echo: the term the filename matched
+  hasStringProvenance: boolean;
+  minDf: number;
+}
+
+export const RELATED_FILES_CAP = 3;
+
+export function deriveRelatedFiles(
+  sourceFileId: string,
+  sourceTokens: Record<string, number>,
+  index: CodebaseIndex,
+  excludeIds: Set<string>,
+): RelatedFile[] {
+  const shared = new Map<string, string[]>(); // candidate fileId → tokens
+  const sourceDir = dirOf(sourceFileId);
+
+  for (const token of Object.keys(sourceTokens)) {
+    const postings = index.contentTokenPostings.get(token);
+    if (!postings) continue;
+    for (const candidate of postings) {
+      if (candidate === sourceFileId || excludeIds.has(candidate)) continue;
+      if (dirOf(candidate) === sourceDir) continue;
+      if (hasImportEdge(index, sourceFileId, candidate)) continue;
+      const list = shared.get(candidate);
+      if (list === undefined) shared.set(candidate, [token]);
+      else list.push(token);
+    }
+  }
+
+  const related: RelatedFile[] = [];
+  for (const [fileId, tokens] of shared) {
+    const hasStringProvenance = tokens.some(
+      t =>
+        (sourceTokens[t] & TOKEN_IN_STRING) !== 0 ||
+        tokenHasStringBit(index, fileId, t),
+    );
+    if (!linkIsStrong(tokens, hasStringProvenance, index)) continue;
+    const minDf = Math.min(
+      ...tokens.map(t => index.contentTokenPostings.get(t)?.length ?? CONTENT_TOKEN_DF_MAX),
+    );
+    tokens.sort(
+      (x, y) =>
+        (index.contentTokenPostings.get(x)?.length ?? CONTENT_TOKEN_DF_MAX) -
+        (index.contentTokenPostings.get(y)?.length ?? CONTENT_TOKEN_DF_MAX),
+    );
+    related.push({ fileId, tokens, hasStringProvenance, minDf });
+  }
+
+  related.sort((x, y) => {
+    if (x.hasStringProvenance !== y.hasStringProvenance) return x.hasStringProvenance ? -1 : 1;
+    if (x.tokens.length !== y.tokens.length) return y.tokens.length - x.tokens.length;
+    return x.minDf - y.minDf;
+  });
+
+  // Twin-cluster merge (boilerplate siblings share near-identical token sets)
+  const grouped: RelatedFile[] = [];
+  for (const r of related) {
+    const host = grouped.find(g => tokenOverlap(g.tokens, r.tokens) >= TWIN_OVERLAP_THRESHOLD);
+    if (host) {
+      (host.alsoFileIds ??= []).push(r.fileId);
+      continue;
+    }
+    grouped.push(r);
+  }
+  return grouped.slice(0, RELATED_FILES_CAP);
+}
+
+/**
+ * Name-echo: files whose FILENAME matches one of the agent's `match` terms.
+ * Separator-insensitive substring (UserPreference ↛ userpreference.py was a
+ * measured miss), df-gated (common terms like `resource` hit 50+ filenames —
+ * skip the term entirely rather than flood).
+ */
+export const NAME_ECHO_MAX_FILES_PER_TERM = 5;
+
+export function deriveNameEchoFiles(
+  terms: string[],
+  index: CodebaseIndex,
+  excludeIds: Set<string>,
+): RelatedFile[] {
+  const out: RelatedFile[] = [];
+  const seen = new Set<string>();
+  for (const term of terms) {
+    const norm = term.toLowerCase().replace(/[_\-\s]/g, '');
+    if (norm.length < MIN_TOKEN_LENGTH) continue;
+    const hits: string[] = [];
+    for (const file of index.files.values()) {
+      if (file.isTestFile || file.isBarrel) continue;
+      const base = file.id.split('/').pop() ?? '';
+      const baseNorm = base.toLowerCase().replace(/\.[a-z0-9]+$/, '').replace(/[_\-.]/g, '');
+      if (!baseNorm.includes(norm)) continue;
+      hits.push(file.id);
+      if (hits.length > NAME_ECHO_MAX_FILES_PER_TERM) break;
+    }
+    if (hits.length === 0 || hits.length > NAME_ECHO_MAX_FILES_PER_TERM) continue;
+    for (const id of hits) {
+      if (excludeIds.has(id) || seen.has(id)) continue;
+      seen.add(id);
+      out.push({ fileId: id, tokens: [], viaName: term, hasStringProvenance: false, minDf: hits.length });
+    }
+  }
+  return out;
+}

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -20,6 +20,7 @@ import { parseTomlContent } from './extractors/toml.js';
 import { parseEnvContent } from './extractors/env.js';
 import { parseXmlContent } from './extractors/xml.js';
 import { parseGroovyContent } from './extractors/groovy.js';
+import { extractContentTokens } from './content-tokens.js';
 
 const MAX_FILE_SIZE = 1_000_000; // 1 MB
 
@@ -64,6 +65,20 @@ export async function parseFile(
     return null;
   }
 
+  const parsed = await parseByLanguage(filePath, language, fileId, content);
+  if (!parsed) return null;
+  // Content-token channel is language-agnostic: shaped full-body identifiers
+  // with provenance bits, extracted once here for every indexed language.
+  parsed.contentTokens = extractContentTokens(content, fileId || filePath);
+  return parsed;
+}
+
+async function parseByLanguage(
+  filePath: string,
+  language: Language,
+  fileId: string,
+  content: string,
+): Promise<ParsedFile | null> {
   const hash = createHash('md5').update(content).digest('hex');
   const lineCount = content.split('\n').length;
   const tokenEstimate = Math.ceil(content.length / 4);

--- a/src/indexer/patch.ts
+++ b/src/indexer/patch.ts
@@ -6,6 +6,7 @@ import { parseFile, buildFileId } from './parser.js';
 import { buildFileDomains, isTestPath } from './tokenize.js';
 import { resolveImportsForFiles } from './resolvers/index.js';
 import { buildSymbolEdges } from './symbol-edges.js';
+import { buildContentTokenPostings, buildContentPresenceIndex } from './content-tokens.js';
 
 /**
  * Incrementally patches the in-memory index for a set of changed files.
@@ -177,6 +178,7 @@ export async function patchIndex(
       symbols: parsed.symbols,
       reexportRatio: parsed.reexportRatio,
       submoduleImportCandidates: parsed.submoduleImportCandidates,
+      contentTokens: parsed.contentTokens,
     };
 
     index.files.set(fileId, newFile);
@@ -267,6 +269,13 @@ export async function patchIndex(
       if (child) child.transitiveImportedByCount += file.importedByCount;
     }
   }
+
+  // -------------------------------------------------------------------------
+  // Phase 8: Rebuild content-token postings (cheap full pass — df window 2–5
+  // means almost any edit can move tokens in or out of the postings)
+  // -------------------------------------------------------------------------
+  index.contentTokenPostings = buildContentTokenPostings(index.files.values());
+  index.contentPresenceIndex = buildContentPresenceIndex(index.files.values());
 
   index.indexedAt = Date.now();
 }

--- a/src/indexer/ts-parser.ts
+++ b/src/indexer/ts-parser.ts
@@ -167,6 +167,110 @@ function callsFromMap(calls: Map<string, number>, exclude?: string): CallSite[] 
 }
 
 // ---------------------------------------------------------------------------
+// Member-assignment definitions: `ko.bindingHandlers.termSearch = {...}`,
+// `arches.foo = function(){}`, `module.exports.bar = () => {}`. The declared-
+// symbol walk only sees `function`/`class`/`const` keywords, so files that
+// define their surface by assigning onto a namespace object (Knockout binding
+// handlers, jQuery plugins, AMD module exports) index as ZERO symbols — and the
+// agent is forced to grep for them (q19: term-search.js had 0 symbols, 5 empty
+// greps). These assignments are usually wrapped in an AMD `define([...], fn)` or
+// an IIFE, so we unwrap one level of call/function wrapper to reach them.
+// ---------------------------------------------------------------------------
+
+// Statement_blocks to treat as "module top level": the program root, plus the
+// body of a single wrapping define()/require()/IIFE call. One level only —
+// enough for AMD/UMD without walking into every nested closure.
+function moduleBodies(root: TSNode): TSNode[] {
+  const bodies: TSNode[] = [root];
+  for (const node of root.namedChildren) {
+    const expr = node.type === 'expression_statement' ? node.namedChildren[0] : node;
+    if (!expr) continue;
+    // define([...], function(){...})  /  (function(){...})()  /  require([...], fn)
+    const call = expr.type === 'call_expression' ? expr
+      : expr.type === 'parenthesized_expression' ? firstChildOfType(expr, 'call_expression')
+      : null;
+    if (!call) continue;
+    const args = firstChildOfType(call, 'arguments') ?? call;
+    for (const a of args.namedChildren) {
+      if (a.type === 'function_expression' || a.type === 'arrow_function') {
+        const blk = firstChildOfType(a, 'statement_block');
+        if (blk) bodies.push(blk);
+      }
+    }
+  }
+  return bodies;
+}
+
+function extractAssignmentSymbols(root: TSNode, fileId: string): SymbolNode[] {
+  const out: SymbolNode[] = [];
+  const seen = new Set<string>();
+  for (const body of moduleBodies(root)) {
+    for (const stmt of body.namedChildren) {
+      if (stmt.type !== 'expression_statement') continue;
+      const assign = stmt.namedChildren[0];
+      if (!assign || assign.type !== 'assignment_expression') continue;
+      const lhs = assign.namedChildren[0];
+      const rhs = assign.namedChildren[1];
+      if (!lhs || !rhs || lhs.type !== 'member_expression') continue;
+      const name = lhs.text.replace(/\s+/g, '');
+      // Only definitions worth a symbol: a function, arrow, object, or class —
+      // not `x.y = 5` primitive config. Object literals are the binding-handler case.
+      const isFn = rhs.type === 'function_expression' || rhs.type === 'arrow_function';
+      const isObj = rhs.type === 'object';
+      const isClass = rhs.type === 'class';
+      if (!isFn && !isObj && !isClass) continue;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const startLine = stmt.startPosition.row + 1;
+      const endLine = stmt.endPosition.row + 1;
+      const calls = new Map<string, number>();
+      const fnBody = firstChildOfType(rhs, 'statement_block');
+      if (fnBody) collectCalls(fnBody, calls);
+      else if (isObj) collectCalls(rhs, calls);
+      // module-level assignments ARE the file's public surface (no `export` in
+      // AMD/script files) → mark exported so they surface in get-structure.
+      out.push({
+        id: `${fileId}#${name}`,
+        name,
+        kind: isClass ? 'class' : isObj ? 'constant' : 'function',
+        startLine,
+        endLine,
+        isExported: true,
+        calls: callsFromMap(calls, name),
+        implementsNames: [],
+      });
+      // Function-valued properties of an assigned object literal become methods
+      // (init/update on a binding handler, the handlers on a controller object).
+      if (isObj) {
+        for (const pair of childrenOfType(rhs, 'pair')) {
+          const key = pair.namedChildren[0];
+          const val = pair.namedChildren[1];
+          if (!key || !val) continue;
+          if (val.type !== 'function_expression' && val.type !== 'arrow_function') continue;
+          const propName = key.type === 'property_identifier' || key.type === 'string'
+            ? key.text.replace(/['"]/g, '') : null;
+          if (!propName) continue;
+          const mCalls = new Map<string, number>();
+          const mBody = firstChildOfType(val, 'statement_block');
+          if (mBody) collectCalls(mBody, mCalls);
+          out.push({
+            id: `${fileId}#${name}.${propName}`,
+            name: `${name}.${propName}`,
+            kind: 'method',
+            startLine: pair.startPosition.row + 1,
+            endLine: pair.endPosition.row + 1,
+            isExported: false,
+            calls: callsFromMap(mCalls, propName),
+            implementsNames: [],
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Extract symbols from a declaration node (unwrapped from export_statement)
 // ---------------------------------------------------------------------------
 function extractFromDeclaration(
@@ -499,6 +603,17 @@ export function parseTsContent(
       const nodes = Array.isArray(result) ? result : [result];
       rawSymbols.push(...nodes);
     }
+  }
+
+  // Member-assignment definitions (Knockout/jQuery/AMD surface the declared-name
+  // walk misses). Added after the keyword-declaration passes; skip any name a
+  // real declaration already claimed so a `const x = ...; window.x = x` re-export
+  // doesn't double-count.
+  const declaredNames = new Set(rawSymbols.map(s => s.name));
+  for (const sym of extractAssignmentSymbols(root, fileId)) {
+    if (declaredNames.has(sym.name)) continue;
+    rawSymbols.push(sym);
+    if (sym.isExported && sym.kind !== 'method') exports.push(sym.name);
   }
 
   // Resolve intra-file calls: replace plain names with full symbol IDs where known

--- a/src/server/find.ts
+++ b/src/server/find.ts
@@ -1,0 +1,740 @@
+/**
+ * `coldstart find <terms...>` — the rich-page query surface.
+ *
+ * One command, one page, one read. The design (verified against the arches
+ * q03/q09 traces, see docs/) fuses two signals the two-tool surface kept apart:
+ *
+ *   - grep-RECALL for candidate selection: ripgrep every term across the repo,
+ *     rank files by DISTINCT-TERM COVERAGE. This catches body-level matches the
+ *     declared-name index misses (nested defs, dynamic refs) and is the reason a
+ *     discriminating file rises — it covers MORE of the query than its lookalikes.
+ *   - AST + grep PRECISION per candidate: for the top files, print indexed
+ *     symbols (with line numbers) AND a filtered scan of body lines that contain
+ *     the query terms (def/class/assignment lines first). The nested defs the
+ *     parser cannot see and the `editable=False`-style context both show up here,
+ *     inline — so the agent answers without a follow-up Read.
+ *
+ * Recall is bounded by the terms it is given: a one-token query cannot
+ * out-rank lookalikes. The skill instructs the agent to pass every salient
+ * identifier from the task — that is the load-bearing half of this command.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import type { CodebaseIndex, IndexedFile, SymbolNode } from '../types.js';
+import { deriveRelatedFiles } from '../indexer/content-tokens.js';
+
+/**
+ * Candidate search is portable by design — no hard dependency on any external
+ * binary. We try fast tools first and fall back to a pure-Node scan so the
+ * command never silently returns empty on a machine without ripgrep/grep:
+ *   rg → git grep → grep → in-process scan of indexed files.
+ * The chosen backend is probed once per process.
+ */
+type Searcher = 'rg' | 'gitgrep' | 'grep' | 'node';
+let _searcher: Searcher | null = null;
+
+function probe(bin: string, args: string[], cwd: string): boolean {
+  try {
+    execFileSync(bin, args, { cwd, stdio: 'ignore', timeout: 4000 });
+    return true;
+  } catch (e: unknown) {
+    // ENOENT = binary absent (unusable); any other exit = present but errored (usable)
+    return (e as { code?: string }).code !== 'ENOENT';
+  }
+}
+
+function pickSearcher(root: string): Searcher {
+  if (_searcher) return _searcher;
+  if (probe('rg', ['--version'], root)) _searcher = 'rg';
+  else if (probe('git', ['rev-parse', '--is-inside-work-tree'], root)) _searcher = 'gitgrep';
+  else if (probe('grep', ['--version'], root)) _searcher = 'grep';
+  else _searcher = 'node';
+  return _searcher;
+}
+
+const MAX_CANDIDATES_LISTED = 12;
+const DETAIL_TOP = 3; // top files get an inline convergence preview; the rest list as bare paths
+
+// Convergence-preview parameters (denoise hub files: show where the rarest terms cluster).
+const WINDOW = 3;            // lines each side counted for local term convergence
+const RARE_FRAC = 0.05;      // a term is a discriminator if it hits < 5% of candidate files
+const MAX_PREVIEW_LINES = 8; // total body lines shown per file
+const MAX_CLUSTERS = 2;      // distinct match regions shown per file
+const IMPORT_RE =
+  /^\s*(import\b|from\s+[\w.]+\s+import\b|export\s+[^=]*\bfrom\b|(?:const|let|var)\s+[^=]*=\s*require\s*\(|require\s*\(|use\s+[\w:\\]+|using\s+[\w.]+|#include\b|@import\b)/;
+
+/** Prose/doc files (release notes, READMEs). They mention every term in plain
+ * text and otherwise out-rank the source file the agent is actually looking for,
+ * so they're partitioned into a secondary list rather than competing with code. */
+const DOC_EXT = /\.(md|markdown|rst|txt|adoc|rdoc)$/i;
+const isDoc = (rel: string): boolean => DOC_EXT.test(rel);
+const MAX_DOC_CANDIDATES = 4;
+
+/** Stylesheets match style vocabulary (sidebar/nav/menu as class names) and crowd code queries,
+ * but ARE the right answer for a genuine CSS task — so they're partitioned into a bare list
+ * (no preview, no evidence sentence) rather than dropped. SCSS is the source, never single it out. */
+const STYLE_EXT = /\.(css|scss|sass|less)$/i;
+const isStyle = (rel: string): boolean => STYLE_EXT.test(rel);
+const MAX_STYLE_CANDIDATES = 4;
+
+/** Minified bundles and vendored third-party trees are never the human-readable answer: a minified
+ * file matches many terms on one giant line (inflating coverage) and previews as noise. Detected by
+ * path (vendored tree / *.min.*) OR by content shape — chars-per-line ≫ real source (minified bundles
+ * run 2700-43000 cpl, real source p99 ≈ 600), which catches un-suffixed bundles like nifty.js that the
+ * path rule misses. Scoped to script/style languages so data/config files and golds are never touched.
+ * Index-only (lineCount/tokenEstimate), NO file read. */
+const VENDOR_PATH = /(^|\/)(node_modules|vendor|bower_components)\//i;
+const MIN_SUFFIX = /\.min\.(js|css)$/i;
+const SCRIPT_STYLE_EXT = /\.(js|jsx|ts|tsx|mjs|cjs|css|scss|sass|less)$/i;
+const MINIFIED_CPL = 1000;
+const isVendorOrMinified = (rel: string, file: IndexedFile): boolean => {
+  if (VENDOR_PATH.test(rel) || MIN_SUFFIX.test(rel)) return true;
+  return SCRIPT_STYLE_EXT.test(rel) && file.lineCount > 0
+    && (file.tokenEstimate * 4) / file.lineCount > MINIFIED_CPL;
+};
+
+/**
+ * Pass 1 — import co-citation among the candidate set (precision relations).
+ *
+ * For the files we're about to list, compute how they relate TO EACH OTHER via the
+ * import graph, so the page can say "consumed by graph.py" instead of leaving the
+ * agent to infer it. Three relations, strongest first:
+ *   - consumes / consumedBy: a DIRECT import edge between two candidates (a fact).
+ *   - siblings: two candidates share a non-hub import neighbour (co-citation). A
+ *     shared neighbour imported by > HUB_DEGREE files is a utility hub, not evidence
+ *     of relatedness, so it's discounted (offline: hub-discounted co-citation degree
+ *     separated gold from lookalikes 2.05×; raw degree did not).
+ * Index-only (outEdges/inEdges/importedByCount), NO file reads.
+ */
+const HUB_DEGREE = 30;
+interface ImportRel { consumes: string[]; consumedBy: string[]; siblings: string[]; }
+
+function computeImportRelations(index: CodebaseIndex, candidates: string[]): Map<string, ImportRel> {
+  const candSet = new Set(candidates);
+  // Non-hub neighbour signature per candidate: low-fanin import targets + low-fanout importers.
+  // Importer ids are namespaced ('<' prefix) so a shared target and a shared importer never collide.
+  const sig = new Map<string, Set<string>>();
+  for (const c of candidates) {
+    const s = new Set<string>();
+    for (const t of index.outEdges.get(c) ?? []) {
+      const f = index.files.get(t);
+      if (f && f.importedByCount <= HUB_DEGREE) s.add(t);
+    }
+    for (const p of index.inEdges.get(c) ?? []) {
+      if ((index.outEdges.get(p) ?? []).length <= HUB_DEGREE) s.add('<' + p);
+    }
+    sig.set(c, s);
+  }
+  const rels = new Map<string, ImportRel>();
+  for (const c of candidates) {
+    const outs = new Set(index.outEdges.get(c) ?? []);
+    const ins = new Set(index.inEdges.get(c) ?? []);
+    const consumes: string[] = [], consumedBy: string[] = [], siblings: string[] = [];
+    const sc = sig.get(c)!;
+    for (const d of candidates) {
+      if (d === c) continue;
+      if (outs.has(d)) { consumes.push(d); continue; }
+      if (ins.has(d)) { consumedBy.push(d); continue; }
+      const sd = sig.get(d)!;
+      let shared = false;
+      for (const n of sc) if (sd.has(n)) { shared = true; break; }
+      if (shared) siblings.push(d);
+    }
+    rels.set(c, { consumes, consumedBy, siblings });
+    void candSet;
+  }
+  return rels;
+}
+
+/** Clean a raw query into distinct, matchable terms (identifiers ≥3 chars). */
+export function parseTerms(raw: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const w of raw.split(/[\s[\]|,()'".]+/)) {
+    if (w.length < 3 || !/^[A-Za-z_][A-Za-z0-9_-]*$/.test(w)) continue;
+    const key = w.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(w);
+  }
+  return out;
+}
+
+/** Run the chosen external lister for one term; repo-relative paths ([] on miss/unsupported). */
+function listFilesExternal(searcher: Searcher, root: string, term: string): string[] {
+  const argv: Record<Exclude<Searcher, 'node'>, string[]> = {
+    rg: ['-l', '-i', '-F', '--', term, '.'],
+    gitgrep: ['grep', '-l', '-i', '-F', '-I', '-e', term],
+    grep: ['-r', '-l', '-i', '-F', '-I', '--', term, '.'],
+  };
+  const bin = searcher === 'gitgrep' ? 'git' : searcher;
+  try {
+    const out = execFileSync(bin, argv[searcher as Exclude<Searcher, 'node'>], {
+      cwd: root,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.split('\n').map((l) => l.replace(/^\.\//, '').trim()).filter(Boolean);
+  } catch {
+    return []; // non-zero exit = no matches
+  }
+}
+
+/**
+ * Build term-coverage per indexed file. External searchers run per-term; the
+ * Node fallback reads each indexed file once and tests all terms together.
+ * Only files present in the index count (restricts to indexed code files).
+ */
+function collectCoverage(index: CodebaseIndex, root: string, terms: string[]): Map<string, Set<string>> {
+  const coverage = new Map<string, Set<string>>();
+  const add = (rel: string, term: string): void => {
+    if (!index.files.has(rel)) return;
+    let s = coverage.get(rel);
+    if (!s) { s = new Set(); coverage.set(rel, s); }
+    s.add(term);
+  };
+
+  const lowers = terms.map((t) => t.toLowerCase());
+
+  // (A) body-content matches — what grep sees.
+  const searcher = pickSearcher(root);
+  if (searcher !== 'node') {
+    for (const term of terms) {
+      for (const rel of listFilesExternal(searcher, root, term)) add(rel, term);
+    }
+  } else {
+    // Pure-Node fallback: one read per indexed file, all terms tested at once.
+    for (const [rel, file] of index.files.entries()) {
+      let text: string;
+      try { text = readFileSync(file.path, 'utf8').toLowerCase(); } catch { continue; }
+      for (let i = 0; i < terms.length; i++) {
+        if (text.includes(lowers[i])) add(rel, terms[i]);
+      }
+    }
+  }
+
+  // (B) name/path/symbol matches — the signal grep CANNOT see. A file whose
+  // distinguishing token is its own filename (e.g. 11726_join_tile_nodegroup.py)
+  // or a declared symbol name is invisible to a body-content grep; without this
+  // it sinks into a wall of equal-coverage lookalikes. This restores the
+  // declared-name index that the two-tool GO surface ranked on.
+  for (const [rel, file] of index.files.entries()) {
+    const path = rel.toLowerCase();
+    for (let i = 0; i < terms.length; i++) {
+      const t = lowers[i];
+      if (path.includes(t) || file.symbols.some((s) => s.name.toLowerCase().includes(t))) {
+        add(rel, terms[i]);
+      }
+    }
+  }
+  return coverage;
+}
+
+/** Per-term document frequency over the candidate set (how many candidate files contain each term).
+ * This is the rarity signal: a low-DF term is a discriminator, a high-DF term ("view" → 45% of files)
+ * is noise that should neither rank a file nor light up a body line. */
+function docFreq(coverage: Map<string, Set<string>>, terms: string[]): Map<string, number> {
+  const df = new Map<string, number>();
+  for (const t of terms) df.set(t, 0);
+  for (const set of coverage.values()) {
+    for (const t of set) df.set(t, (df.get(t) ?? 0) + 1);
+  }
+  return df;
+}
+
+/** Mark comment-only and docstring lines so they don't count as content matches — this is what kills
+ * the "view"⊂"review" docstring noise and prose hits. Approximate (line-based) but cheap and language-agnostic. */
+function excludedLines(lines: string[]): boolean[] {
+  const ex = new Array<boolean>(lines.length).fill(false);
+  let inTriple = false;
+  let delim = '';
+  for (let i = 0; i < lines.length; i++) {
+    const s = lines[i].trim();
+    if (inTriple) {
+      ex[i] = true;
+      if (s.includes(delim)) inTriple = false;
+      continue;
+    }
+    const m = s.match(/("""|''')/);
+    if (m) {
+      ex[i] = true;
+      if ((s.split(m[1]).length - 1) % 2 === 1) { inTriple = true; delim = m[1]; }
+      continue;
+    }
+    if (/^(#|\/\/|\/\*|\*|<!--|;;|--\s)/.test(s)) ex[i] = true;
+  }
+  return ex;
+}
+
+/** Innermost indexed symbol whose line range contains `line` (1-based) — used to LABEL a preview
+ * cluster with its scope (e.g. "in class ResourceInstance"), not to print the whole symbol list. */
+function enclosing(file: IndexedFile, line: number): SymbolNode | null {
+  let best: SymbolNode | null = null;
+  for (const s of file.symbols) {
+    if (s.startLine <= line && line <= s.endLine) {
+      if (!best || s.endLine - s.startLine < best.endLine - best.startLine) best = s;
+    }
+  }
+  return best;
+}
+
+/**
+ * Convergence preview: instead of dumping every line that mentions a term (which floods hub files
+ * like models.py with matches from unrelated classes), score each matched line by RARITY-WEIGHTED
+ * LOCAL CONVERGENCE — sum of 1/DF over the distinct query terms within ±WINDOW lines. The answer is
+ * where the rare terms co-locate; scattered single-common-term matches score ~20-60× lower and drop out.
+ * A matched line that is an import statement is boosted and annotated with its resolved target, because
+ * it both marks a usage and points at the definition file.
+ */
+function convergencePreview(
+  file: IndexedFile,
+  terms: string[],
+  df: Map<string, number>,
+  nFiles: number,
+  specToTarget: Array<{ spec: string; target: string }>,
+): string[] {
+  let text: string;
+  try { text = readFileSync(file.path, 'utf8'); } catch { return []; }
+  const lines = text.split('\n');
+  const excl = excludedLines(lines);
+  const lterms = terms.map((t) => t.toLowerCase());
+  const weight = (t: string): number => nFiles / Math.max(1, df.get(t) ?? nFiles);
+  const isRare = (t: string): boolean => (df.get(t) ?? nFiles) / nFiles < RARE_FRAC;
+
+  // terms present in each non-excluded line
+  const inLine: string[][] = lines.map((l, i) => {
+    if (excl[i]) return [];
+    const low = l.toLowerCase();
+    return terms.filter((_t, k) => low.includes(lterms[k]));
+  });
+
+  interface Hit { line: number; score: number; }
+  const hits: Hit[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (inLine[i].length === 0) continue;
+    const windowTerms = new Set<string>();
+    for (let j = Math.max(0, i - WINDOW); j <= Math.min(lines.length - 1, i + WINDOW); j++) {
+      for (const t of inLine[j]) windowTerms.add(t);
+    }
+    // keep only discriminating lines: ≥2 distinct terms nearby, OR a rare term on the line itself.
+    // (drops `resourceinstanceid` in an unrelated class — one common term, no neighbours.)
+    if (windowTerms.size < 2 && !inLine[i].some(isRare)) continue;
+    let score = 0;
+    for (const t of windowTerms) score += weight(t);
+    if (IMPORT_RE.test(lines[i])) score *= 1.5;
+    hits.push({ line: i, score });
+  }
+  if (hits.length === 0) return [];
+
+  // cluster kept hits by proximity, then rank clusters by peak score
+  hits.sort((a, b) => a.line - b.line);
+  const clusters: Hit[][] = [];
+  for (const h of hits) {
+    const last = clusters[clusters.length - 1];
+    if (last && h.line - last[last.length - 1].line <= WINDOW) last.push(h);
+    else clusters.push([h]);
+  }
+  const peakOf = (c: Hit[]): number => Math.max(...c.map((h) => h.score));
+  clusters.sort((a, b) => peakOf(b) - peakOf(a));
+
+  const out: string[] = [];
+  let shown = 0;
+  for (const cluster of clusters.slice(0, MAX_CLUSTERS)) {
+    if (shown >= MAX_PREVIEW_LINES) break;
+    const peak = cluster.reduce((a, b) => (b.score > a.score ? b : a));
+    const sym = enclosing(file, peak.line + 1);
+    out.push(sym
+      ? `   in ${sym.kind} ${sym.name} [L${sym.startLine}-${sym.endLine}]:`
+      : `   near L${peak.line + 1}:`);
+    const lineSet = new Set(cluster.map((h) => h.line));
+    const start = Math.max(0, cluster[0].line - 1);              // one context line above
+    const end = Math.min(lines.length - 1, cluster[cluster.length - 1].line + 1); // and below
+    for (let i = start; i <= end && shown < MAX_PREVIEW_LINES; i++) {
+      if (excl[i] && !lineSet.has(i)) continue;   // skip comment context, keep comment only if it's a hit
+      const raw = lines[i].trim().slice(0, 120);
+      if (!raw) continue;
+      let suffix = '';
+      if (IMPORT_RE.test(lines[i])) {
+        const tgt = specToTarget.find((st) => st.spec && lines[i].includes(st.spec));
+        if (tgt) suffix = `   → defined in ${tgt.target}`;
+      }
+      out.push(`     L${i + 1}: ${raw}${suffix}`);
+      shown++;
+    }
+  }
+  return out;
+}
+
+export function buildRichPage(index: CodebaseIndex, root: string, rawQuery: string, asData = false, via = false): string {
+  const terms = parseTerms(rawQuery);
+  if (terms.length === 0) {
+    return 'find: no usable terms. Pass the salient identifiers from the task, e.g. `coldstart find ResourceInstance principaluser editable`.';
+  }
+
+  // 1. grep-recall: term → indexed files, accumulate distinct-term coverage.
+  const coverage = collectCoverage(index, root, terms);
+
+  if (coverage.size === 0) {
+    return `find: no indexed file contains any of [${terms.join(', ')}].\nThese identifiers may not exist in the repo, or be in excluded/binary files. Reformulate, or grep directly.`;
+  }
+
+  const df = docFreq(coverage, terms);
+  const nFiles = index.files.size;
+  const lterms = terms.map((t) => t.toLowerCase());
+  const rareTerms = terms.filter((t) => (df.get(t) ?? nFiles) / nFiles < RARE_FRAC);
+
+  // Rarity (BM25-style IDF): a term hitting few files is a discriminator; a common domain
+  // token (order/payment/view) hits ~everything → near-zero weight. This is what makes the
+  // ranker robust on domain-heavy repos and what keeps it from promoting hubs.
+  const idf = (t: string): number => {
+    const d = df.get(t) ?? 0;
+    return Math.log(1 + (nFiles - d + 0.5) / (d + 0.5));
+  };
+  const maxIdf = Math.max(1, ...terms.map(idf));
+
+  // Relevance score — index-only, NO file reads (term frequency was measured to add nothing
+  // once name/path are in play; see find-ranking sim). Binary term-coverage sets the tier;
+  // within/across tiers a file is lifted by rarity-weighted evidence that a term NAMES a
+  // declared symbol here (definition signal) or appears in the PATH. Length-free + IDF-weighted,
+  // so the 2700-line hub gets no edge. (Offline: top-12 recall 67%→79%, hub-misfires ~halved.)
+  const NAME_W = 3, PATH_W = 2;
+  const scoreCache = new Map<string, number>();
+  const score = (rel: string): number => {
+    let v = scoreCache.get(rel);
+    if (v !== undefined) return v;
+    const file = index.files.get(rel)!;
+    const pathLow = rel.toLowerCase();
+    let boost = 0;
+    for (let k = 0; k < terms.length; k++) {
+      const t = lterms[k];
+      if (!t) continue;
+      if (file.symbols.some((s) => s.name.toLowerCase().includes(t))) boost += NAME_W * idf(terms[k]);
+      if (pathLow.includes(t)) boost += PATH_W * idf(terms[k]);
+    }
+    v = coverage.get(rel)!.size * 3 + boost / maxIdf;
+    scoreCache.set(rel, v);
+    return v;
+  };
+
+  // rank: relevance score desc, then path (stable). importedBy dropped — centrality was the hub trap.
+  const ranked = [...coverage.entries()].sort((a, b) => {
+    const d = score(b[0]) - score(a[0]);
+    return d !== 0 ? d : a[0].localeCompare(b[0]);
+  });
+
+  // Per-file MATCH EVIDENCE, as a short plain-English sentence — what the file actually does with the
+  // query terms, strongest signal first: declares a symbol of that name > the term is in its path >
+  // the term is imported here (a consumer, not the definer) > a rare term sits in its body. Common
+  // (non-discriminating) body terms are omitted — every file matches them, so listing them is the
+  // noise we're cutting. `disc` (count of discriminating signals) doubles as the NOISE FLOOR:
+  // disc===0 means the file matched only common words → dropped from the listing. Index-only
+  // (graph edges + declared symbols), NO file reads; cached per file.
+  const rareSet = new Set(rareTerms);
+  const tick = (s: string): string => `\`${s}\``;
+  // Does `rel` import a definition that carries `term`? A term appearing on an import line resolves
+  // to an out-edge whose target file is named for the term or declares a symbol of that name. Cheap:
+  // walks only this file's out-edges. Lets the sentence say "imports X" (consumer) vs "mentions X".
+  const importTargetFor = (rel: string, term: string): string | null => {
+    const tl = term.toLowerCase();
+    for (const tgt of index.outEdges.get(rel) ?? []) {
+      if (tgt.toLowerCase().includes(tl)) return tgt;
+      const tf = index.files.get(tgt);
+      if (tf && tf.symbols.some((s) => s.name.toLowerCase().includes(tl))) return tgt;
+    }
+    return null;
+  };
+  // Grade-1 symbol locator: for a previewed file, the DECLARED symbols whose name matches a
+  // discriminating query term, with their line ranges — so the agent reads the right offset
+  // instead of windowing a large file to find them. The convergence preview shows where rare
+  // terms CLUSTER (often an incidental method); this shows where the NAMED symbols LIVE — the
+  // agent's actual read targets. (q22 read graph.py 8× hunting for serialize/restore_state that
+  // the index had located at L1965/L2098.) Index-only, NO file read. Container symbols that
+  // enclose another matched symbol are dropped (keep the specific method, not the 2800-line class).
+  const MATCHED_SYM_CAP = 6;
+  const MATCHED_SYM_MIN_LINES = 80; // only worth it on files big enough to hunt within
+  // Gate symbol matching on terms that DISCRIMINATE THIS QUERY (idf ≥ the query's median), not the
+  // global 5% rare threshold: `serialize`/`restore` are common repo-wide but are exactly the symbols
+  // a "graph serialize restore" query wants, while generic `graph`/`function` would flood a god-file.
+  const sortedIdf = terms.map(idf).sort((a, b) => a - b);
+  const medIdf = sortedIdf[Math.floor((sortedIdf.length - 1) / 2)];
+  const discTermIdx = terms.map((_t, k) => k).filter((k) => idf(terms[k]) >= medIdf);
+
+  // Structured ranking export (--json): the real score(), coverage, and per-file
+  // symbol-binding (NAME channel) + path-binding for every term — so a convergence
+  // characterization reads the ranker's actual numbers, not a parse of the page.
+  if (asData) {
+    const discSet = new Set(discTermIdx.map((k) => lterms[k]));
+    const rows = ranked.slice(0, 40).map(([rel]) => {
+      const file = index.files.get(rel)!;
+      const pathLow = rel.toLowerCase();
+      const defines: string[] = [], inPath: string[] = [];
+      for (let k = 0; k < terms.length; k++) {
+        const t = lterms[k];
+        if (!t) continue;
+        if (file.symbols.some((s) => s.name.toLowerCase().includes(t))) defines.push(terms[k]);
+        if (pathLow.includes(t)) inPath.push(terms[k]);
+      }
+      // does a DISCRIMINATING term bind to a declared symbol here? (Signal 1)
+      const defsDisc = defines.filter((t) => discSet.has(t.toLowerCase()));
+      return { path: rel, score: +score(rel).toFixed(4), coverage: coverage.get(rel)!.size,
+               defines, inPath, definesDiscriminating: defsDisc };
+    });
+    return JSON.stringify({
+      terms, nFiles, rareTerms,
+      discTerms: discTermIdx.map((k) => terms[k]),
+      idf: Object.fromEntries(terms.map((t) => [t, +idf(t).toFixed(4)])),
+      ranked: rows,
+    });
+  }
+
+  const matchedSymbols = (rel: string): string[] => {
+    const file = index.files.get(rel)!;
+    if (file.lineCount < MATCHED_SYM_MIN_LINES) return [];
+    const hits = file.symbols.filter((s) => {
+      const nl = s.name.toLowerCase();
+      return discTermIdx.some((k) => nl.includes(lterms[k]));
+    });
+    if (hits.length === 0) return [];
+    // drop a symbol if it strictly contains another matched symbol (keep the inner, specific one)
+    const specific = hits.filter((s) =>
+      !hits.some((o) => o !== s && o.startLine >= s.startLine && o.endLine <= s.endLine
+        && (o.startLine > s.startLine || o.endLine < s.endLine)));
+    // rank by rarity-weighted term match (Σ idf of distinct discriminating terms in the name), so the
+    // most query-specific methods win the cap; tiebreak by line order for readability.
+    const symScore = (s: { name: string }): number => {
+      const nl = s.name.toLowerCase();
+      return discTermIdx.reduce((acc, k) => acc + (nl.includes(lterms[k]) ? idf(terms[k]) : 0), 0);
+    };
+    return specific
+      .sort((a, b) => symScore(b) - symScore(a) || a.startLine - b.startLine)
+      .slice(0, MATCHED_SYM_CAP)
+      .sort((a, b) => a.startLine - b.startLine)
+      .map((s) => `${s.name} [L${s.startLine}-${s.endLine}]`);
+  };
+
+  interface Evidence {
+    text: string; disc: number;
+    declares: string[]; inPath: string[];
+    imports: Array<{ term: string; from: string }>; mentions: string[];
+  }
+  const evCache = new Map<string, Evidence>();
+  const evidence = (rel: string): Evidence => {
+    const cached = evCache.get(rel);
+    if (cached) return cached;
+    const file = index.files.get(rel)!;
+    const pathLow = rel.toLowerCase();
+    const matched = coverage.get(rel)!;
+    const declares: string[] = [], inPath: string[] = [], mentions: string[] = [];
+    const imports: Array<{ term: string; from: string }> = [];
+    for (let k = 0; k < terms.length; k++) {
+      const t = terms[k];
+      if (!matched.has(t)) continue;
+      if (file.symbols.some((s) => s.name.toLowerCase().includes(lterms[k]))) { declares.push(t); continue; }
+      if (pathLow.includes(lterms[k])) { inPath.push(t); continue; }
+      if (!rareSet.has(t)) continue; // common body-only term → noise, omit
+      const tgt = importTargetFor(rel, t);
+      if (tgt) imports.push({ term: t, from: tgt });
+      else mentions.push(t);
+    }
+    const parts: string[] = [];
+    if (declares.length) parts.push(`Defines ${declares.map(tick).join(', ')}.`);
+    if (inPath.length) parts.push(`Named for ${inPath.map(tick).join(', ')} (in its path).`);
+    for (const im of imports) parts.push(`Imports ${tick(im.term)} from ${im.from}.`);
+    if (mentions.length) parts.push(`Mentions ${mentions.map(tick).join(', ')} in its body.`);
+    const disc = declares.length + inPath.length + imports.length + mentions.length;
+    const res: Evidence = { text: parts.join(' '), disc, declares, inPath, imports, mentions };
+    evCache.set(rel, res);
+    return res;
+  };
+  // Compact "Role:" line — the file's identity in query terms, strongest signal first, one line.
+  const roleText = (rel: string): string => {
+    const ev = evidence(rel);
+    const segs: string[] = [];
+    if (ev.declares.length) segs.push(`defines ${ev.declares.map(tick).join(', ')}`);
+    if (ev.inPath.length) segs.push(`named for ${ev.inPath.map(tick).join(', ')}`);
+    if (ev.imports.length) segs.push(`imports ${ev.imports.map((i) => tick(i.term)).join(', ')} (from ${base(ev.imports[0].from)})`);
+    if (ev.mentions.length) segs.push(`mentions ${ev.mentions.map(tick).join(', ')}`);
+    return segs.join('; ');
+  };
+
+  // Partition the listing. Vendored/minified bundles are dropped outright (never an answer); code
+  // files lead with previews; stylesheets and prose/docs split into bare secondary lists so they can't
+  // crowd or out-rank the source file. NOISE FLOOR: drop code files with no discriminating evidence.
+  const droppedCount = ranked.filter(([rel]) => isVendorOrMinified(rel, index.files.get(rel)!)).length;
+  const kept = ranked.filter(([rel]) => !isVendorOrMinified(rel, index.files.get(rel)!));
+  const styleRanked = kept.filter(([rel]) => isStyle(rel));
+  const docRanked = kept.filter(([rel]) => isDoc(rel));
+  const codeRanked = kept.filter(([rel]) => !isDoc(rel) && !isStyle(rel) && evidence(rel).disc > 0);
+
+  const lines: string[] = [];
+  lines.push(`find: ${terms.join(' ')}  (${terms.length} terms, ${coverage.size} candidate files)`);
+  if (rareTerms.length === 0) {
+    lines.push(`  ⚠ no discriminating term — all of [${terms.join(', ')}] are common in this repo. Add a specific symbol, filename, or field name and re-run.`);
+  }
+  lines.push('');
+
+  // Top files get an inline convergence preview; the rest list as bare paths (cheap landscape,
+  // and `| head` truncation now drops whole tail files instead of cutting every file's evidence).
+  const detailSet = (codeRanked.length > 0 ? codeRanked : docRanked).slice(0, DETAIL_TOP);
+  const candidateList = codeRanked.slice(0, MAX_CANDIDATES_LISTED).map(([rel]) => rel);
+  const candidateSet = new Set(candidateList);
+
+  // Pass 1 — import co-citation among the listed candidates (precision relations).
+  const relations = computeImportRelations(index, candidateList);
+  const base = (rel: string): string => rel.split('/').pop() ?? rel;
+  // Query-grounded "via" (A/B variant only): the connecting term = a DISCRIMINATING term the DEFINER
+  // declares that the CONSUMER also matched — i.e. the rare query identifier that flows across the edge.
+  // Filtered to discriminating terms (idf ≥ query median): a common connector like `graph`/`delete`
+  // sits on every edge and is noise; the rare one (`LoadStaging`) is the meaning-making token. No reads.
+  const discLower = new Set(discTermIdx.map((k) => lterms[k]));
+  const viaTerms = (definer: string, other: string): string[] => {
+    const decl = new Set(evidence(definer).declares.map((t) => t.toLowerCase()));
+    if (decl.size === 0) return [];
+    const out: string[] = [];
+    for (const t of coverage.get(other) ?? []) {
+      const tl = t.toLowerCase();
+      if (decl.has(tl) && discLower.has(tl)) out.push(t);
+    }
+    return out.sort((a, b) => idf(b) - idf(a)).slice(0, 2);
+  };
+  // Render the relation line for a candidate, strongest signal first, capped. When `via`, annotate each
+  // edge with the query term that connects the two files (the "consumed in X via blah" the agent asked for).
+  const relText = (rel: string, via: boolean): string => {
+    const r = relations.get(rel);
+    if (!r) return '';
+    const label = (other: string, definer: string, consumer: string): string => {
+      if (!via) return tick(base(other));
+      const vs = viaTerms(definer, consumer);
+      return `${tick(base(other))}${vs.length ? ` (via ${vs.map(tick).join(', ')})` : ''}`;
+    };
+    const parts: string[] = [];
+    if (r.consumedBy.length) parts.push(`used by ${r.consumedBy.slice(0, 3).map((d) => label(d, rel, d)).join(', ')}`);
+    if (r.consumes.length) parts.push(`uses ${r.consumes.slice(0, 3).map((d) => label(d, d, rel)).join(', ')}`);
+    if (r.siblings.length) parts.push(`near ${r.siblings.slice(0, 3).map((d) => tick(base(d))).join(', ')}`);
+    return parts.join(' · ');
+  };
+
+  // Soft anchor: the connected set the agent should NAME, not just the file it opens. If ≥2 of the
+  // top files relate to each other, say so up front — the recall losses were the agent answering from
+  // one opened file and dropping the cluster it never read.
+  const connected = detailSet.filter(([rel]) => {
+    const r = relations.get(rel);
+    return r && (r.consumedBy.length || r.consumes.length || r.siblings.length);
+  }).length;
+
+  lines.push('== matches (top files previewed; ranked by term coverage + definition/path match) ==');
+  if (connected >= 2) {
+    lines.push('These top files reference each other — they are likely ONE answer set. Open the file marked START HERE, then name the connected files (below) in your answer; you do not need to read each one.');
+  }
+  detailSet.forEach(([rel, ts], i) => {
+    const file = index.files.get(rel)!;
+    lines.push('');
+    const anchor = i === 0 ? ' · START HERE' : '';
+    lines.push(`▸ ${rel}   [${ts.size}/${terms.length}${anchor}]`);
+    const role = roleText(rel);
+    if (role) lines.push(`   Role:  ${role}`);
+    const syms = matchedSymbols(rel);
+    if (syms.length) lines.push(`   Read:  ${syms.join(', ')}`);
+    const rt = relText(rel, via);
+    if (rt) lines.push(`   Wired: ${rt}`);
+    const specToTarget = index.edges
+      .filter((e) => e.from === rel)
+      .map((e) => ({ spec: e.specifier, target: index.files.get(e.to)?.relativePath ?? e.to }));
+    const preview = convergencePreview(file, terms, df, nFiles, specToTarget);
+    if (preview.length) for (const p of preview) lines.push(p);
+    else lines.push('     (no discriminating line — terms appear scattered; open the file)');
+  });
+
+  const rest = codeRanked.slice(DETAIL_TOP, MAX_CANDIDATES_LISTED);
+  if (rest.length > 0) {
+    lines.push('');
+    lines.push('-- more candidates (paths + what matched) --');
+    for (const [rel, ts] of rest) {
+      const role = roleText(rel);
+      const rt = relText(rel, via);
+      const tail = [role, rt].filter(Boolean).join(' · ');
+      lines.push(`  [${ts.size}/${terms.length}] ${rel}${tail ? `  — ${tail}` : ''}`);
+    }
+  }
+  if (codeRanked.length > MAX_CANDIDATES_LISTED) {
+    lines.push(`  [+${codeRanked.length - MAX_CANDIDATES_LISTED} more lower-coverage code files]`);
+  }
+  if (droppedCount > 0) {
+    lines.push(`  [${droppedCount} vendor/minified file${droppedCount === 1 ? '' : 's'} hidden]`);
+  }
+
+  // Pass 2 — shared-rare-token bridge (recall). For each previewed file, find files that
+  // co-mention the same rare, identifier-shaped tokens but produce NO import edge — the
+  // implicit-reference relations (migrations↔models, config-by-name, JS↔Python pairs) that the
+  // import graph cannot see. Gated by deriveRelatedFiles: cross-dir only, import-edge dedup,
+  // ≥2 shared tokens OR string-literal provenance, twin-merge, cap 3. Index-only, NO file reads.
+  const bridgeExclude = new Set(candidateSet);
+  for (const [rel] of detailSet) bridgeExclude.add(rel);
+  // Query-relevance gate. A bridge survives only if a shared token relates to a query
+  // stem. Without it, any file sharing an unrelated rare token with a big top match
+  // (e.g. a migration that touches one of models.py's many unrelated fields) surfaces —
+  // measured offline as 73% of related entries, all recurring noise (9075_external_oauth,
+  // 0001_initial, …); the query-relevant gold (q19 javascript.htm via `term…`) survives.
+  const qStems = new Set<string>();
+  for (const t of terms) {
+    const tl = t.toLowerCase();
+    if (tl.length >= 4) qStems.add(tl);
+    for (const part of tl.split(/[_\W]+/)) if (part.length >= 4) qStems.add(part);
+  }
+  const relatesToQuery = (toks: string[]): boolean =>
+    qStems.size === 0 ||
+    toks.some((tok) => {
+      const tl = tok.toLowerCase();
+      for (const s of qStems) if (tl.includes(s) || s.includes(tl)) return true;
+      return false;
+    });
+  const bridged: Array<{ from: string; fileId: string; tokens: string[]; alsoFileIds?: string[] }> = [];
+  const bridgedSeen = new Set<string>();
+  for (const [rel] of detailSet) {
+    const src = index.files.get(rel);
+    if (!src?.contentTokens) continue;
+    for (const rf of deriveRelatedFiles(rel, src.contentTokens, index, bridgeExclude)) {
+      if (bridgedSeen.has(rf.fileId)) continue;
+      if (!relatesToQuery(rf.tokens)) continue;
+      bridgedSeen.add(rf.fileId);
+      bridgeExclude.add(rf.fileId);
+      bridged.push({ from: rel, fileId: rf.fileId, tokens: rf.tokens, alsoFileIds: rf.alsoFileIds });
+    }
+  }
+  if (bridged.length > 0) {
+    lines.push('');
+    lines.push('-- related files (no import edge; share rare identifiers with a top match) --');
+    for (const b of bridged.slice(0, 6)) {
+      const also = b.alsoFileIds?.length ? ` (+${b.alsoFileIds.length} similar)` : '';
+      lines.push(`  ${b.fileId}${also}   — shares ${b.tokens.slice(0, 3).map(tick).join(', ')} with ${base(b.from)}`);
+    }
+  }
+
+  if (styleRanked.length > 0) {
+    lines.push('');
+    lines.push('-- stylesheets matching your terms (css/scss — not previewed) --');
+    for (const [rel, ts] of styleRanked.slice(0, MAX_STYLE_CANDIDATES)) {
+      lines.push(`  [${ts.size}/${terms.length}] ${rel}`);
+    }
+  }
+
+  if (docRanked.length > 0) {
+    lines.push('');
+    lines.push('-- docs/notes mentioning your terms (prose, not definitions) --');
+    for (const [rel, ts] of docRanked.slice(0, MAX_DOC_CANDIDATES)) {
+      lines.push(`  [${ts.size}/${terms.length}] ${rel}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Previews show where your rarest terms converge (comments/docstrings filtered, ±1 context line). If the answer is not here, add a more discriminating term and re-run.');
+  return lines.join('\n');
+}
+
+
+
+
+
+
+

--- a/src/server/find.ts
+++ b/src/server/find.ts
@@ -625,7 +625,9 @@ export function buildRichPage(index: CodebaseIndex, root: string, rawQuery: stri
 
   lines.push('== matches (top files previewed; ranked by term coverage + definition/path match) ==');
   if (connected >= 2) {
-    lines.push('These top files reference each other — they are likely ONE answer set. Open the file marked START HERE, then name the connected files (below) in your answer; you do not need to read each one.');
+    lines.push(
+      'These top files reference each other — they are likely ONE answer set. Open the file marked START HERE, then name the connected files (below) in your answer; you do not need to read each one.',
+    );
   }
   detailSet.forEach(([rel, ts], i) => {
     const file = index.files.get(rel)!;

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -19,20 +19,22 @@ export const TOOL_DEFINITIONS = [
     name: 'get-overview',
     description:
       'Locate files by matching `query` against DECLARED NAMES — filenames, path segments, exported symbols. Reach for GO BEFORE Read/Grep/Glob when finding which files are relevant.\n\n' +
-      'OUTPUT: `<path> [tok1, tok2, ...]` per result. Bracketed tokens are the matched name tokens, rarest-first (leftmost = highest signal).\n\n' +
+      'OUTPUT: results grouped into sections by WHERE they matched (file/dir names; code/symbol names; both). Each line is `<path> matched: [tok1, tok2, ...]` — matched name tokens, rarest-first (leftmost = highest signal). Sections are categories, NOT a ranking: line order across sections does not mean relevance order, and the strongest match may sit in any section — scan all sections before choosing.\n\n' +
+      'RELATION ANNOTATIONS: some result lines carry `← imported by X (also listed)` (an import edge between two shown results) or `~ shares `token` with X (also listed)` (the two results share a rare identifier/string literal). The `~` links are real relations the import graph cannot see — migration↔model schema twins, config-by-name references, cross-language pairs. Treat a linked pair as ONE unit of evidence: if one is worth reading, fetch the other in the same step instead of rediscovering it later.\n\n' +
       'CAPABILITIES:\n' +
       '- Naming-variant tolerant — case, separators, plural ≡ singular. `LoadStaging` ≡ `load_staging` ≡ `load-staging`; `tile` ≡ `tiles`. Pass the concept; do NOT grep-alternate spellings.\n' +
       '- Multi-concept — `auth payment` (AND), `[auth|login|jwt] payment` (OR), plus a small built-in synonym set (auth/login/jwt, search/find/query, message/post/chat).\n' +
       '- `path: "arches/app/**/*.py"` — glob scope; comma-combine; `!` to exclude.\n' +
       '- `include_tests: true` — opt in to tests (excluded by default).\n\n' +
-      'DOES NOT MATCH:\n' +
-      '- File body content (comments, docstrings, strings, HTML/template, SQL) → grep.\n' +
+      'DOES NOT MATCH (but see Content presence below):\n' +
+      '- File body content (comments, docstrings, strings, HTML/template, SQL).\n' +
       '- Import specifiers (by design).\n' +
       '- Nested symbols → use `get-structure`.\n\n' +
+      'CONTENT PRESENCE: when a query token matches NO declared name, GO reports where that token lives in file BODIES instead — `Content presence` lines name the files (rare token), give a count (common token), or state the identifier appears NOWHERE in indexed content. Trust the nowhere-line: the identifier does not exist in this repo — do not grep spelling variants of it. This makes GO the right FIRST probe even for identifiers you would otherwise grep for.\n\n' +
       'AFTER THE RESULT:\n' +
       '1. Path looks right → `get-structure` on it. Default returns symbols + imports + per-symbol callers + importers in one shot — that is your "who uses this" answer.\n' +
       '2. Leading `[matched]` token names your concept but the path is off → re-call GO with that token (~10× cheaper than bash-grep).\n' +
-      '3. Query words missing from every `[matched]` list → concept lives in body content; grep, scoped by file extension.\n\n' +
+      '3. Query words missing from every `[matched]` list → check the `Content presence` lines first; they tell you where the word lives in file bodies (or that it does not exist). Grep only for phrases/regex patterns GO cannot index.\n\n' +
       'FRAMEWORK CONVENTION FILES (page.tsx, route.ts, __init__.py): query by directory name — the filename is generic.',
     inputSchema: {
       type: 'object',
@@ -43,7 +45,7 @@ export const TOOL_DEFINITIONS = [
         },
         max_results: {
           type: 'number',
-          description: 'Page size, default 10. The top results are the best-scored declared-name matches; reformulate `query` before paging deep.',
+          description: 'Page size, default 10. The shown results are the best-scored declared-name matches, but display groups them by match channel — position in the output is not score order. Reformulate `query` before paging deep.',
         },
         include_tests: {
           type: 'boolean',
@@ -64,10 +66,11 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'get-structure',
     description:
-      'Drill into a known file. Returns four sections as compact text:\n' +
+      'Drill into a known file. Returns these sections as compact text:\n' +
       '- Symbols — top-level + per-class methods (name, kind, line range, extends/implements). With cross-file callers attached per exported symbol (inline if 1 caller; newline-per-caller block if ≥2). For huge files (>20 symbols, no `match`), symbols are reordered by caller count (most-used first) and truncated to top 15.\n' +
       '- Imports — 1-hop internal outbound dependencies (library imports stripped).\n' +
-      '- Importers — 1-hop reverse: files in this repo that import this one.\n' +
+      '- Importers — 1-hop reverse: files in this repo that import this one. With `match`, additionally lists EVERY indexed file (importer or not, any language) whose CONTENT references the matched term even when its filename does not (a registry, admin, or config file using the symbol — or a frontend file referencing a backend name). That subsection IS the complete "who uses <symbol>" answer: it is exhaustive over indexed content, so a subsystem absent from it does NOT use the symbol — do not grep to enumerate or re-verify use-sites, and do not keep hunting in subsystems the section rules out.\n' +
+      '- Related — files sharing rare identifier/string-literal tokens with this file (with `match`: with the matched symbols\' code region), shown only when NO import edge connects them. These are name-reference relations the import graph cannot see — Django migrations↔models, config-by-name registration, cross-language (JS↔Python) pairs. Treat them as first-class neighbors: the shared token shown is the reason they are related.\n' +
       'Use this AFTER get-overview surfaces a candidate file. This is the right tool for "who uses this file" / "who calls this symbol" — no separate call needed.\n\n' +
       '`view` controls which sections you get (default `full` = all four). `symbols`, `imports`, `importers`, `callers` each return one section in isolation when you want a byte-light answer.\n\n' +
       'For god-files (large classes, large routers, large config modules), pass `match` to filter symbols/imports/importers/callers to one area — e.g. `match: "auth"` or `match: "/^handle/"`. Substring is case-insensitive; wrap in slashes for regex.\n\n' +
@@ -87,6 +90,10 @@ export const TOOL_DEFINITIONS = [
           type: 'string',
           enum: ['full', 'symbols', 'imports', 'importers', 'callers'],
           description: 'Which sections to return. Default "full" = symbols (with inline callers) + imports + importers. Use one of the narrower views to halve or quarter the output when you know what you need: "symbols" (shape only, no callers), "imports" (outbound only), "importers" (inbound only), "callers" (per-symbol cross-file callers in expanded form, no symbol shape).',
+        },
+        symbol: {
+          type: 'string',
+          description: 'Deliver the BODY of the named symbol(s) inline, sliced from their indexed line range — so you read a method WITHOUT a Read at a guessed offset. Comma/pipe-separate names (`serialize,restore_state`). A bare name matches the method (`serialize` → `Graph.serialize`). Each body is followed by `callers:`/`calls:` POINTERS (file + line range) so the next hop is one more `get-structure --symbol` call, not a windowed Read. Use this the moment a file’s symbol list shows the method you need — it replaces the read-at-offset hunt on god-files. If the name is NOT a declared symbol (a runtime/template-injected value, a string key, a config token), it falls back to an in-tool GREP: returns the body lines where the token appears, with context — so you never shell out to grep. Overrides `view`/`match`.',
         },
       },
       required: ['file_path'],
@@ -138,6 +145,7 @@ export function registerToolHandlers(
         result = handleGetStructure(index, {
           file_path: (params['file_path'] ?? params['file'] ?? params['file_name']) as string,
           match: params['match'] as string | undefined,
+          symbol: params['symbol'] as string | undefined,
           view: params['view'] as 'full' | 'symbols' | 'imports' | 'importers' | 'callers' | undefined,
         });
         break;

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,5 +1,15 @@
-import type { CodebaseIndex, IndexedFile } from '../types.js';
+import { readFileSync } from 'node:fs';
+import type { CodebaseIndex, IndexedFile, SymbolNode } from '../types.js';
 import { IDF_RARITY_THRESHOLD } from '../constants.js';
+import {
+  extractContentTokens,
+  deriveInPageTokenLinks,
+  deriveRelatedFiles,
+  deriveNameEchoFiles,
+  isShapedToken,
+  RELATED_FILES_CAP,
+  type RelatedFile,
+} from '../indexer/content-tokens.js';
 import {
   TEST_QUERY_KEYWORDS,
   parseConceptGroups,
@@ -96,6 +106,61 @@ function buildResultEntry(
   };
 }
 
+// Annotate import links AMONG the shown results (in-page only — bounded by
+// page size, no hub fan-out; arches measurement: median 2 links/page). An edge
+// between two shown files is the same structural evidence get-structure would
+// deliver one call later; surfacing it at wall-1 hands the agent its
+// read-trigger evidence (gold-timeline: GS edges are the dominant read
+// trigger) without a turn spent.
+function annotateInPageImports(
+  results: Record<string, unknown>[],
+  index: CodebaseIndex,
+): void {
+  const pageIds = new Set(results.map(r => r.path as string));
+  for (const r of results) {
+    const importers = (index.inEdges.get(r.path as string) ?? []).filter(id =>
+      pageIds.has(id),
+    );
+    if (importers.length === 0) continue;
+    const names = importers.slice(0, 2).map(id => id.split('/').pop());
+    r.importedByShown =
+      names.join(', ') +
+      (importers.length > 2 ? ` +${importers.length - 2}` : '');
+  }
+}
+
+// Annotate rare-content-token links AMONG the shown results. The pair shares
+// identifier/string tokens that are rare corpus-wide (df 2–5) but have NO
+// import edge — exactly the relations the import graph cannot see (migrations
+// ↔ models, config-by-name, cross-language pairs). Display-only; the line
+// names the shared token because a relation is the actionable unit — bare
+// filenames in context stay inert (q16: wall-1 exposure was universal in all
+// 21 runs and inert in 16).
+const LINK_TOKENS_SHOWN = 3;
+function annotateInPageTokenLinks(
+  results: Record<string, unknown>[],
+  index: CodebaseIndex,
+  queryTokens: string[],
+): void {
+  const pageIds = results.map(r => r.path as string);
+  const links = deriveInPageTokenLinks(pageIds, index, queryTokens);
+  if (links.length === 0) return;
+  const byPath = new Map(results.map(r => [r.path as string, r]));
+  for (const link of links) {
+    const host = byPath.get(link.a);
+    if (!host) continue;
+    const otherIds = [link.b, ...(link.alsoB ?? [])];
+    const otherNames = otherIds.slice(0, 2).map(id => id.split('/').pop()).join(', ') +
+      (otherIds.length > 2 ? ` +${otherIds.length - 2}` : '');
+    const shown = link.tokens.slice(0, LINK_TOKENS_SHOWN).map(t => `\`${t}\``).join(', ');
+    const extra = link.tokens.length - LINK_TOKENS_SHOWN;
+    const line = `~ shares ${shown}${extra > 0 ? ` +${extra}` : ''} with ${otherNames} (also listed)`;
+    const existing = host.tokenLinks as string[] | undefined;
+    if (existing) existing.push(line);
+    else host.tokenLinks = [line];
+  }
+}
+
 // Factual classification of HOW a file matched, from per-token DomainEvidence
 // (not a role/purpose claim — see [[coldstart-is-evidence-not-classifier]]).
 //   'symbol' — matched only on declared code names (exports/classes/functions)
@@ -142,7 +207,10 @@ function formatMatchedTokens(m: MatchResult, index: CodebaseIndex): string[] {
 function formatResultLine(entry: Record<string, unknown>): string {
   const path = entry.path as string;
   const matched = entry.matched as string[];
-  return `${path} matched: [${matched.join(', ')}]`;
+  const link = entry.importedByShown as string | undefined;
+  return `${path} matched: [${matched.join(', ')}]${
+    link ? ` ← imported by ${link} (also listed)` : ''
+  }`;
 }
 
 const GO_FOOTER =
@@ -151,6 +219,71 @@ const GO_FOOTER =
 // ============================================================================
 // get-overview
 // ============================================================================
+
+// ---------------------------------------------------------------------------
+// Content-presence fallback (option B). For query tokens that match ZERO
+// declared names (where GO is structurally blind), report where the token
+// lives in file BODIES — or, for identifier-shaped tokens only, that it
+// appears nowhere. Characterized on 52 real runs (2026-06-12): 24% of real GO
+// query tokens are declared-name-invisible; clean fires named gold 8/17;
+// absence assertions are valid ONLY for shaped tokens (unshaped words never
+// enter contentTokens, so their absence proves nothing). Display-only.
+// ---------------------------------------------------------------------------
+const CONTENT_PRESENCE_MAX_LINES = 3;
+const CONTENT_PRESENCE_FLOOD = 8; // df above this → count only, never a file list
+
+function deriveContentPresenceLines(
+  rawQuery: string,
+  index: CodebaseIndex,
+): string[] {
+  const presence = index.contentPresenceIndex;
+  if (!presence || presence.size === 0) return [];
+
+  const words: string[] = [];
+  const seen = new Set<string>();
+  for (const w of rawQuery.split(/[\s[\]|,]+/)) {
+    if (w.length < 4 || !/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(w)) continue;
+    const key = w.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    words.push(w);
+  }
+
+  const listed: string[] = [];
+  const absent: string[] = [];
+  const flood: string[] = [];
+  for (const w of words) {
+    const lower = w.toLowerCase();
+    const norm = lower.replace(/[.-]/g, '_');
+    // Skip tokens GO can match: any lexical form present among declared names
+    let declared = false;
+    for (const form of new Set([...expandLexical(lower), ...expandLexical(norm)])) {
+      if ((index.tokenDocFreq.get(form) ?? 0) > 0) {
+        declared = true;
+        break;
+      }
+    }
+    if (declared) continue;
+
+    const entry = presence.get(lower) ?? presence.get(norm);
+    if (entry) {
+      if (entry.n <= CONTENT_PRESENCE_FLOOD) {
+        listed.push(
+          `\`${w}\` matches no declared name but appears in file CONTENT of: ${entry.files.join(', ')}`,
+        );
+      } else {
+        flood.push(
+          `\`${w}\` matches no declared name; found in ${entry.n} files' content — scope with \`path\` or grep`,
+        );
+      }
+    } else if (isShapedToken(w) || isShapedToken(w.replace(/[.-]/g, '_'))) {
+      absent.push(
+        `\`${w}\` appears NOWHERE in indexed file content — this identifier does not exist in the repo; do not grep spelling variants`,
+      );
+    }
+  }
+  return [...listed, ...absent, ...flood].slice(0, CONTENT_PRESENCE_MAX_LINES);
+}
 
 export function handleGetOverview(
   index: CodebaseIndex,
@@ -189,6 +322,7 @@ export function handleGetOverview(
   }
 
   const compiledGlob = pathSpec ? compileGlob(pathSpec) : null;
+  const contentPresenceLines = deriveContentPresenceLines(query, index);
 
   const allTokens = conceptGroups.flat();
   const isTestQuery = include_tests || allTokens.some(t => TEST_QUERY_KEYWORDS.has(t));
@@ -281,6 +415,8 @@ export function handleGetOverview(
     const results = fallbackMatched
       .slice((page - 1) * max_results, page * max_results)
       .map(m => buildResultEntry(m, index));
+    annotateInPageImports(results, index);
+    annotateInPageTokenLinks(results, index, allTokens);
 
     const response: Record<string, unknown> = { filter: query };
 
@@ -304,6 +440,7 @@ export function handleGetOverview(
     response.__rawText = renderOverviewText({
       query,
       results: results,
+      contentPresenceLines,
       fallback: fallbackMatched.length > 0,
       noMatches: fallbackMatched.length === 0,
       truncatedExtra: truncated ? fallbackMatched.length - page * max_results : 0,
@@ -318,6 +455,8 @@ export function handleGetOverview(
   const results = afterB
     .slice((page - 1) * max_results, page * max_results)
     .map(m => buildResultEntry(m, index));
+  annotateInPageImports(results, index);
+  annotateInPageTokenLinks(results, index, allTokens);
 
   const response: Record<string, unknown> = {
     filter: query,
@@ -338,6 +477,7 @@ export function handleGetOverview(
   response.__rawText = renderOverviewText({
     query,
     results,
+    contentPresenceLines,
     fallback: false,
     noMatches: false,
     truncatedExtra: truncated ? afterB.length - page * max_results : 0,
@@ -353,6 +493,7 @@ export function handleGetOverview(
 function renderOverviewText(opts: {
   query: string;
   results: Record<string, unknown>[];
+  contentPresenceLines?: string[];
   fallback: boolean;
   noMatches: boolean;
   truncatedExtra: number;
@@ -369,9 +510,11 @@ function renderOverviewText(opts: {
   if (opts.noMatches) {
     lines.push('[No declared-name matches.]');
   } else {
-    // Group results by match channel. Section order = first appearance, which
-    // preserves global rank: the top-ranked result leads its section and sections
-    // are ordered by their best-ranked member; rank order WITHIN a section is kept.
+    // Group results by match channel. Sections appear in order of their
+    // best-ranked member and rank order is kept WITHIN a section — but the
+    // flattened line order is NOT global rank: a later section's lead can
+    // outrank an earlier section's tail. Anything consuming this text
+    // (hooks, analysis scripts, agents) must not read line order as ranking.
     const SECTION_LABEL: Record<MatchChannel, string> = {
       symbol: 'Matched in code/symbol names:',
       name: 'Matched in file/dir names:',
@@ -391,8 +534,18 @@ function renderOverviewText(opts: {
       const ch = order[i];
       if (i > 0) lines.push('');
       lines.push(SECTION_LABEL[ch]);
-      for (const r of groups.get(ch)!) lines.push('  ' + formatResultLine(r));
+      for (const r of groups.get(ch)!) {
+        lines.push('  ' + formatResultLine(r));
+        const tokenLinks = r.tokenLinks as string[] | undefined;
+        if (tokenLinks) for (const tl of tokenLinks) lines.push('    ' + tl);
+      }
     }
+  }
+
+  if (opts.contentPresenceLines && opts.contentPresenceLines.length > 0) {
+    lines.push('');
+    lines.push('Content presence (query tokens with NO declared-name match, located in file bodies):');
+    for (const l of opts.contentPresenceLines) lines.push('  ' + l);
   }
 
   if (opts.truncatedExtra > 0) {
@@ -408,7 +561,7 @@ function renderOverviewText(opts: {
 
   lines.push('');
   if (opts.noMatches) {
-    lines.push('Next: GO indexes declared names only. For content in templates, SQL, comments, docstrings, config — use grep (scope by file extension).');
+    lines.push('Next: GO indexes declared names only. Check the Content presence lines above (file-body evidence) if present; otherwise grep, scoped by file extension.');
   } else {
     lines.push(GO_FOOTER);
   }
@@ -432,6 +585,7 @@ function attachPathExclusion(
 type GsView = 'full' | 'symbols' | 'imports' | 'importers' | 'callers';
 
 const IMPORTERS_LIST_CAP = 20;
+const BODY_REF_IMPORTERS_CAP = 8;
 // For huge files, show top-K symbols sorted by caller count first; the rest
 // collapse into a tail. Avoids the 60-class wall-of-text problem.
 const SYMBOLS_TOP_K = 15;
@@ -453,6 +607,7 @@ export function handleGetStructure(
     file_path: string;
     match?: string;
     view?: GsView;
+    symbol?: string;
   },
 ): object {
   if (!params.file_path) {
@@ -463,6 +618,17 @@ export function handleGetStructure(
     return { error: `File not found: ${params.file_path}` };
   }
   const [fileId, file] = fileEntry;
+
+  // Grade-2 symbol-body delivery: `--symbol name1,name2` slices the named
+  // method bodies straight from the indexed [startLine,endLine] range so the
+  // agent gets them in ONE call instead of windowing a god-file at guessed
+  // offsets (q22 read graph.py 8× hunting serialize/restore_state). Each slice
+  // is followed by 1-line caller/callee POINTERS (not bodies) so the next hop
+  // is one directed call away. This is the lever; grade-1 (the matched-symbol
+  // line ranges in `find`) only pointed the agent at the offsets.
+  if (params.symbol && params.symbol.trim()) {
+    return renderSymbolSlice(index, fileId, file, params.symbol);
+  }
 
   // Validate `view`: an invalid value (stale client, typo, or a hallucinated
   // name like "outline") would otherwise silently disable EVERY section and
@@ -507,6 +673,7 @@ export function handleGetStructure(
   let totalSymbolCount = 0;
   let filteredSymbolCount = 0;
   let truncatedSymbolCount = 0;
+  let matchMissedSymbols = false;
 
   if (wantSymbols) {
     const baseFiltered = file.symbols
@@ -515,9 +682,16 @@ export function handleGetStructure(
       .sort((a, b) => a.startLine - b.startLine);
     totalSymbolCount = baseFiltered.length;
 
-    const filtered = matchPredicate
+    let filtered = matchPredicate
       ? baseFiltered.filter(s => matchPredicate(s.name))
       : baseFiltered;
+    // Match-miss auto-fallback: a "0 symbols match" result's only possible
+    // follow-up is re-calling without the filter (a measured wasted call).
+    // Return the full view instead, flagged via matchMissedSymbols.
+    if (matchPredicate && filtered.length === 0 && baseFiltered.length > 0) {
+      filtered = baseFiltered;
+      matchMissedSymbols = true;
+    }
     filteredSymbolCount = filtered.length;
 
     // Compute display names + parent class indent (preserves source-order
@@ -553,7 +727,7 @@ export function handleGetStructure(
     // is steering, not browsing.
     if (
       view === 'full' &&
-      !matchPredicate &&
+      (!matchPredicate || matchMissedSymbols) &&
       annotated.length > SYMBOLS_HUGE_FILE_THRESHOLD
     ) {
       const sorted = annotated.slice().sort((a, b) => {
@@ -596,6 +770,8 @@ export function handleGetStructure(
   let importersFiltered = 0;
   let importersExtra = 0;
   let totalImporterCount = 0;
+  let bodyRefImporters: string[] = [];
+  let bodyRefTotal = 0;
   if (wantImporters) {
     const allImporters = buildAllImporters(fileId, index);
     totalImporterCount = allImporters.length;
@@ -605,6 +781,80 @@ export function handleGetStructure(
     importersFiltered = filteredImporters.length;
     importersShown = filteredImporters.slice(0, IMPORTERS_LIST_CAP);
     importersExtra = filteredImporters.length - importersShown.length;
+
+    // Body-reference filter: with `match`, the filename filter alone hides the
+    // files an agent actually wants — files that *reference* the matched
+    // symbol but don't carry it in their path (q16: admin.py registers
+    // models.SpatialView via attribute access; not a call edge, filename
+    // doesn't match → invisible, and the agent reconstructed this set with 25
+    // greps). Scan is REPO-WIDE, not importer-scoped: the cross-language
+    // use-sites this section exists for (a JS file referencing a Python
+    // symbol) import nothing from the target file, so an importer-only scan
+    // misses them — and only a repo-wide scan makes the rendered
+    // exhaustiveness claim true (q16 run-3: the agent held "body-refs =
+    // admin.py + graph.py" at call 11 and still spent 20 calls hunting a JS
+    // frontend that doesn't exist, because nothing said the list was
+    // complete). Shape-gated tokens only, so single-word terms find nothing —
+    // the section is omitted, never rendered as a misleading "0".
+    if (matchPredicate) {
+      const alreadyShown = new Set(importersShown);
+      for (const [p, f] of index.files) {
+        if (p === fileId || alreadyShown.has(p)) continue;
+        const toks = f.contentTokens;
+        if (!toks) continue;
+        for (const k of Object.keys(toks)) {
+          if (matchPredicate(k)) { bodyRefImporters.push(p); break; }
+        }
+      }
+      bodyRefTotal = bodyRefImporters.length;
+      // Source files first — tests are verification, not mechanism.
+      bodyRefImporters = [
+        ...bodyRefImporters.filter(p => !isTestPath(p)),
+        ...bodyRefImporters.filter(isTestPath),
+      ].slice(0, BODY_REF_IMPORTERS_CAP);
+    }
+  }
+
+  // Related files via the content-token channel (full view only). When the
+  // agent passed `match`, scope the source tokens to the matched symbols'
+  // line ranges — the match param is the agent's stated intent, and the echo
+  // lands at the attend-moment (the call right before the region gets Read).
+  // Dedupe is against what THIS payload renders (importsOut/importersShown),
+  // not the raw edge set — a god-file's truncated importer list can hide a
+  // file that the edge set technically contains.
+  let relatedOut: RelatedFile[] = [];
+  if (view === 'full') {
+    const excludeIds = new Set<string>([fileId, ...importsOut, ...importersShown, ...bodyRefImporters]);
+    let sourceTokens = file.contentTokens;
+    if (matchPredicate && !matchMissedSymbols && symbolsOut.length > 0 && index.contentTokenPostings.size > 0) {
+      try {
+        const allLines = readFileSync(file.path, 'utf-8').split('\n');
+        const parts: string[] = [];
+        let taken = 0;
+        for (const s of symbolsOut) {
+          parts.push(allLines.slice(s.startLine - 1, s.endLine).join('\n'));
+          taken += s.endLine - s.startLine + 1;
+          if (taken > 3000) break;
+        }
+        sourceTokens = extractContentTokens(parts.join('\n'), fileId) ?? sourceTokens;
+      } catch { /* unreadable — fall back to file-level tokens */ }
+    }
+    if (sourceTokens && index.contentTokenPostings.size > 0) {
+      relatedOut = deriveRelatedFiles(fileId, sourceTokens, index, excludeIds);
+    }
+    // Name-echo: filenames matching the agent's match terms (df-gated,
+    // separator-insensitive). Regex specs are skipped — terms only.
+    if (params.match && relatedOut.length < RELATED_FILES_CAP) {
+      const spec = params.match.trim();
+      if (!(spec.length >= 2 && spec.startsWith('/') && spec.endsWith('/'))) {
+        const terms = spec.split('|').map(s => s.trim()).filter(s => s.length > 0);
+        const echoExclude = new Set([...excludeIds, ...relatedOut.map(r => r.fileId)]);
+        relatedOut = [
+          ...relatedOut,
+          ...deriveNameEchoFiles(terms, index, echoExclude),
+        ].slice(0, RELATED_FILES_CAP);
+      }
+    }
   }
 
   // Render text.
@@ -616,6 +866,9 @@ export function handleGetStructure(
   if (wantSymbols) {
     if (symbolsOut.length > 0) {
       lines.push('');
+      if (matchMissedSymbols) {
+        lines.push(`[0 of ${totalSymbolCount} symbols match "${params.match}" — showing all symbols instead:]`);
+      }
       lines.push('Symbols:');
       for (const s of symbolsOut) {
         const range = s.startLine === s.endLine ? `[L${s.startLine}]` : `[L${s.startLine}-${s.endLine}]`;
@@ -703,7 +956,38 @@ export function handleGetStructure(
       if (importersExtra > 0) lines.push(`[+${importersExtra} more — narrow with \`match\`]`);
     } else if (matchPredicate && totalImporterCount > 0) {
       lines.push('');
-      lines.push(`Importers: 0 of ${totalImporterCount} match "${params.match}".`);
+      lines.push(`Importers: 0 of ${totalImporterCount} match "${params.match}" by filename.`);
+    }
+    // Body references: the grep-replacement answer to "who uses <match>" —
+    // files whose CONTENT references the matched term even though their
+    // filename doesn't. Repo-wide scan, so the closing exhaustiveness line is
+    // a true claim: absence here = no other indexed file names the term.
+    if (bodyRefImporters.length > 0) {
+      lines.push('');
+      lines.push(`Files referencing "${params.match}" in content (${bodyRefTotal}${bodyRefTotal > bodyRefImporters.length ? `, showing ${bodyRefImporters.length}` : ''}) — use-sites the lists above miss:`);
+      for (const p of bodyRefImporters) lines.push(`  ${p}`);
+      if (bodyRefTotal > bodyRefImporters.length) {
+        lines.push(`  The count (${bodyRefTotal}) is exhaustive over indexed file content — exactly that many files reference "${params.match}" as a named identifier; the list is truncated, narrow \`match\` to see the rest. Do not grep to re-verify.`);
+      } else {
+        lines.push(`  This list is exhaustive over indexed file content: no other file references "${params.match}" as a named identifier. Do not grep to re-verify, and do not hunt for use-sites in other subsystems.`);
+      }
+    }
+  }
+
+  // Related (content-token channel)
+  if (relatedOut.length > 0) {
+    lines.push('');
+    lines.push('Related (shares rare tokens, no import edge — name-reference relations the import graph cannot see):');
+    for (const r of relatedOut) {
+      if (r.viaName) {
+        lines.push(`  ${r.fileId} — filename matches "${r.viaName}"`);
+      } else {
+        const ids = [r.fileId, ...(r.alsoFileIds ?? [])];
+        const names = ids.slice(0, 2).join(', ') + (ids.length > 2 ? ` +${ids.length - 2}` : '');
+        const shown = r.tokens.slice(0, 3).map(t => `\`${t}\``).join(', ');
+        const extra = r.tokens.length - 3;
+        lines.push(`  ${names} — shares ${shown}${extra > 0 ? ` +${extra}` : ''}`);
+      }
     }
   }
 
@@ -719,6 +1003,176 @@ export function handleGetStructure(
     lines.push(nextHint);
   }
 
+  return { __rawText: lines.join('\n') };
+}
+
+// Grade-2 caps. Bodies are the expensive payload, so bound them; pointers are
+// cheap so they stay generous.
+const SLICE_SYMBOL_CAP = 4;      // distinct symbols sliced in one call
+const SLICE_LINE_BUDGET = 450;   // total body lines across all slices
+const SLICE_CALLEE_CAP = 10;     // callee pointers per symbol
+
+// Resolve requested symbol name(s) → SymbolNodes in `file`, tiered so a bare
+// last-segment like `serialize` lands on `Graph.serialize` and never on the
+// substring lookalike `serialized_graph`. Tiers, first non-empty wins per name:
+//   1. exact full name (`Graph.serialize`)        2. exact last segment (`serialize`)
+//   3. case-insensitive substring (last resort, e.g. a typo or partial recall)
+function resolveSliceSymbols(file: IndexedFile, spec: string): SymbolNode[] {
+  const names = spec.split(/[,|]/).map(s => s.trim()).filter(Boolean);
+  const picked = new Map<string, SymbolNode>(); // by symbol id, dedupe
+  for (const q of names) {
+    const ql = q.toLowerCase();
+    const exact = file.symbols.filter(s => s.name.toLowerCase() === ql);
+    const lastSeg = exact.length ? exact
+      : file.symbols.filter(s => s.name.toLowerCase().split('.').pop() === ql);
+    const tier = lastSeg.length ? lastSeg
+      : file.symbols.filter(s => s.name.toLowerCase().includes(ql));
+    for (const s of tier) picked.set(s.id, s);
+  }
+  return [...picked.values()].sort((a, b) => a.startLine - b.startLine);
+}
+
+// In-tool grep fallback for `--symbol` when no declared symbol matches: locate
+// the token(s) in the file body and return the matching line regions with
+// context, so the agent never shells out to grep. Caps keep it byte-light.
+const CONTENT_CONTEXT = 2;     // context lines each side of a match
+const CONTENT_REGION_CAP = 8;  // distinct regions returned
+const CONTENT_LINE_CAP = 70;   // total lines returned
+function renderContentMatch(file: IndexedFile, spec: string, allLines: string[]): object {
+  const terms = spec.split(/[,|]/).map(s => s.trim().toLowerCase()).filter(Boolean);
+  const hitLines: number[] = []; // 0-based
+  for (let i = 0; i < allLines.length; i++) {
+    const low = allLines[i].toLowerCase();
+    if (terms.some(t => low.includes(t))) hitLines.push(i);
+  }
+  if (hitLines.length === 0) {
+    const avail = file.symbols
+      .filter(s => s.isExported || s.kind === 'class' || s.kind === 'function' || s.kind === 'method')
+      .slice(0, 25).map(s => s.name).join(', ');
+    return {
+      __rawText: `${file.relativePath}: no symbol named "${spec}", and the token does not appear in this file's content either.\n` +
+        (avail ? `Declared symbols here: ${avail}${file.symbols.length > 25 ? ', …' : ''}` : 'No top-level symbols indexed in this file.') +
+        '\nThe identifier is not in this file — check the file path, or the value may be injected at runtime from elsewhere.',
+      error: `no symbol or content match for "${spec}"`,
+    };
+  }
+  // Merge nearby hits into regions.
+  const regions: Array<[number, number]> = [];
+  for (const ln of hitLines) {
+    const start = Math.max(0, ln - CONTENT_CONTEXT);
+    const end = Math.min(allLines.length - 1, ln + CONTENT_CONTEXT);
+    const last = regions[regions.length - 1];
+    if (last && start <= last[1] + 1) last[1] = Math.max(last[1], end);
+    else regions.push([start, end]);
+  }
+  const lines: string[] = [
+    `${file.relativePath} (${file.lineCount} lines) — no declared symbol matches "${spec}"; showing ${hitLines.length} content match${hitLines.length === 1 ? '' : 'es'} (in-tool grep, so you don't have to):`,
+  ];
+  let shown = 0;
+  let r = 0;
+  for (const [start, end] of regions) {
+    if (r >= CONTENT_REGION_CAP || shown >= CONTENT_LINE_CAP) {
+      lines.push(`   … [+${regions.length - r} more match regions — narrow \`--symbol\` or read the file]`);
+      break;
+    }
+    r++;
+    lines.push('');
+    for (let i = start; i <= end && shown < CONTENT_LINE_CAP; i++) {
+      lines.push(`${String(i + 1).padStart(5)}  ${allLines[i]}`);
+      shown++;
+    }
+  }
+  lines.push('');
+  lines.push('These are content matches, not a declared symbol — the token has no static definition here (often runtime/template-injected). Do not grep this file to re-confirm.');
+  return { __rawText: lines.join('\n') };
+}
+
+function renderSymbolSlice(
+  index: CodebaseIndex,
+  fileId: string,
+  file: IndexedFile,
+  spec: string,
+): object {
+  const wanted = resolveSliceSymbols(file, spec);
+
+  let allLines: string[];
+  try {
+    allLines = readFileSync(file.path, 'utf-8').split('\n');
+  } catch (e) {
+    return { error: `could not read ${file.relativePath}: ${e}` };
+  }
+
+  // No declared symbol matched — fall back to a CONTENT match (in-tool grep):
+  // return the body lines where the requested token(s) live, with context. This
+  // is the answer for tokens that have no static symbol (runtime/template-
+  // injected data like `arches.termSearchTypes`, string keys, config values) —
+  // so the agent gets the body text from the SAME call instead of shelling out
+  // to grep and guessing spellings (q19's 5 empty greps).
+  if (wanted.length === 0) {
+    return renderContentMatch(file, spec, allLines);
+  }
+
+  // Caller pointers: reuse the file-level builder (exported symbols only).
+  const callersByName = new Map<string, string[]>();
+  for (const entry of buildCallersForFile(fileId, file, index)) {
+    callersByName.set(entry.exportedSymbol, entry.callers);
+  }
+  // Callee pointers: resolve this symbol's outgoing calls edges → target location.
+  const symInfo = buildSymbolInfoMap(index);
+  const locById = new Map<string, { rel: string; start: number; end: number }>();
+  for (const f of index.files.values()) {
+    for (const s of f.symbols) locById.set(s.id, { rel: f.relativePath, start: s.startLine, end: s.endLine });
+  }
+  const calleesOf = (symId: string): string[] => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const edge of index.symbolEdges) {
+      if (edge.type !== 'calls' || edge.from !== symId) continue;
+      if (seen.has(edge.to)) continue;
+      seen.add(edge.to);
+      const meta = symInfo.get(edge.to);
+      if (!meta) continue;
+      const loc = locById.get(edge.to);
+      out.push(loc
+        ? `${meta.name} → ${loc.rel} [L${loc.start}-${loc.end}]`
+        : `${meta.name} → ${meta.file}`);
+      if (out.length >= SLICE_CALLEE_CAP) break;
+    }
+    return out;
+  };
+
+  const lines: string[] = [`${file.relativePath} (${file.lineCount} lines) — bodies for: ${wanted.map(s => s.name).join(', ')}`];
+  const sliced = wanted.slice(0, SLICE_SYMBOL_CAP);
+  if (wanted.length > sliced.length) {
+    lines.push(`[${wanted.length} symbols matched; slicing the first ${sliced.length} — narrow \`--symbol\` for the rest: ${wanted.slice(sliced.length).map(s => s.name).join(', ')}]`);
+  }
+
+  let spent = 0;
+  for (const s of sliced) {
+    lines.push('');
+    lines.push(`━━ ${s.kind} ${s.name} [L${s.startLine}-${s.endLine}]${s.extendsName ? ` extends ${s.extendsName}` : ''} ━━`);
+    const want = s.endLine - s.startLine + 1;
+    const room = Math.max(0, SLICE_LINE_BUDGET - spent);
+    if (room === 0) {
+      lines.push(`   [line budget reached — re-call \`--symbol ${s.name}\` alone to read this body]`);
+    } else {
+      const take = Math.min(want, room);
+      for (let i = s.startLine; i < s.startLine + take && i <= allLines.length; i++) {
+        lines.push(`${String(i).padStart(5)}  ${allLines[i - 1]}`);
+      }
+      if (take < want) lines.push(`   … [+${want - take} more lines truncated by budget — re-call \`--symbol ${s.name}\` alone for the full body]`);
+      spent += take;
+    }
+    // Pointers (not bodies): who calls this, what this calls — each is one directed `--symbol` hop away.
+    const callers = callersByName.get(s.name) ?? [];
+    if (callers.length) lines.push(`   callers: ${callers.slice(0, 6).join(' · ')}`);
+    const callees = calleesOf(s.id);
+    if (callees.length) lines.push(`   calls: ${callees.join(' · ')}`);
+    if (!callers.length && !callees.length) lines.push('   (no indexed callers/callees)');
+  }
+
+  lines.push('');
+  lines.push('Bodies delivered inline — no Read needed. Follow `calls:`/`callers:` pointers with another `gs <file> --symbol <name>` to hop without windowing.');
   return { __rawText: lines.join('\n') };
 }
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1083,7 +1083,20 @@ function renderContentMatch(file: IndexedFile, spec: string, allLines: string[])
     }
   }
   lines.push('');
-  lines.push('These are content matches, not a declared symbol — the token has no static definition here (often runtime/template-injected). Do not grep this file to re-confirm.');
+  lines.push('These are content matches, not a declared symbol — the token has no static definition here (often runtime/template-injected). Grepping this file again returns these same lines; you already have them.');
+  // STOP-GUESSING menu: a wrong `--symbol` guess still produces content hits (the word appears
+  // somewhere in the body), which reads as "productive" and invites re-guessing OTHER names — the
+  // #1 wasted-call pattern (q21: 3 serial gs on one file guessing upload/unzip/write_zip_file…,
+  // none of which are methods). Surface the file's ACTUAL declared symbols so the next call picks a
+  // real one instead of guessing again. Same menu the no-hit branch already shows.
+  const menu = file.symbols
+    .filter(s => s.isExported || s.kind === 'class' || s.kind === 'function' || s.kind === 'method')
+    .slice(0, 25).map(s => s.name);
+  if (menu.length) {
+    lines.push('');
+    lines.push(`"${spec}" is NOT a declared symbol here. This file's methods are: ${menu.join(', ')}${file.symbols.length > 25 ? ', …' : ''}`);
+    lines.push(`These are the file's only declared symbols — a name that isn't listed has no body to slice. Is the name you need in this list? If yes, pass it; if not, the token is runtime/template text — Read the file rather than guessing another \`--symbol\`.`);
+  }
   return { __rawText: lines.join('\n') };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface IndexedFile {
   containerResolutions?: Array<{ targetClass: string; line: number }>;  // PHP only: DI container class references
   djangoConventionRefs?: Array<{ kind: string; value: string }>;  // Python only: Django convention string refs (middleware, auth backends, etc.)
   submoduleImportCandidates?: string[];  // Python only: `from pkg import sub` bonus specifiers — resolve to an edge if a file exists, but a miss is NOT counted as unresolved (most are symbol imports)
+  contentTokens?: Record<string, number>;  // shaped full-body tokens → provenance bits (TOKEN_IN_CODE | TOKEN_IN_STRING); absent for excluded files (vendored, markdown)
 }
 
 export interface Edge {
@@ -113,6 +114,8 @@ export interface CodebaseIndex {
   outEdges: Map<string, string[]>;       // fileId → [fileId] (imports)
   inEdges: Map<string, string[]>;        // fileId → [fileId] (importers)
   tokenDocFreq: Map<string, number>;     // token → number of files containing that token (for IDF scoring)
+  contentTokenPostings: Map<string, string[]>;  // rare content token (df 2–5) → fileIds; derived from files' contentTokens, rebuilt on load/patch
+  contentPresenceIndex: Map<string, { n: number; files: string[] }>;  // lowercased content token → df + first files; derived, rebuilt on load/patch (GO content-presence fallback)
   indexedAt: number;                    // Date.now()
   gitHead: string;                      // HEAD commit hash or ''
 }
@@ -138,6 +141,7 @@ export interface ParsedFile {
   containerResolutions?: Array<{ targetClass: string; line: number }>;  // PHP only: DI container class references
   djangoConventionRefs?: Array<{ kind: string; value: string }>;  // Python only: Django convention string refs
   submoduleImportCandidates?: string[];  // Python only: `from pkg import sub` bonus specifiers (see IndexedFile)
+  contentTokens?: Record<string, number>;  // shaped full-body tokens → provenance bits (see IndexedFile)
 }
 
 export interface CacheMeta {

--- a/tests/content-tokens.test.ts
+++ b/tests/content-tokens.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Tests for the content-token link channel: extraction (shape gate,
+ * provenance, comment/vendored exclusion), postings (df window), link
+ * derivation gates (cross-directory, edge redundancy, strength, query-stem,
+ * triangle dedupe, caps), and GO/GS rendering.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildContentPresenceIndex,
+  extractContentTokens,
+  buildContentTokenPostings,
+  deriveInPageTokenLinks,
+  deriveRelatedFiles,
+  deriveNameEchoFiles,
+  isShapedToken,
+  isVendoredAssetPath,
+  TOKEN_IN_CODE,
+  TOKEN_IN_STRING,
+  TOKEN_LINKS_PER_PAGE,
+} from '../src/indexer/content-tokens.js';
+import { handleGetOverview, handleGetStructure } from '../src/server/tools.js';
+import type { CodebaseIndex, IndexedFile, Edge } from '../src/types.js';
+
+// ============================================================================
+// Synthetic index builder
+// ============================================================================
+type FileSpec = Partial<IndexedFile> & { id: string };
+
+function makeFile(spec: FileSpec): IndexedFile {
+  return {
+    id: spec.id,
+    path: spec.path ?? '/nonexistent/' + spec.id,
+    relativePath: spec.id,
+    language: spec.language ?? 'python',
+    domainMap: spec.domainMap ?? {},
+    exports: spec.exports ?? [],
+    hasDefaultExport: false,
+    imports: spec.imports ?? [],
+    hash: 'h',
+    lineCount: 10,
+    tokenEstimate: 10,
+    importedByCount: 0,
+    transitiveImportedByCount: 0,
+    isBarrel: spec.isBarrel ?? false,
+    isTestFile: spec.isTestFile ?? false,
+    symbols: spec.symbols ?? [],
+    contentTokens: spec.contentTokens,
+  };
+}
+
+function makeIndex(specs: FileSpec[], edges: Edge[] = []): CodebaseIndex {
+  const files = new Map(specs.map(s => [s.id, makeFile(s)]));
+  const outEdges = new Map<string, string[]>();
+  const inEdges = new Map<string, string[]>();
+  for (const id of files.keys()) {
+    outEdges.set(id, []);
+    inEdges.set(id, []);
+  }
+  for (const e of edges) {
+    outEdges.get(e.from)!.push(e.to);
+    inEdges.get(e.to)!.push(e.from);
+  }
+  const tokenDocFreq = new Map<string, number>();
+  for (const f of files.values()) {
+    for (const t of Object.keys(f.domainMap)) {
+      tokenDocFreq.set(t, (tokenDocFreq.get(t) ?? 0) + 1);
+    }
+  }
+  return {
+    rootDir: '/',
+    files,
+    edges,
+    symbolEdges: [],
+    outEdges,
+    inEdges,
+    tokenDocFreq,
+    contentTokenPostings: buildContentTokenPostings(files.values()),
+    contentPresenceIndex: buildContentPresenceIndex(files.values()),
+    indexedAt: Date.now(),
+    gitHead: '',
+  };
+}
+
+// ============================================================================
+// Shape gate
+// ============================================================================
+describe('isShapedToken', () => {
+  it('accepts multi-word identifier shapes, case preserved', () => {
+    expect(isShapedToken('limit_choices_to')).toBe(true);
+    expect(isShapedToken('source_identifier__isnull')).toBe(true); // double underscore
+    expect(isShapedToken('jwksUri')).toBe(true);
+    expect(isShapedToken('UserPreference')).toBe(true);
+    expect(isShapedToken('SEARCH_ITEMS_PER_PAGE')).toBe(true);
+  });
+
+  it('rejects prose and single words (the measured noise classes)', () => {
+    expect(isShapedToken('preference')).toBe(false);
+    expect(isShapedToken('ideally')).toBe(false);
+    expect(isShapedToken('index')).toBe(false);
+    expect(isShapedToken('Account')).toBe(false); // single-word Pascal
+    expect(isShapedToken('ABCDEF')).toBe(false); // single-word caps
+    expect(isShapedToken('a_b')).toBe(false); // too short
+    expect(isShapedToken('_private_thing')).toBe(false); // leading underscore
+  });
+});
+
+// ============================================================================
+// Extraction
+// ============================================================================
+describe('extractContentTokens', () => {
+  it('tags string-literal occurrences and code occurrences with provenance bits', () => {
+    const tokens = extractContentTokens(
+      `FILENAME_GENERATOR = "arches.app.utils.storage_filename_generator"\nresult = limit_choices_to\n`,
+      'settings.py',
+    )!;
+    expect(tokens['FILENAME_GENERATOR'] & TOKEN_IN_CODE).toBeTruthy();
+    expect(tokens['storage_filename_generator'] & TOKEN_IN_STRING).toBeTruthy();
+    expect(tokens['storage_filename_generator'] & TOKEN_IN_CODE).toBeFalsy();
+    expect(tokens['limit_choices_to']).toBe(TOKEN_IN_CODE);
+  });
+
+  it('drops comment-derived tokens (measured noise class)', () => {
+    const tokens = extractContentTokens(
+      `# this mentions user_preference in a comment\nx = 1  // and todo_marker here\nreal_token_here = 2\n`,
+      'a.py',
+    )!;
+    expect(tokens['user_preference']).toBeUndefined();
+    expect(tokens['todo_marker']).toBeUndefined();
+    expect(tokens['real_token_here']).toBeDefined();
+  });
+
+  it('still captures string-literal tokens on commented lines before the marker', () => {
+    const tokens = extractContentTokens(`path = 'term_filter.py'  # registers component\n`, 'a.py')!;
+    expect(tokens['term_filter']).toBeDefined();
+  });
+
+  it('returns undefined for vendored/minified assets and markdown', () => {
+    expect(extractContentTokens('var jquery_thing = 1;', 'media/js/jquery.min.js')).toBeUndefined();
+    expect(extractContentTokens('shared_token_here', 'docs/notes.md')).toBeUndefined();
+    expect(isVendoredAssetPath('app/vendor/lib.js')).toBe(true);
+    expect(isVendoredAssetPath('app/models/models.py')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Postings — df window
+// ============================================================================
+describe('buildContentTokenPostings', () => {
+  it('keeps only tokens with df in [2,5], excluding test files and barrels', () => {
+    const specs: FileSpec[] = [
+      { id: 'a/one.py', contentTokens: { shared_pair: 1, lonely_token: 1, common_token: 1 } },
+      { id: 'b/two.py', contentTokens: { shared_pair: 1, common_token: 1 } },
+      { id: 'tests/t.py', isTestFile: true, contentTokens: { shared_pair: 1 } },
+    ];
+    for (let i = 0; i < 6; i++) {
+      specs.push({ id: `c/f${i}.py`, contentTokens: { common_token: 1 } });
+    }
+    const postings = buildContentTokenPostings(specs.map(makeFile));
+    expect(postings.get('shared_pair')).toEqual(['a/one.py', 'b/two.py']); // test file excluded
+    expect(postings.has('lonely_token')).toBe(false); // df=1
+    expect(postings.has('common_token')).toBe(false); // df=8 > 5
+  });
+});
+
+// ============================================================================
+// In-page link derivation — the gates
+// ============================================================================
+describe('deriveInPageTokenLinks', () => {
+  const goldPair: FileSpec[] = [
+    {
+      id: 'app/models/models.py',
+      contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_STRING },
+    },
+    {
+      id: 'app/models/migrations/11857_fix.py',
+      contentTokens: { limit_choices_to: TOKEN_IN_STRING, source_identifier__isnull: TOKEN_IN_STRING },
+    },
+  ];
+
+  it('links cross-directory files sharing rare tokens (the q16 shape)', () => {
+    const index = makeIndex(goldPair);
+    const links = deriveInPageTokenLinks(['app/models/models.py', 'app/models/migrations/11857_fix.py'], index);
+    expect(links).toHaveLength(1);
+    expect(links[0].b).toBe('app/models/migrations/11857_fix.py');
+    expect(links[0].tokens).toContain('limit_choices_to');
+    expect(links[0].hasStringProvenance).toBe(true);
+  });
+
+  it('suppresses same-directory pairs (boilerplate twins)', () => {
+    const index = makeIndex([
+      { id: 'm/11848_a.py', contentTokens: { spatial_view_thing: 1, other_shared_tok: 1 } },
+      { id: 'm/11857_b.py', contentTokens: { spatial_view_thing: 1, other_shared_tok: 1 } },
+    ]);
+    expect(deriveInPageTokenLinks(['m/11848_a.py', 'm/11857_b.py'], index)).toHaveLength(0);
+  });
+
+  it('suppresses pairs already connected by an import edge (rendered as ← imported by)', () => {
+    const index = makeIndex(
+      [
+        { id: 'a/x.py', contentTokens: { shared_tok_one: 1, shared_tok_two: 1 } },
+        { id: 'b/y.py', contentTokens: { shared_tok_one: 1, shared_tok_two: 1 } },
+      ],
+      [{ from: 'b/y.py', to: 'a/x.py', type: 'import', specifier: 'x' }],
+    );
+    expect(deriveInPageTokenLinks(['a/x.py', 'b/y.py'], index)).toHaveLength(0);
+  });
+
+  it('kills weak 2-word single-code-token pairs but keeps single string-literal tokens', () => {
+    // 2-word generic (the measured weak-single noise class: new_ids, child_node)
+    const weak = makeIndex([
+      { id: 'a/x.py', contentTokens: { child_node: TOKEN_IN_CODE } },
+      { id: 'b/y.py', contentTokens: { child_node: TOKEN_IN_CODE } },
+    ]);
+    expect(deriveInPageTokenLinks(['a/x.py', 'b/y.py'], weak)).toHaveLength(0);
+
+    const stringRef = makeIndex([
+      { id: 'a/x.py', contentTokens: { child_node: TOKEN_IN_STRING } },
+      { id: 'b/y.py', contentTokens: { child_node: TOKEN_IN_CODE } },
+    ]);
+    expect(deriveInPageTokenLinks(['a/x.py', 'b/y.py'], stringRef)).toHaveLength(1);
+  });
+
+  it('admits a single CODE token when ultra-rare (df ≤ 3) and ≥3 words — the q16 gold shape', () => {
+    // limit_choices_to: df 3, 3 words, code provenance on both sides
+    const index = makeIndex([
+      { id: 'app/models/models.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE } },
+      { id: 'app/migrations/11857_fix.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE } },
+      { id: 'app/other/10516_rename.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE } },
+    ]);
+    const links = deriveInPageTokenLinks(['app/models/models.py', 'app/migrations/11857_fix.py'], index);
+    expect(links).toHaveLength(1);
+    expect(links[0].tokens).toEqual(['limit_choices_to']);
+  });
+
+  it('suppresses tokens containing a query stem (they link by construction)', () => {
+    const index = makeIndex([
+      { id: 'a/x.py', contentTokens: { spatial_view_helper: TOKEN_IN_STRING } },
+      { id: 'b/y.py', contentTokens: { spatial_view_helper: TOKEN_IN_STRING } },
+    ]);
+    expect(deriveInPageTokenLinks(['a/x.py', 'b/y.py'], index, ['spatial'])).toHaveLength(0);
+    expect(deriveInPageTokenLinks(['a/x.py', 'b/y.py'], index, ['unrelated'])).toHaveLength(1);
+  });
+
+  it('drops the triangle third side when implied by two stronger links', () => {
+    const index = makeIndex([
+      { id: 'a/x.py', contentTokens: { tok_alpha_beta: TOKEN_IN_STRING, tok_gamma_delta: TOKEN_IN_STRING } },
+      { id: 'b/y.py', contentTokens: { tok_alpha_beta: TOKEN_IN_STRING, tok_gamma_delta: TOKEN_IN_STRING, tok_extra_one: TOKEN_IN_STRING } },
+      { id: 'c/z.py', contentTokens: { tok_alpha_beta: TOKEN_IN_STRING, tok_gamma_delta: TOKEN_IN_STRING, tok_extra_one: TOKEN_IN_STRING } },
+    ]);
+    const links = deriveInPageTokenLinks(['a/x.py', 'b/y.py', 'c/z.py'], index);
+    // b–c is strongest (3 tokens); a–b and a–c carry subsets → one of them
+    // survives as second link, the third side is implied and dropped.
+    expect(links).toHaveLength(2);
+  });
+
+  it('caps links per page', () => {
+    const specs: FileSpec[] = [];
+    for (let i = 0; i < 5; i++) {
+      specs.push({
+        id: `d${i}/f${i}.py`,
+        contentTokens: { [`pair_token_${i}_a`]: TOKEN_IN_STRING, [`pair_token_${i}_b`]: TOKEN_IN_STRING },
+      });
+      specs.push({
+        id: `e${i}/g${i}.py`,
+        contentTokens: { [`pair_token_${i}_a`]: TOKEN_IN_STRING, [`pair_token_${i}_b`]: TOKEN_IN_STRING },
+      });
+    }
+    const index = makeIndex(specs);
+    const links = deriveInPageTokenLinks(specs.map(s => s.id), index);
+    expect(links.length).toBeLessThanOrEqual(TOKEN_LINKS_PER_PAGE);
+  });
+});
+
+// ============================================================================
+// GS-side related files + name-echo
+// ============================================================================
+describe('deriveRelatedFiles', () => {
+  it('finds the migration from the model and excludes rendered neighbors', () => {
+    const index = makeIndex([
+      { id: 'app/models/models.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_CODE } },
+      { id: 'app/models/migrations/11857_fix.py', contentTokens: { limit_choices_to: TOKEN_IN_STRING, source_identifier__isnull: TOKEN_IN_STRING } },
+      { id: 'app/views/spatialview.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_CODE } },
+    ]);
+    const src = index.files.get('app/models/models.py')!.contentTokens!;
+    const related = deriveRelatedFiles('app/models/models.py', src, index, new Set(['app/views/spatialview.py']));
+    expect(related).toHaveLength(1);
+    expect(related[0].fileId).toBe('app/models/migrations/11857_fix.py');
+    expect(related[0].tokens).toEqual(
+      expect.arrayContaining(['limit_choices_to', 'source_identifier__isnull']),
+    );
+  });
+});
+
+describe('deriveNameEchoFiles', () => {
+  it('matches compound filenames separator-insensitively (UserPreference → userpreference.py)', () => {
+    const index = makeIndex([
+      { id: 'app/views/api/userpreference.py' },
+      { id: 'app/models/models.py' },
+    ]);
+    const hits = deriveNameEchoFiles(['UserPreference'], index, new Set());
+    expect(hits).toHaveLength(1);
+    expect(hits[0].fileId).toBe('app/views/api/userpreference.py');
+    expect(hits[0].viaName).toBe('UserPreference');
+  });
+
+  it('df-gates common terms (skips terms matching too many filenames)', () => {
+    const specs: FileSpec[] = [];
+    for (let i = 0; i < 8; i++) specs.push({ id: `r${i}/resource_${i}.py` });
+    const index = makeIndex(specs);
+    expect(deriveNameEchoFiles(['resource'], index, new Set())).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// End-to-end rendering
+// ============================================================================
+describe('GO token-link rendering', () => {
+  it('renders the ~ shares line under the linked result', () => {
+    const specs: FileSpec[] = [
+      {
+        id: 'app/models/models.py',
+        domainMap: { spatialview: { filename: 1, path: 0, symbol: 1 } },
+        contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_CODE },
+      },
+      {
+        id: 'app/migrations/11857_fix.py',
+        domainMap: { spatialview: { filename: 1, path: 0, symbol: 0 } },
+        contentTokens: { limit_choices_to: TOKEN_IN_STRING, source_identifier__isnull: TOKEN_IN_STRING },
+      },
+    ];
+    // Filler corpus so the query token passes the IDF rarity predicate
+    for (let i = 0; i < 60; i++) specs.push({ id: `filler/f${i}.py` });
+    const index = makeIndex(specs);
+    const res = handleGetOverview(index, { query: 'spatialview' }) as { __rawText: string };
+    expect(res.__rawText).toContain('~ shares `limit_choices_to`');
+    expect(res.__rawText).toContain('with 11857_fix.py (also listed)');
+  });
+});
+
+describe('GS Related section rendering', () => {
+  it('renders Related with shared tokens in the full view', () => {
+    const index = makeIndex([
+      { id: 'app/models/models.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_CODE } },
+      { id: 'app/migrations/11857_fix.py', contentTokens: { limit_choices_to: TOKEN_IN_STRING, source_identifier__isnull: TOKEN_IN_STRING } },
+    ]);
+    const res = handleGetStructure(index, { file_path: 'app/models/models.py' }) as { __rawText: string };
+    expect(res.__rawText).toContain('Related (shares rare tokens, no import edge');
+    expect(res.__rawText).toContain('app/migrations/11857_fix.py — shares `limit_choices_to`');
+  });
+
+  it('omits Related when an import edge already connects the pair', () => {
+    const index = makeIndex(
+      [
+        { id: 'app/models/models.py', contentTokens: { limit_choices_to: TOKEN_IN_CODE, source_identifier__isnull: TOKEN_IN_CODE } },
+        { id: 'app/migrations/11857_fix.py', contentTokens: { limit_choices_to: TOKEN_IN_STRING, source_identifier__isnull: TOKEN_IN_STRING } },
+      ],
+      [{ from: 'app/migrations/11857_fix.py', to: 'app/models/models.py', type: 'import', specifier: 'models' }],
+    );
+    const res = handleGetStructure(index, { file_path: 'app/models/models.py' }) as { __rawText: string };
+    expect(res.__rawText).not.toContain('Related (');
+  });
+
+  it('lists files referencing the match term in body content, repo-wide (the admin.py + cross-language case)', () => {
+    // admin.py imports models.py and references SpatialView via attribute
+    // access — no call edge, filename doesn't match. viewer.js references the
+    // symbol WITHOUT importing the file (JS↔Python, no possible edge) — the
+    // repo-wide scan must surface both; a file with no body reference must
+    // not appear. The section must also close with the exhaustiveness line
+    // (the q16 run-3 tail happened because nothing said the list was complete).
+    const index = makeIndex(
+      [
+        { id: 'app/models/models.py', symbols: [{ id: 's1', name: 'SpatialView', kind: 'class', startLine: 1, endLine: 5, isExported: true, implementsNames: [] }] },
+        { id: 'admin.py', contentTokens: { SpatialView: TOKEN_IN_CODE } },
+        { id: 'app/media/js/viewer.js', contentTokens: { SpatialView: TOKEN_IN_CODE } },
+        { id: 'app/views/unrelated.py', contentTokens: { other_token_here: TOKEN_IN_CODE } },
+      ],
+      [
+        { from: 'admin.py', to: 'app/models/models.py', type: 'import', specifier: 'models' },
+        { from: 'app/views/unrelated.py', to: 'app/models/models.py', type: 'import', specifier: 'models' },
+      ],
+    );
+    const res = handleGetStructure(index, {
+      file_path: 'app/models/models.py',
+      match: 'spatialview', // lowercase, the form real runs use
+    }) as { __rawText: string };
+    expect(res.__rawText).toContain('Files referencing "spatialview" in content (2)');
+    expect(res.__rawText).toContain('admin.py');
+    expect(res.__rawText).toContain('app/media/js/viewer.js');
+    expect(res.__rawText).not.toContain('unrelated.py');
+    expect(res.__rawText).toContain('This list is exhaustive over indexed file content');
+  });
+
+  it('omits the body-reference section when nothing matches (never a misleading 0)', () => {
+    const index = makeIndex(
+      [
+        { id: 'app/models/models.py', symbols: [{ id: 's1', name: 'SpatialView', kind: 'class', startLine: 1, endLine: 5, isExported: true, implementsNames: [] }] },
+        { id: 'app/views/unrelated.py', contentTokens: { other_token_here: TOKEN_IN_CODE } },
+      ],
+      [{ from: 'app/views/unrelated.py', to: 'app/models/models.py', type: 'import', specifier: 'models' }],
+    );
+    const res = handleGetStructure(index, {
+      file_path: 'app/models/models.py',
+      match: 'spatialview',
+    }) as { __rawText: string };
+    expect(res.__rawText).not.toContain('referencing "spatialview" in content');
+  });
+
+  it('adds name-echo files for match terms', () => {
+    const index = makeIndex([
+      { id: 'app/models/models.py', contentTokens: { some_token_here: TOKEN_IN_CODE } },
+      { id: 'app/views/api/userpreference.py' },
+    ]);
+    const res = handleGetStructure(index, {
+      file_path: 'app/models/models.py',
+      match: 'UserPreference',
+    }) as { __rawText: string };
+    expect(res.__rawText).toContain('app/views/api/userpreference.py — filename matches "UserPreference"');
+  });
+});
+
+// ============================================================================
+// Content-presence index + GO fallback lines (option B)
+// ============================================================================
+describe('buildContentPresenceIndex', () => {
+  it('counts df case-insensitively and caps the file list', () => {
+    const specs: FileSpec[] = [];
+    for (let i = 0; i < 12; i++) {
+      specs.push({ id: `app/mod${i}.py`, contentTokens: { geom_nodes: TOKEN_IN_CODE } });
+    }
+    // same token in two casings within one file → one df
+    specs.push({ id: 'app/dual.py', contentTokens: { SpatialView: TOKEN_IN_CODE, spatialView: TOKEN_IN_CODE } });
+    specs.push({ id: 'tests/excluded_test.py', isTestFile: true, contentTokens: { geom_nodes: TOKEN_IN_CODE } });
+    const presence = buildContentPresenceIndex(specs.map(makeFile));
+    const entry = presence.get('geom_nodes')!;
+    expect(entry.n).toBe(12); // test file excluded
+    expect(entry.files.length).toBe(8); // CONTENT_PRESENCE_LIST_CAP
+    expect(presence.get('spatialview')!.n).toBe(1);
+  });
+});
+
+describe('GO content-presence fallback', () => {
+  function presenceIndex(specs: FileSpec[]): CodebaseIndex {
+    const index = makeIndex(specs);
+    index.contentPresenceIndex = buildContentPresenceIndex([...index.files.values()]);
+    return index;
+  }
+
+  it('names the files for a declared-name-invisible token with small content df', () => {
+    const index = presenceIndex([
+      { id: 'app/views/base.py', contentTokens: { geom_nodes: TOKEN_IN_CODE } },
+      { id: 'app/media/map-layer-manager.js', language: 'javascript', contentTokens: { geom_nodes: TOKEN_IN_CODE } },
+    ]);
+    const res = handleGetOverview(index, { query: 'geom_nodes dropdown' }) as { __rawText: string };
+    expect(res.__rawText).toContain('Content presence');
+    expect(res.__rawText).toContain('`geom_nodes` matches no declared name but appears in file CONTENT of: app/views/base.py, app/media/map-layer-manager.js');
+  });
+
+  it('asserts absence ONLY for shaped tokens', () => {
+    const index = presenceIndex([{ id: 'app/views/base.py', contentTokens: { other_token_here: TOKEN_IN_CODE } }]);
+    const res = handleGetOverview(index, { query: 'graph_published sidebar' }) as { __rawText: string };
+    expect(res.__rawText).toContain('`graph_published` appears NOWHERE in indexed file content');
+    expect(res.__rawText).not.toContain('`sidebar`'); // unshaped — absence unprovable, stay silent
+  });
+
+  it('stays silent for tokens that match declared names', () => {
+    const index = presenceIndex([
+      { id: 'app/spatialview.py', domainMap: { spatialview: { filename: 1, path: 0, symbol: 0 } }, contentTokens: { spatialView: TOKEN_IN_CODE } },
+    ]);
+    const res = handleGetOverview(index, { query: 'spatialview' }) as { __rawText: string };
+    expect(res.__rawText).not.toContain('Content presence');
+  });
+
+  it('gives a count-only line when the token floods', () => {
+    const specs: FileSpec[] = [];
+    for (let i = 0; i < 20; i++) specs.push({ id: `app/m${i}.py`, contentTokens: { load_event: TOKEN_IN_CODE } });
+    const index = presenceIndex(specs);
+    const res = handleGetOverview(index, { query: 'load_event' }) as { __rawText: string };
+    expect(res.__rawText).toContain("`load_event` matches no declared name; found in 20 files' content");
+    expect(res.__rawText).not.toContain('appears in file CONTENT of:');
+  });
+});

--- a/tests/get-overview.test.ts
+++ b/tests/get-overview.test.ts
@@ -13,6 +13,7 @@ import { parseFile, buildFileId } from '../src/indexer/parser.js';
 import { resolveImports } from '../src/indexer/resolvers/index.js';
 import { buildGraph } from '../src/indexer/graph.js';
 import { buildFileDomains, isTestPath } from '../src/indexer/tokenize.js';
+import { buildContentTokenPostings, buildContentPresenceIndex } from '../src/indexer/content-tokens.js';
 import { handleGetOverview, handleGetStructure } from '../src/server/tools.js';
 import type { CodebaseIndex, IndexedFile, SymbolEdge, DomainEvidence } from '../src/types.js';
 
@@ -53,6 +54,7 @@ async function buildTestIndex(rootDir: string): Promise<CodebaseIndex> {
           isTestFile: isTestPath(wf.relativePath),
           symbols: parsed.symbols,
           reexportRatio: parsed.reexportRatio,
+          contentTokens: parsed.contentTokens,
         };
         indexedFiles.push(file);
       } catch {
@@ -157,6 +159,8 @@ async function buildTestIndex(rootDir: string): Promise<CodebaseIndex> {
     outEdges,
     inEdges,
     tokenDocFreq,
+    contentTokenPostings: buildContentTokenPostings(filesMap.values()),
+    contentPresenceIndex: buildContentPresenceIndex(filesMap.values()),
     indexedAt: Date.now(),
     gitHead: '',
   };
@@ -493,13 +497,16 @@ describe('GS `match` filter', () => {
     expect(text).not.toContain('loginUser');
   });
 
-  it('match with no symbol hits reports the "0 of N match" summary', () => {
+  it('match with no symbol hits falls back to the full symbol list (flagged)', () => {
+    // A "0 symbols match" result's only possible follow-up is re-calling
+    // without the filter — so GS returns the unfiltered view instead.
     const result = handleGetStructure(index, {
       file_path: 'auth/service.ts',
       match: 'nonexistentxyz',
     }) as any;
     const text = result.__rawText as string;
-    expect(text).toMatch(/Symbols: 0 of \d+ match "nonexistentxyz"/);
+    expect(text).toMatch(/\[0 of \d+ symbols match "nonexistentxyz" — showing all symbols instead:\]/);
+    expect(text).toContain('loginUser'); // full list rendered despite the miss
   });
 });
 


### PR DESCRIPTION
## Summary

Brings the `coldstart-v2` navigation work to `main`. Two commits land here:

1. **`a132051` — two-pass relevance + rich-page presentation + `gs --symbol` bodies**
   The richer `coldstart find` page (ranked relevant files with a connected-set "START HERE" hint) and per-symbol body slicing for `gs --symbol`.

2. **`45e6abf` — STOP-GUESSING symbol menu + CLI search hooks + coldstart skill** (this PR's new work)

Together these are the CLI + hooks + skill surface validated in benchmarking: on the full 27-query arches benchmark, this configuration cut agent tokens **~64% at recall parity** vs the no-tool baseline.

## What's in `45e6abf`

### `tools.ts` — STOP-GUESSING menu on content matches (`gs --symbol`)
A wrong `--symbol` guess still produces content hits (the word appears *somewhere* in the file body), which reads as "productive" and invites the agent to re-guess **other** names — the single biggest wasted-call pattern observed (e.g. 3 serial `gs` calls on one file guessing method names that don't exist).

When the requested symbol isn't a declared name, we now surface the file's **actual declared symbols** so the next call picks a real one (or falls back to `Read`) instead of guessing again. This reuses the menu the no-hit branch already shows. The content-match note is also reworded toward an explicit *"you already have these lines"* stop signal rather than implying there's more to find.

### `find.ts`
Formatting-only wrap of the connected-set hint line. No behavioural change.

### `hooks/` — Node (`.mjs`) port of the Python search-behaviour hooks
The plugin-shippable form of the behavioural levers:
- `run-hook.mjs` — crash-resilient ESM wrapper (fail-open on any error)
- `canonical-find-key.mjs` — shared query-key function imported by **both** hooks, so the preguard and nudge can't drift out of sync
- `nudge-handler.mjs` — PostToolUse: emits a no-new-evidence redundancy nudge; per-agent state keyed `{sid}_{aid}` (verified to fire **inside subagents** with clean per-agent isolation)
- `preguard-handler.mjs` — PreToolUse: denies an exact `find` re-run
- `find-nudge.mjs` / `find-preguard.mjs` — thin entry points

### `skills/coldstart/SKILL.md`
The coldstart navigation skill: the `go`/`gs` flow, output-reading guide, and a stop rule.

## Verification
- `npm run build` — clean
- `npm test` — **356 / 356 pass**
- Staged content scanned for personal paths / private identifiers — clean
- Local `.mcp.json.disabled` artifact intentionally **not** committed

## Known follow-up (not in this PR)
`SKILL.md` documents `coldstart go`/`gs`, while the validated benchmark path is `coldstart find`. That go-vs-find skew, and the broader MCP-vs-CLI divergence (the rich `find` page is currently CLI-only and not exposed over MCP), are slated for the upcoming code-quality refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)