### PR TITLE
coldstart 2.0 — unify go→find, two-tool surface, keeper + thin readers, init-wired hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,21 @@ process model is rebuilt around a single background keeper with stateless reader
   "is my index fresh?" job is covered by `status`).
 - **`init` rewritten around a single `coldstart.md`.** `coldstart init` writes one
   `coldstart.md` (CLI or MCP flavor) at the repo root carrying all agent guidance;
-  Claude Code gets `@coldstart.md` wired into `CLAUDE.md`, other apps wire it
-  manually. No per-IDE rules files, no skill. `init` also warms the index in the
-  background so the first lookup is instant.
+  Claude Code gets `@coldstart.md` wired into `CLAUDE.md` **and the find/gs search
+  hooks registered in `.claude/settings.json`**, other apps wire it manually. No
+  per-IDE rules files, no skill. `init` also warms the index in the background so
+  the first lookup is instant.
+
+### Added
+- **Search hooks wired by `init` (Claude Code).** `coldstart init` now registers two
+  hooks in `.claude/settings.json`, pointing at the version-pinned copies under
+  `~/.coldstart/versions/<v>/hooks/`: a PostToolUse nudge that flags search behaviour
+  going wrong, and a PreToolUse guard that denies an exact `find` re-run. Merged
+  idempotently — every other setting and any foreign hooks are preserved, a malformed
+  `settings.json` is left untouched. The handlers are surface-agnostic: a shared
+  `normalizeColdstartCall` rewrites an MCP `find`/`gs` call into the equivalent CLI
+  command string, so the detectors run unchanged whether the agent reached coldstart
+  via the CLI or the MCP tools. The hooks ship in the package (`hooks/`).
 
 ### Fixed
 - **Convention-edge freshness on incremental patch.** Editing a single Rails/Django/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ For Rails repos: the Ruby parser emits synthetic edges for `has_many`/`belongs_t
 
 **Live updates:** the keeper's `fs.watch` listener keeps the cache current. Changes are debounced (400 ms), then either patched incrementally (≤30 files, ~2–5 ms/file) or trigger a full background rebuild (>30 files), and the cache is re-saved ~5 s after edits settle. No restarts required.
 
-**Setup:** `coldstart init` writes a single `coldstart.md` at the repo root (CLI- or MCP-flavored) carrying all agent guidance. For Claude Code it wires `@coldstart.md` into CLAUDE.md; for any other app it writes coldstart.md for manual wiring. (No skill, no per-IDE rules files.)
+**Setup:** `coldstart init` writes a single `coldstart.md` at the repo root (CLI- or MCP-flavored) carrying all agent guidance. For Claude Code it also wires `@coldstart.md` into CLAUDE.md and registers the find/gs search hooks (PostToolUse nudge + PreToolUse find-dedup guard) in `.claude/settings.json` — merged idempotently, pointing at the version-pinned hooks in `~/.coldstart/versions/<v>/`. For any other app it writes coldstart.md for manual wiring. (No skill, no per-IDE rules files.) The same hooks ship in the Claude Code plugin. Hook handlers normalize CLI (`coldstart find`/`gs`) and MCP (`mcp__coldstart__find`/`gs`) calls to one code path (`hooks/coldstart-call.mjs`).
 
 Key files:
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,57 @@
+# Philosophy: bring your own semantics
+
+> **coldstart is a retrieval primitive, not a comprehension layer. The semantic layer is the agent.**
+
+The most common critique of coldstart, next to embedding-based code-search tools, is that it "has no semantics" — no vector index, no LLM-generated file summaries, no learned notion of what a file *means*. That's true, and it's deliberate. This document is the full argument for why omitting that layer is the stronger design, not a gap.
+
+## The core claim
+
+Every consumer of coldstart is already a frontier language model — the most capable semantic reasoner in the loop. A tool that pre-computes meaning is duplicating, at index time and worse, what the agent does natively at query time. coldstart does the one thing the agent *can't* do cheaply — find the right file without burning tokens grepping — and leaves meaning to the reasoner that has the task in hand.
+
+## Four reasons it's the stronger design
+
+**1. Semantics computed before the question are the wrong semantics.**
+Embeddings and LLM summaries freeze one interpretation of a file at index time, blind to the task. The agent holds the task. It can judge relevance *in context*, weigh two candidate files against the actual goal, and follow a hunch the index never anticipated. A static semantic layer commits to "what this file is about" before anyone asked the question — and is then stuck with that guess, no matter what the real query turns out to be.
+
+**2. A frozen meaning drifts; a structural fact doesn't.**
+Embeddings must recompute on every edit and silently lag the code — a stale vector returns a confident wrong answer, and you can't tell by looking. coldstart indexes facts that are cheap to keep *exact*: paths, symbol names, exports, import/call edges. A background keeper patches them in milliseconds as you type, so the index never lies about the current tree. Exactness you can maintain beats meaning you can't.
+
+**3. Evidence the agent can trust beats a score it has to second-guess.**
+coldstart returns *why* a file ranked — these query terms are defined here, imported there, referenced on these lines. That's checkable. A cosine similarity score isn't: the agent either trusts it blindly or spends tokens re-verifying it, and a frontier agent will re-verify. Because there's no model inference in the index, every result is deterministic, offline, free, needs no API key or GPU, and traces back to a concrete token or edge. The agent never has to wonder whether the tool hallucinated.
+
+**4. The bottleneck was never comprehension.**
+Agents already read and reason about code well — that's the part they're good at. What they waste tokens on is *finding* the right file: the orientation flailing, the speculative greps, the reading of three wrong files before the right one. coldstart does only that, hands the file off, and gets out of the way. Adding a semantic layer would re-spend tokens solving a problem the agent doesn't have, and wedge a second, dumber interpreter between the agent and the source.
+
+## The one place semantic search looks like it wins
+
+Vocabulary mismatch — you search `auth`, the code says `credential`. This is the real case for a semantic index, and it deserves an honest answer rather than a dodge.
+
+coldstart's answer is to put that bridge where the knowledge already lives. The agent knows the synonyms; the guidance tells it to pass *every* salient identifier from the task — the symbol, the domain noun, the rare token it half-remembers — not one distilled keyword. On the index side, `find` doesn't only match declared names: a repo-wide name-reference pass widens the net to where those tokens actually appear. The agent supplies the vocabulary; the index supplies the exactness.
+
+Splitting the work the other way — a model guessing synonyms at index time, frozen and blind to the task — is strictly worse: it's the same guess for every future query, computed once, never corrected by the question that finally arrives. The agent, asked live, with the task in front of it, makes a better bridge every time.
+
+## So when *is* coldstart the wrong tool?
+
+Being honest about the boundary is part of the argument:
+
+- **A literal string, phrase, or regex inside file bodies** → that's `grep`, and `grep` is exact and free. coldstart routes you to files by *name and structure*, not by arbitrary body content.
+- **Reading an implementation** → that's `Read`, after `gs` has shown you the file's shape and callers.
+- **Deep semantic Q&A about behavior** ("does this function ever deadlock?") → that's the agent's reasoning over the code coldstart found, not coldstart's job.
+
+coldstart is honest about being a router. It doesn't interpose its own (possibly wrong) interpretation between the agent and the code. It gets the agent to the right file fast, with evidence, and stops.
+
+## It works best with Claude Code
+
+The design assumes a shell-capable, tool-using frontier agent, and Claude Code is the cleanest fit:
+
+- **CLI-primary.** Claude Code has a shell, so it reaches `coldstart find` / `coldstart gs` directly — the fast path, no MCP round-trip.
+- **Auto-wired.** `coldstart init` writes the agent guidance, imports it into `CLAUDE.md`, and registers the find/gs search hooks in `.claude/settings.json` — so the right search behavior is in place from the first prompt, not something the user has to remember.
+- **The model is the semantic layer.** The whole philosophy rests on the consumer being a strong reasoner that brings its own meaning. That's exactly what Claude is.
+
+No-shell clients (e.g. Claude Desktop) get the identical engine through the MCP `find`/`gs` tools — same results, just wired by hand.
+
+## In one line
+
+"coldstart has no semantics" isn't a gap to apologize for. It's a refusal to pre-chew what the agent can taste. Tools that wrap an embedding model around code search are answering a question the agent can already answer for itself. coldstart answers the one it can't — *which file, without the token tax* — and stops there.
+
+**Bring your own semantics. The model already has them.**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ coldstart init
 
 `init` writes a single `coldstart.md` at your repo root (the agent-facing guidance) and wires it in:
 
-- **Claude Code** → ensures `CLAUDE.md` imports it via `@coldstart.md`.
+- **Claude Code** → ensures `CLAUDE.md` imports it via `@coldstart.md`, and registers the find/gs search hooks in `.claude/settings.json` (a PostToolUse nudge + a PreToolUse find-dedup guard — merged into any existing settings, never overwriting them).
 - **Any other app** → writes `coldstart.md` only, and prints the MCP server entry to paste into your client's config.
 
 It then warms the index in the background, so your first lookup is instant. Re-running `init` is safe — it never duplicates entries.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ coldstart ships as one binary with two front doors:
 
 Same engine, same index, same results. Pick whichever your agent can reach.
 
+It works best with **Claude Code**: shell-capable, so it gets the fast CLI path, and `coldstart init` auto-wires the guidance import *and* the search hooks for it. Other clients use the MCP surface with manual wiring.
+
+---
+
+## Bring your own semantics
+
+coldstart has no embeddings, no summaries, no semantic layer — **on purpose. The semantic layer is the agent.** Every consumer is already a frontier model, the most capable reasoner in the loop; pre-computing meaning at index time only duplicates that, worse and stale. So coldstart indexes what's cheap to keep *exact* — paths, symbols, exports, the import/call graph — returns *why* each file ranked (this term defined here, imported there), and leaves meaning to the reasoner that has the task in hand. It does the one thing the agent can't do cheaply: find the right file without burning tokens grepping.
+
+That's not a missing feature next to embedding-based tools — it's the design. The full argument is in **[PHILOSOPHY.md](./PHILOSOPHY.md)**.
+
 ---
 
 ## Install
@@ -165,13 +175,13 @@ node dist/index.js find auth --root .
 node dist/index.js --root . --no-daemon
 ```
 
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the index pipeline and process model, and [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for recovery procedures.
+See [PHILOSOPHY.md](./PHILOSOPHY.md) for why coldstart has no semantic layer, [ARCHITECTURE.md](./ARCHITECTURE.md) for the index pipeline and process model, and [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for recovery procedures.
 
 ---
 
 ## Limitations
 
-1. It's a routing layer, not a behavior summarizer — no semantic analysis or code summaries.
+1. It's a routing layer, not a behavior summarizer — no semantic analysis or code summaries. This is deliberate: the consuming agent is the semantic layer (see [PHILOSOPHY.md](./PHILOSOPHY.md)).
 2. `gs` callers are one-hop and file-scoped. Member-expression calls (`this.method()`, `api.method()`) aren't cross-file resolved; named function/constant calls are. Chase further hops by calling `gs` on the caller files.
 3. Dynamic/computed imports (`import(variable)`) and runtime-DSL references (polymorphic associations, gem/reflection-backed models) stay unresolved.
 4. Hidden directories and files over 1 MB are skipped.

--- a/hooks/coldstart-call.mjs
+++ b/hooks/coldstart-call.mjs
@@ -1,0 +1,58 @@
+/**
+ * coldstart-call.mjs — normalize a tool call into the shape the detectors expect.
+ *
+ * coldstart is reachable two ways with IDENTICAL semantics:
+ *   - CLI  : Bash `coldstart find <terms>` / `coldstart gs <file> --symbol <s>`
+ *   - MCP  : tools `mcp__coldstart__find {query}` / `mcp__coldstart__gs {file_path,...}`
+ *
+ * The nudge/preguard detectors were written against the CLI surface: they key on
+ * `tool === "Bash"` and run regexes over the command STRING. Rather than fork the
+ * detector logic per surface, this normalizer rewrites an MCP coldstart call into
+ * the equivalent CLI command string and reports it as a Bash call. Every downstream
+ * regex (FIND_RE/GS_RE/GS_FILE_RE/SEARCH_RE) and the canonical-find-key then run
+ * UNCHANGED — same logic, regardless of which surface the agent used.
+ *
+ * Non-coldstart calls pass through untouched (tool name + `tool_input.command`).
+ *
+ * The MCP tool name is `mcp__<serverKey>__<tool>`; the benchmark wires coldstart
+ * under the server key `coldstart` (see the arm's `.mcp.json`). If you key it
+ * differently, change MCP_SERVER_KEY below — that is the only surface-specific knob.
+ */
+
+const MCP_SERVER_KEY = "coldstart";
+const MCP_FIND = `mcp__${MCP_SERVER_KEY}__find`;
+const MCP_GS = `mcp__${MCP_SERVER_KEY}__gs`;
+
+function str(v) {
+  return typeof v === "string" ? v : "";
+}
+
+/**
+ * @param {string} toolName  input.tool_name
+ * @param {any}    toolInput input.tool_input (already coerced to {} if missing)
+ * @returns {{ tool: string, cmd: string }}
+ *   For an MCP coldstart find/gs call: { tool: "Bash", cmd: "<synthesized CLI command>" }.
+ *   For anything else: { tool: <toolName>, cmd: <tool_input.command or ""> }.
+ */
+export function normalizeColdstartCall(toolName, toolInput) {
+  const tin = toolInput && typeof toolInput === "object" ? toolInput : {};
+
+  if (toolName === MCP_FIND) {
+    // find accepts `query` (alias `domain_filter`); `path` scopes it (folded into the dedup key).
+    const query = str(tin.query) || str(tin.domain_filter);
+    const path = str(tin.path) ? ` --path ${str(tin.path)}` : "";
+    return { tool: "Bash", cmd: `coldstart find ${query}${path}`.trim() };
+  }
+
+  if (toolName === MCP_GS) {
+    // gs needs the file as the first token after `gs` (GS_FILE_RE), plus the flags
+    // that the detectors look at (--symbol drives the slice/re-guess detectors).
+    const file = str(tin.file_path) || str(tin.file) || str(tin.file_name);
+    const symbol = str(tin.symbol) ? ` --symbol ${str(tin.symbol)}` : "";
+    const match = str(tin.match) ? ` --match ${str(tin.match)}` : "";
+    const view = str(tin.view) ? ` --view ${str(tin.view)}` : "";
+    return { tool: "Bash", cmd: `coldstart gs ${file}${symbol}${match}${view}`.trim() };
+  }
+
+  return { tool: toolName || "", cmd: str(tin.command) };
+}

--- a/hooks/nudge-handler.mjs
+++ b/hooks/nudge-handler.mjs
@@ -1,5 +1,10 @@
 /**
- * nudge-handler.mjs — PostToolUse nudge for the `coldstart find` CLI.
+ * nudge-handler.mjs — PostToolUse nudge for coldstart `find`/`gs`, CLI and MCP.
+ *
+ * The agent may reach coldstart via the CLI (Bash `coldstart find/gs`) or the MCP
+ * tools (`mcp__coldstart__find/gs`). normalizeColdstartCall rewrites an MCP call
+ * into the equivalent CLI command string so every detector below runs unchanged on
+ * either surface — same logic, only the entry tool name differs.
  *
  * Fires advisory nudges (additionalContext) at the moments the agent's search
  * behaviour goes wrong. Detectors, each fires sparingly:
@@ -32,6 +37,7 @@
 
 import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { canonicalFindKey } from "./canonical-find-key.mjs";
+import { normalizeColdstartCall } from "./coldstart-call.mjs";
 
 // ---- detector thresholds (tune freely) ----
 const FINDS_BEFORE_READ = 2; // (1) nudge to read after this many finds w/o a Read/gs
@@ -95,9 +101,10 @@ function matchAllGroup(re, s, group) {
 export default function handle(input) {
   const sid = input.session_id || "default";
   const aid = input.agent_id || ""; // set when inside a subagent
-  const tool = input.tool_name || "";
   const tin = input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {};
-  const cmd = typeof tin.command === "string" ? tin.command : "";
+  // Collapse CLI and MCP coldstart calls to one shape: an MCP find/gs becomes a
+  // synthetic `coldstart find/gs ...` Bash command so the detectors run unchanged.
+  const { tool, cmd } = normalizeColdstartCall(input.tool_name || "", tin);
   const out = resultText(input);
 
   const key = aid ? `${sid}_${aid}` : sid;

--- a/hooks/preguard-handler.mjs
+++ b/hooks/preguard-handler.mjs
@@ -27,6 +27,7 @@
 
 import { readFileSync } from "node:fs";
 import { canonicalFindKey } from "./canonical-find-key.mjs";
+import { normalizeColdstartCall } from "./coldstart-call.mjs";
 
 const REASON =
   "You have ALREADY run this exact `coldstart find` earlier in this session — same " +
@@ -41,9 +42,12 @@ const REASON =
  * @returns {object|null} a permissionDecision:"deny" envelope, or null to allow
  */
 export default function handle(input) {
-  if ((input.tool_name || "") !== "Bash") return null;
   const tin = input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {};
-  const cmd = typeof tin.command === "string" ? tin.command : "";
+  // Normalize so a `mcp__coldstart__find` call is deduped against a CLI `coldstart
+  // find` (and vice-versa) using the same canonical key. Non-coldstart Bash falls
+  // through to canonicalFindKey, which returns null for anything that isn't a find.
+  const { tool, cmd } = normalizeColdstartCall(input.tool_name || "", tin);
+  if (tool !== "Bash") return null;
   const key = canonicalFindKey(cmd);
   if (!key) return null;
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "main": "./dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "hooks"
   ],
   "keywords": [
     "cli",

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,7 +5,8 @@
  * agent-facing guidance. Clients pull it in by reference, so future wording
  * changes touch only coldstart.md, never the client's own rules file.
  *
- *   - Claude Code  → ensure CLAUDE.md exists and imports it via `@coldstart.md`.
+ *   - Claude Code  → ensure CLAUDE.md exists and imports it via `@coldstart.md`,
+ *     and register the find/gs search hooks in `.claude/settings.json`.
  *   - Any other app → write coldstart.md only; the user wires it as rules/
  *     instructions/skill however their app prefers (and, for no-shell clients,
  *     adds the MCP server entry we print).
@@ -133,6 +134,17 @@ function mcpServerEntry(cwd: string): { command: string; args: string[] } {
   return { command: 'node', args: [entryPath, '--root', cwd] };
 }
 
+/**
+ * Absolute path to the shipped hooks dir, inside the version-pinned stable
+ * install (sibling of `dist/`). Pinning to the stable copy means the path we
+ * write into settings.json survives a later `npm update`/uninstall of the live
+ * package. Throws (same as mcpServerEntry) if no install can be located.
+ */
+function resolveHooksDir(): string {
+  const entryPath = getOrInstallStableVersion(); // <stable>/node_modules/<pkg>/dist/index.js
+  return path.join(path.dirname(path.dirname(entryPath)), 'hooks');
+}
+
 // ---------------------------------------------------------------------------
 // Writers
 // ---------------------------------------------------------------------------
@@ -158,6 +170,81 @@ export function wireClaudeImport(cwd: string): 'created' | 'added' | 'present' {
   return 'added';
 }
 
+// Hook entry files (in the shipped hooks/ dir). The PostToolUse nudge fires
+// search-behaviour advice; the PreToolUse guard denies an exact find re-run.
+const HOOK_PRE = 'find-preguard.mjs';
+const HOOK_POST = 'find-nudge.mjs';
+
+/** True if a settings.json hook-array entry is one WE wrote (by entry filename),
+ *  so re-running init can strip + refresh it instead of duplicating it. */
+function isColdstartHookEntry(entry: unknown): boolean {
+  const hooks = (entry as { hooks?: unknown })?.hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => {
+    const cmd = (h as { command?: unknown })?.command;
+    return typeof cmd === 'string' && (cmd.includes(HOOK_PRE) || cmd.includes(HOOK_POST));
+  });
+}
+
+/**
+ * Register the find/gs search hooks in the project's `.claude/settings.json`.
+ *
+ * Merges (never clobbers): preserves every other setting and any non-coldstart
+ * hooks. Idempotent — strips our prior entries (matched by entry filename) and
+ * re-adds them, so a re-run refreshes a stale hook path without duplicating.
+ * Fail-safe — if settings.json exists but is not valid JSON, we leave it alone
+ * and report, rather than overwrite a file the user owns.
+ *
+ * The matchers are surface-agnostic: PreToolUse fires for the CLI `coldstart
+ * find` (Bash) AND the `mcp__coldstart__find` tool; PostToolUse fires for all
+ * tools. The hook handler normalizes both surfaces to one code path.
+ */
+export function wireClaudeHooks(cwd: string): 'created' | 'updated' | { error: string } {
+  let hooksDir: string;
+  try {
+    hooksDir = resolveHooksDir();
+  } catch (e) {
+    return { error: `could not resolve a stable install path (${e})` };
+  }
+  const preCmd = `node ${path.join(hooksDir, HOOK_PRE)}`;
+  const postCmd = `node ${path.join(hooksDir, HOOK_POST)}`;
+
+  const dir = path.join(cwd, '.claude');
+  const filePath = path.join(dir, 'settings.json');
+
+  let settings: Record<string, unknown> = {};
+  const existed = fs.existsSync(filePath);
+  if (existed) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (parsed && typeof parsed === 'object') settings = parsed as Record<string, unknown>;
+    } catch {
+      return { error: `${filePath} is not valid JSON — left untouched; wire hooks manually` };
+    }
+  }
+
+  const hooksCfg =
+    settings.hooks && typeof settings.hooks === 'object'
+      ? (settings.hooks as Record<string, unknown>)
+      : {};
+  const stripOurs = (arr: unknown): unknown[] =>
+    (Array.isArray(arr) ? arr : []).filter((e) => !isColdstartHookEntry(e));
+
+  hooksCfg.PreToolUse = [
+    ...stripOurs(hooksCfg.PreToolUse),
+    { matcher: 'Bash|mcp__coldstart__find', hooks: [{ type: 'command', command: preCmd }] },
+  ];
+  hooksCfg.PostToolUse = [
+    ...stripOurs(hooksCfg.PostToolUse),
+    { matcher: '*', hooks: [{ type: 'command', command: postCmd }] },
+  ];
+  settings.hooks = hooksCfg;
+
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+  return existed ? 'updated' : 'created';
+}
+
 // ---------------------------------------------------------------------------
 // Setup routines
 // ---------------------------------------------------------------------------
@@ -167,6 +254,12 @@ function setupClaude(cwd: string): void {
   const importResult = wireClaudeImport(cwd);
   out(`  coldstart.md  — ${mdResult} (CLI flavor)`);
   out(`  CLAUDE.md     — ${importResult === 'present' ? 'already imports @coldstart.md' : `${importResult} @coldstart.md import`}`);
+  const hookResult = wireClaudeHooks(cwd);
+  if (typeof hookResult === 'object') {
+    out(`  settings.json — search hooks NOT wired: ${hookResult.error}`);
+  } else {
+    out(`  settings.json — ${hookResult} find/gs search hooks (PreToolUse + PostToolUse)`);
+  }
 }
 
 function setupOther(cwd: string): void {
@@ -215,6 +308,7 @@ export async function runInit(): Promise<void> {
     out('Will write:');
     out('  coldstart.md  — agent guidance (CLI flavor)');
     out('  CLAUDE.md     — import `@coldstart.md` (create if missing, append if present)');
+    out('  .claude/settings.json — register find/gs search hooks (PreToolUse + PostToolUse)');
     out('');
     const answer = await ask('Set up for Claude Code? [Y/n] ');
     claude = answer === '' || answer === 'y';

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { coldstartMd, writeColdstartMd, wireClaudeImport } from '../src/init.js';
+import { coldstartMd, writeColdstartMd, wireClaudeImport, wireClaudeHooks } from '../src/init.js';
 
 // We can't easily test runInit interactively, but we can test that the
 // MCP entry structure is correct when it's generated. This is a basic
@@ -116,5 +116,75 @@ describe('init wiring (coldstart.md import model)', () => {
     // exactly one occurrence — no duplicate import appended
     const body = fs.readFileSync(path.join(tempDir, 'CLAUDE.md'), 'utf8');
     expect(body.match(/@coldstart\.md/g)!.length).toBe(1);
+  });
+});
+
+describe('wireClaudeHooks (settings.json hook wiring)', () => {
+  let tempDir: string; // the project being wired
+  let homeDir: string; // fake HOME holding a pre-seeded stable install (no copy)
+  let prevHome: string | undefined;
+  const settingsPath = (): string => path.join(tempDir, '.claude', 'settings.json');
+  const readSettings = (): any => JSON.parse(fs.readFileSync(settingsPath(), 'utf8'));
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-hooks-test-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-home-test-'));
+    // Pre-seed the version-pinned stable install so getOrInstallStableVersion
+    // early-returns (entry exists) instead of copying anything.
+    const version = JSON.parse(
+      fs.readFileSync(path.resolve(path.dirname(__filename), '..', 'package.json'), 'utf8'),
+    ).version as string;
+    const stable = path.join(homeDir, '.coldstart', 'versions', version, 'node_modules', 'coldstart');
+    fs.mkdirSync(path.join(stable, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(stable, 'dist', 'index.js'), '// stub');
+    fs.mkdirSync(path.join(stable, 'hooks'), { recursive: true });
+    prevHome = process.env.HOME;
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    for (const d of [tempDir, homeDir]) if (fs.existsSync(d)) fs.rmSync(d, { recursive: true });
+  });
+
+  it('creates settings.json with surface-agnostic find/gs hook matchers', () => {
+    expect(wireClaudeHooks(tempDir)).toBe('created');
+    const s = readSettings();
+    expect(s.hooks.PreToolUse[0].matcher).toBe('Bash|mcp__coldstart__find');
+    expect(s.hooks.PreToolUse[0].hooks[0].command).toContain('find-preguard.mjs');
+    expect(s.hooks.PostToolUse[0].matcher).toBe('*');
+    expect(s.hooks.PostToolUse[0].hooks[0].command).toContain('find-nudge.mjs');
+    // path points at the version-pinned stable install, not a tilde
+    expect(s.hooks.PostToolUse[0].hooks[0].command).toContain('.coldstart/versions');
+  });
+
+  it('merges into existing settings without clobbering and is idempotent', () => {
+    fs.mkdirSync(path.join(tempDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        permissions: { allow: ['Read(*)'] },
+        hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ type: 'command', command: 'node /other.mjs' }] }] },
+      }),
+    );
+    expect(wireClaudeHooks(tempDir)).toBe('updated');
+    expect(wireClaudeHooks(tempDir)).toBe('updated'); // re-run
+    const s = readSettings();
+    expect(s.permissions).toEqual({ allow: ['Read(*)'] }); // preserved
+    // foreign hook kept + exactly one of ours (no duplication across re-runs)
+    expect(s.hooks.PostToolUse).toHaveLength(2);
+    expect(s.hooks.PostToolUse.filter((e: any) => e.matcher === 'Write')).toHaveLength(1);
+    expect(s.hooks.PostToolUse.filter((e: any) => e.matcher === '*')).toHaveLength(1);
+    expect(s.hooks.PreToolUse).toHaveLength(1);
+  });
+
+  it('refuses to clobber a malformed settings.json', () => {
+    fs.mkdirSync(path.join(tempDir, '.claude'), { recursive: true });
+    fs.writeFileSync(settingsPath(), '{ not valid json');
+    const res = wireClaudeHooks(tempDir);
+    expect(typeof res).toBe('object');
+    expect((res as { error: string }).error).toContain('not valid JSON');
+    expect(fs.readFileSync(settingsPath(), 'utf8')).toBe('{ not valid json'); // untouched
   });
 });


### PR DESCRIPTION
## Summary

This is the **coldstart 2.0** branch. It collapses the tool surface, rebuilds the process model around a single background keeper, renames the package CLI-first, and has `init` wire everything (import + search hooks) for Claude Code. Net diff is **−2300 lines** (3731 deleted / 1417 added) — most of it dead-code and dead-surface removal.

## What changed

**Two operations, two surfaces.**
- Tools/commands renamed to `find` + `gs` (`get-overview` → `find`, `get-structure` → `gs`). Surface reduced 4 → 2: `trace-deps`/`trace-impact` fold into a single file-scoped `gs` call (symbols with per-symbol cross-file callers, 1-hop outbound imports, reverse importers; `view` = `full`/`symbols`/`imports`/`importers`/`callers`).
- Exposed identically as **CLI** (`coldstart find`/`gs`, the primary path) and **MCP** (`find`/`gs`, no-shell fallback) with byte-identical output.

**One keeper, thin readers.** The HTTP-serving daemon is gone. `coldstart --daemon` now *only* keeps the on-disk cache fresh (watch → patch/rebuild → save); it serves nothing. `find`/`gs` and the stdio MCP server are stateless readers that lazy-spawn the keeper. No bridge, HTTP server, or port. Lockfile drops `port`; `status` is HTTP-free; `doctor` removed (folded into `status`). Deleted: `bridge.ts`, `http-daemon.ts`, `scoring.ts`, `glob.ts`.

**Package renamed `coldstart-mcp` → `coldstart` @ 2.0.0.** CLI is primary, MCP is the no-shell fallback. `coldstart-mcp` deprecated on npm; the `coldstart-mcp` binary name retained as an alias so existing MCP configs keep working.

**`init` rewritten + hook wiring.** `init` writes one `coldstart.md` (CLI or MCP flavor) carrying all agent guidance, wires `@coldstart.md` into `CLAUDE.md`, **registers the find/gs search hooks in `.claude/settings.json`** (PostToolUse nudge + PreToolUse find-dedup guard, pointed at version-pinned `~/.coldstart/versions/<v>/hooks/`), and warms the index in the background. No per-IDE rules files, no skill. The merge is idempotent and never clobbers foreign settings/hooks; a malformed `settings.json` is left untouched.
- A shared `hooks/coldstart-call.mjs` rewrites an MCP `find`/`gs` call into the equivalent CLI command string, so the nudge + preguard detectors run unchanged on either surface. `hooks/` now ships in the npm package.

**Fixed: convention-edge freshness on incremental patch.** Editing a single Rails/Django/Laravel/C# convention file used to drop that file's synthetic convention edges until the next full rebuild. `patchIndex` now re-runs the idempotent synthetic-edge passes; a shared `baseIndexedFile()` keeps the buildIndex / runProbe / patch construction sites from drifting. Regression test added.

**Internal dedup.** Shared tree-sitter node helpers (`node-helpers.ts`), a shared parser factory, and a `MAX_DIR_WALK_DEPTH` constant replace ~20 copied helpers, 13 hand-rolled parser singletons, and a magic number.

## Tests

`npm run build` clean, **326 tests green** (added `tests/init.test.ts` hook-wiring cases + `tests/patch-synthetic-freshness.test.ts`; removed the dead `get-overview.test.ts`).

## Notes
- 2.0.0 is still **unreleased** — `npm publish` + `npm deprecate coldstart-mcp` are a separate post-merge step.
- Capability regression carried over from the two-tool collapse: no transitive multi-hop tracing; `gs` callers are one-hop, file-scoped (chase further hops by `gs`-ing the caller files). Documented in README limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)