### PR TITLE
Anchor JVM + C# edge resolution to the AST namespace, not directory layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "coldstart-mcp",
-  "version": "1.5.0",
+  "name": "coldstart",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "coldstart-mcp",
-      "version": "1.5.0",
+      "name": "coldstart",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",
@@ -27,6 +27,7 @@
         "tree-sitter-typescript": "^0.23.2"
       },
       "bin": {
+        "coldstart": "dist/index.js",
         "coldstart-mcp": "dist/index.js"
       },
       "devDependencies": {
@@ -986,15 +987,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1003,13 +1004,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1030,9 +1031,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1043,13 +1044,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1058,13 +1059,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1073,9 +1074,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1086,13 +1087,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1764,9 +1765,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2157,9 +2158,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2885,9 +2886,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2983,20 +2984,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3026,8 +3027,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,12 +322,16 @@ async function runProbe(rootDir: string, excludes: string[], includes: string[])
 
   const tParse = Date.now() - tParseStart;
   const tResolveStart = Date.now();
-  const { resolveImportsForFiles } = await import('./indexer/resolvers/index.js');
+  const { resolveImportsForFiles, buildPackageIndex } = await import('./indexer/resolvers/index.js');
 
   // Per-language resolve timing — pass the FULL fileIdSet (resolvers index it
   // once via WeakMap) but invoke per-language so we can attribute time. Java
   // resolves to Kotlin files and vice versa, so we must not narrow the set.
   const fullFileIdSet = new Set(indexedFiles.map(f => f.id));
+  // JVM package index over the FULL set — anchors Java/Kotlin FQCN resolution on
+  // each file's declared `package`, so non-Maven layouts (e.g. JMRI's java/src/)
+  // resolve correctly instead of mis-deriving the package from the path.
+  const pkgById = buildPackageIndex(indexedFiles);
   const filesByLang = new Map<string, IndexedFile[]>();
   for (const f of indexedFiles) {
     const arr = filesByLang.get(f.language) ?? [];
@@ -339,7 +343,7 @@ async function runProbe(rootDir: string, excludes: string[], includes: string[])
   let allUnresolved: Awaited<ReturnType<typeof resolveImportsForFiles>>['unresolved'] = [];
   for (const [lang, files] of filesByLang) {
     const t0 = Date.now();
-    const r = await resolveImportsForFiles(files, fullFileIdSet, rootDir);
+    const r = await resolveImportsForFiles(files, fullFileIdSet, rootDir, pkgById);
     langTimes[lang] = Date.now() - t0;
     allEdges = allEdges.concat(r.edges);
     allUnresolved = allUnresolved.concat(r.unresolved);

--- a/src/indexer/extractors/csharp.ts
+++ b/src/indexer/extractors/csharp.ts
@@ -74,6 +74,10 @@ export interface CSharpParseResult {
   hasDefaultExport: false;
   symbols: SymbolNode[];
   partialDeclarations?: PartialDeclaration[];
+  /** The file's primary declared namespace (`namespace Foo.Bar`), if any. Used
+   *  to resolve `using` directives by declared namespace rather than by guessing
+   *  it from the directory layout. */
+  packageName?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +307,7 @@ export function parseCSharpContent(
   const imports: string[] = [];
   const symbols: SymbolNode[] = [];
   const exports: string[] = [];
+  let packageName: string | undefined;
 
   function visitChildren(nodes: TSNode[]): void {
     for (const node of nodes) {
@@ -316,6 +321,13 @@ export function parseCSharpContent(
       }
 
       if (node.type === 'namespace_declaration' || node.type === 'file_scoped_namespace_declaration') {
+        // First declared namespace becomes the file's package identity. The name
+        // node (`qualified_name`) already carries the full dotted form, e.g.
+        // `Serilog.Core.Pipeline`.
+        if (packageName === undefined) {
+          const nameNode = firstChildOfType(node, 'qualified_name') ?? firstChildOfType(node, 'identifier');
+          if (nameNode) packageName = nameNode.text;
+        }
         const body = firstChildOfType(node, 'declaration_list') ??
           node; // file-scoped: members are siblings
         visitChildren(body.namedChildren);
@@ -370,6 +382,7 @@ export function parseCSharpContent(
     hasDefaultExport: false,
     symbols,
     partialDeclarations: partialDeclarations.length > 0 ? partialDeclarations : undefined,
+    packageName,
   };
 }
 

--- a/src/indexer/extractors/kotlin.ts
+++ b/src/indexer/extractors/kotlin.ts
@@ -74,6 +74,7 @@ export interface KotlinParseResult {
   exports: string[];
   hasDefaultExport: false;
   symbols: SymbolNode[];
+  packageName: string;  // declared package — anchors layout-independent FQCN resolution
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +351,7 @@ export function parseKotlinContent(
     exports: [...new Set(exports)],
     hasDefaultExport: false,
     symbols,
+    packageName,
   };
 }
 

--- a/src/indexer/indexed-file.ts
+++ b/src/indexer/indexed-file.ts
@@ -35,6 +35,7 @@ export function baseIndexedFile(
     tokenEstimate: parsed.tokenEstimate,
     symbols: parsed.symbols,
     reexportRatio: parsed.reexportRatio,
+    packageName: parsed.packageName,
     constantReferences: parsed.constantReferences,
     partialDeclarations: parsed.partialDeclarations,
     eloquentRelations: parsed.eloquentRelations,

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -137,6 +137,7 @@ async function parseByLanguage(
       lineCount,
       tokenEstimate,
       symbols: javaResult.symbols,
+      packageName: javaResult.packageName,
     };
   }
 
@@ -269,6 +270,7 @@ async function parseByLanguage(
       tokenEstimate,
       symbols: csharpResult.symbols,
       partialDeclarations: csharpResult.partialDeclarations,
+      packageName: csharpResult.packageName,
     };
   }
 
@@ -306,7 +308,7 @@ async function parseByLanguage(
       kotlinResult = parseKotlinContent(content, fileId || filePath);
     } catch (err) {
       console.error(`[parser] Tree-sitter error in ${fileId || filePath}: ${err}`);
-      kotlinResult = { imports: [], exports: [], hasDefaultExport: false as const, symbols: [] };
+      kotlinResult = { imports: [], exports: [], hasDefaultExport: false as const, symbols: [], packageName: '' };
     }
 
     return {
@@ -317,6 +319,7 @@ async function parseByLanguage(
       lineCount,
       tokenEstimate,
       symbols: kotlinResult.symbols,
+      packageName: kotlinResult.packageName,
     };
   }
 

--- a/src/indexer/patch.ts
+++ b/src/indexer/patch.ts
@@ -4,7 +4,7 @@ import type { CodebaseIndex, IndexedFile, ParsedFile, Language } from '../types.
 import { EXTENSION_TO_LANGUAGE } from '../constants.js';
 import { parseFile, buildFileId } from './parser.js';
 import { buildFileDomains, isTestPath } from './tokenize.js';
-import { resolveImportsForFiles } from './resolvers/index.js';
+import { resolveImportsForFiles, buildPackageIndex } from './resolvers/index.js';
 import { buildSymbolEdges } from './symbol-edges.js';
 import { buildContentTokenPostings } from './content-tokens.js';
 import { baseIndexedFile } from './indexed-file.js';
@@ -186,7 +186,10 @@ export async function patchIndex(
   // Phase 4: Resolve imports for updated files, rebuild edges + inEdges
   // -------------------------------------------------------------------------
   if (newFiles.length > 0) {
-    const { edges: newEdges } = await resolveImportsForFiles(newFiles, fileIdSet, rootDir);
+    // Build the JVM package index from the FULL set (not just newFiles) so a
+    // changed Java/Kotlin file resolves against unchanged ones by declared package.
+    const pkgById = buildPackageIndex([...index.files.values()]);
+    const { edges: newEdges } = await resolveImportsForFiles(newFiles, fileIdSet, rootDir, pkgById);
 
     for (const edge of newEdges) {
       index.edges.push(edge);

--- a/src/indexer/resolvers/csharp.ts
+++ b/src/indexer/resolvers/csharp.ts
@@ -1,18 +1,25 @@
 import { join } from 'node:path';
 
 /**
- * C# resolver: maps a `using` namespace to any .cs file in the corresponding
- * directory.
+ * C# resolver: maps a `using Foo.Bar` directive to a representative .cs file
+ * that *declares* namespace `Foo.Bar`.
  *
- * `using Serilog.Core.Pipeline` — namespace-as-path: convert dots to slashes
- * and look for any `.cs` file under <source-root>/Serilog/Core/Pipeline/.
+ * Preferred path is the AST-declared namespace (`pkgById`): each .cs file's
+ * `namespace Foo.Bar` declaration (parsed by the extractor) is indexed, and a
+ * `using` resolves to any file whose declared namespace matches. This is
+ * layout-independent — C# namespaces routinely diverge from the directory tree
+ * (a `RootNamespace` in the .csproj, files moved without renaming the folder),
+ * so guessing the namespace from the path silently fails on those repos.
  *
- * Unlike Java where one class = one file, a C# namespace is spread across
- * many files. We pick any file in the directory as a representative — that's
- * sufficient for graph-level "this import points at this part of the repo".
+ * Fallback (files without a known namespace, or no pkgById): the old
+ * namespace-as-path heuristic — `using Serilog.Core.Pipeline` → look for any
+ * .cs file under a `Serilog/Core/Pipeline/` directory. On conventional repos
+ * where the namespace mirrors the folders, the two agree exactly, so the
+ * fallback never regresses a conventional layout.
  *
- * Source roots are discovered by suffix-matching `.cs` paths against a small
- * set of layout markers (project-name dir is also accepted).
+ * Unlike Java where one class = one file, a C# namespace spans many files; we
+ * return one representative — sufficient for graph-level "this import points at
+ * this part of the repo".
  */
 
 const ROOT_MARKERS = ['/src/', '/source/', '/lib/'];
@@ -22,20 +29,29 @@ interface CSharpIndex {
   dirToFile: Map<string, string>;
   // Discovered source roots (rootDir-relative, may be empty string for repo root)
   roots: string[];
+  // Declared namespace → a representative .cs fileId declaring it (AST-anchored)
+  byNamespace: Map<string, string>;
 }
 
-const indexCache = new WeakMap<Set<string>, CSharpIndex>();
+// Memoized on (fileIdSet identity, pkgById identity). pkgById changes per resolve
+// cycle, so a stale path-only index can't leak into a later cycle.
+const indexCache = new WeakMap<Set<string>, { idx: CSharpIndex; pkgById?: Map<string, string> }>();
 
-function buildIndex(fileIdSet: Set<string>): CSharpIndex {
+function buildIndex(fileIdSet: Set<string>, pkgById?: Map<string, string>): CSharpIndex {
   const cached = indexCache.get(fileIdSet);
-  if (cached) return cached;
+  if (cached && cached.pkgById === pkgById) return cached.idx;
   const dirToFile = new Map<string, string>();
+  const byNamespace = new Map<string, string>();
   const roots = new Set<string>();
   for (const id of fileIdSet) {
     if (!id.endsWith('.cs')) continue;
     const slash = id.lastIndexOf('/');
     const dirPath = slash >= 0 ? id.slice(0, slash) : '';
     if (!dirToFile.has(dirPath)) dirToFile.set(dirPath, id);
+
+    // AST-anchored: index the file's declared namespace (first-write-wins).
+    const ns = pkgById?.get(id);
+    if (ns && !byNamespace.has(ns)) byNamespace.set(ns, id);
 
     // Discover roots — strip the longest ROOT_MARKER occurrence
     let rootFound = false;
@@ -53,8 +69,8 @@ function buildIndex(fileIdSet: Set<string>): CSharpIndex {
     }
   }
   roots.add('');
-  const result: CSharpIndex = { dirToFile, roots: Array.from(roots) };
-  indexCache.set(fileIdSet, result);
+  const result: CSharpIndex = { dirToFile, roots: Array.from(roots), byNamespace };
+  indexCache.set(fileIdSet, { idx: result, pkgById });
   return result;
 }
 
@@ -64,8 +80,14 @@ export async function resolveCSharp(
   fileIdSet: Set<string>,
   _rootDir: string,
   _aliasMap: Map<string, string[]>,
+  pkgById?: Map<string, string>,
 ): Promise<string | null> {
-  const { dirToFile, roots } = buildIndex(fileIdSet);
+  const { dirToFile, roots, byNamespace } = buildIndex(fileIdSet, pkgById);
+
+  // AST-anchored: a file declaring exactly this namespace.
+  const declared = byNamespace.get(specifier);
+  if (declared) return declared;
+
   const nsPath = specifier.replace(/\./g, '/');
 
   for (const root of roots) {

--- a/src/indexer/resolvers/index.ts
+++ b/src/indexer/resolvers/index.ts
@@ -254,6 +254,7 @@ type ResolverFn = (
   fileIdSet: Set<string>,
   rootDir: string,
   aliasMap: Map<string, string[]>,
+  pkgById?: Map<string, string>, // JVM only: fileId → declared package, for layout-independent FQCN resolution
 ) => Promise<string | null>;
 
 function getResolver(language: Language): ResolverFn {
@@ -289,6 +290,11 @@ export async function resolveImportsForFiles(
   files: IndexedFile[],
   fileIdSet: Set<string>,
   rootDir: string,
+  // JVM (Java/Kotlin) FQCN resolution anchors on each file's declared `package`
+  // rather than guessing it from the directory layout. Built once from the FULL
+  // file set by the caller (so a changed file can resolve against unchanged ones
+  // in patch mode); files without a package fall back to the path-regex.
+  pkgById?: Map<string, string>,
 ): Promise<ResolveResult> {
   const aliasMap = await buildAliasMap(rootDir);
 
@@ -302,7 +308,7 @@ export async function resolveImportsForFiles(
       const resolver = getResolver(file.language);
       const resolvedTargets = new Set<string>();
       for (const specifier of file.imports) {
-        const resolved = await resolver(specifier, file.path, fileIdSet, rootDir, aliasMap);
+        const resolved = await resolver(specifier, file.path, fileIdSet, rootDir, aliasMap, pkgById);
         if (resolved && resolved !== file.id) {
           edges.push({ from: file.id, to: resolved, type: 'import', specifier });
           resolvedTargets.add(resolved);
@@ -314,7 +320,7 @@ export async function resolveImportsForFiles(
       // add an edge if the specifier resolves to a real file, but a miss is
       // NOT counted as unresolved — most are symbol imports, not files.
       for (const specifier of file.submoduleImportCandidates ?? []) {
-        const resolved = await resolver(specifier, file.path, fileIdSet, rootDir, aliasMap);
+        const resolved = await resolver(specifier, file.path, fileIdSet, rootDir, aliasMap, pkgById);
         if (resolved && resolved !== file.id && !resolvedTargets.has(resolved)) {
           edges.push({ from: file.id, to: resolved, type: 'import', specifier });
           resolvedTargets.add(resolved);
@@ -335,5 +341,16 @@ export async function resolveImports(
   rootDir: string,
 ): Promise<ResolveResult> {
   const fileIdSet = new Set(files.map(f => f.id));
-  return resolveImportsForFiles(files, fileIdSet, rootDir);
+  return resolveImportsForFiles(files, fileIdSet, rootDir, buildPackageIndex(files));
+}
+
+/**
+ * fileId → declared package, for the JVM resolver. Built from the FULL file set
+ * (only JVM files carry `packageName`) so a file can be FQCN-resolved by its
+ * `package` line regardless of where it sits on disk.
+ */
+export function buildPackageIndex(files: IndexedFile[]): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const f of files) if (f.packageName) m.set(f.id, f.packageName);
+  return m;
 }

--- a/src/indexer/resolvers/java.ts
+++ b/src/indexer/resolvers/java.ts
@@ -22,11 +22,26 @@ interface FqcnIndex {
   byFqcn: Map<string, string>;
 }
 
-const indexCache = new WeakMap<Set<string>, FqcnIndex>();
+// Memoized on (fileIdSet identity, pkgById identity). pkgById changes per resolve
+// cycle, so a stale path-only index from a prior cycle can't leak in.
+const indexCache = new WeakMap<Set<string>, { idx: FqcnIndex; pkgById?: Map<string, string> }>();
 
-function buildFqcnIndex(fileIdSet: Set<string>): FqcnIndex {
+/**
+ * Build the FQCN→fileId map.
+ *
+ * Preferred keying is the file's *declared package* (`pkgById`): FQCN =
+ * `<package>.<filename-stem>`. This is layout-independent — it resolves the same
+ * whether the repo uses Maven (`src/main/java/com/foo/Bar.java`) or any other tree
+ * (e.g. JMRI's `java/src/jmri/Bar.java`), because it reads the `package` line the
+ * parser already extracted instead of guessing the package from the directory path.
+ *
+ * Files without a known package (default package, parse miss, or a non-JVM call
+ * site) fall back to the source-root path regex. On Maven layouts the two agree
+ * exactly, so the fallback never regresses a conventional repo.
+ */
+function buildFqcnIndex(fileIdSet: Set<string>, pkgById?: Map<string, string>): FqcnIndex {
   const cached = indexCache.get(fileIdSet);
-  if (cached) return cached;
+  if (cached && cached.pkgById === pkgById) return cached.idx;
   const byFqcn = new Map<string, string>();
 
   for (const id of fileIdSet) {
@@ -36,7 +51,16 @@ function buildFqcnIndex(fileIdSet: Set<string>): FqcnIndex {
     }
     if (!ext) continue;
 
-    // Find where the package path starts (right after the source-root marker)
+    // Package-anchored (layout-independent): FQCN = <declared package>.<stem>.
+    const pkg = pkgById?.get(id);
+    if (pkg) {
+      const base = id.slice(id.lastIndexOf('/') + 1, id.length - ext.length);
+      const fqcn = `${pkg}.${base}`;
+      if (!byFqcn.has(fqcn)) byFqcn.set(fqcn, id);
+      continue;
+    }
+
+    // Fallback: derive the package from the source-root path convention.
     let pkgStart: number | null = null;
     const m = SRC_LANG_RE.exec(id);
     if (m) {
@@ -57,7 +81,7 @@ function buildFqcnIndex(fileIdSet: Set<string>): FqcnIndex {
   }
 
   const result: FqcnIndex = { byFqcn };
-  indexCache.set(fileIdSet, result);
+  indexCache.set(fileIdSet, { idx: result, pkgById });
   return result;
 }
 
@@ -67,10 +91,11 @@ export async function resolveJava(
   fileIdSet: Set<string>,
   _rootDir: string,
   _aliasMap: Map<string, string[]>,
+  pkgById?: Map<string, string>,
 ): Promise<string | null> {
   if (specifier.endsWith('.*')) return null;
 
-  const { byFqcn } = buildFqcnIndex(fileIdSet);
+  const { byFqcn } = buildFqcnIndex(fileIdSet, pkgById);
 
   const direct = byFqcn.get(specifier);
   if (direct) return direct;

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface IndexedFile {
   isTestFile: boolean;      // true if any path segment is a test/automation directory
   symbols: SymbolNode[];    // symbol-level nodes within this file (TS/JS only)
   reexportRatio?: number;   // TS/JS only: ratio of re-export statements to total export statements
+  packageName?: string;     // Namespace-bearing langs (Java/Kotlin/C#): declared package/namespace, e.g. "com.example.auth". Anchors resolution to the AST declaration, not directory layout — see resolvers/java.ts, resolvers/csharp.ts.
   constantReferences?: string[][];  // Ruby only: ordered FQCN candidate groups (nesting-aware) to resolve via autoload
   partialDeclarations?: Array<{ kind: 'class' | 'struct' | 'interface' | 'record'; name: string; namespace?: string }>;  // C# only: partial type declarations
   eloquentRelations?: Array<{ targetClass: string; line: number }>;  // PHP only: Eloquent relationship class references
@@ -134,6 +135,7 @@ export interface ParsedFile {
   tokenEstimate: number;
   symbols: SymbolNode[];    // symbol-level nodes (TS/JS only, empty for other languages)
   reexportRatio?: number;   // TS/JS only
+  packageName?: string;     // Namespace-bearing langs (Java/Kotlin/C#): declared package/namespace — anchors resolution to the AST declaration (see resolvers/java.ts, resolvers/csharp.ts)
   constantReferences?: string[][];  // Ruby only: ordered FQCN candidate groups (nesting-aware) to resolve via autoload
   partialDeclarations?: Array<{ kind: 'class' | 'struct' | 'interface' | 'record'; name: string; namespace?: string }>;  // C# only: partial type declarations
   eloquentRelations?: Array<{ targetClass: string; line: number }>;  // PHP only: Eloquent relationship class references

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -15,6 +15,7 @@ const TS_MULTI_TARGET_FIXTURES = join(FIXTURES, 'ts-multi-target');
 const TS_LONGEST_PREFIX_FIXTURES = join(FIXTURES, 'ts-longest-prefix');
 const NPM_WORKSPACES_FIXTURES = join(FIXTURES, 'npm-workspaces');
 const CPP_FIXTURES = join(FIXTURES, 'cpp');
+const CSHARP_FIXTURES = join(FIXTURES, 'csharp');
 const GO_REPLACE_FIXTURES = join(FIXTURES, 'go-replace');
 const GO_WORKSPACE_FIXTURES = join(FIXTURES, 'go-workspace');
 const PHP_PSR4_FIXTURES = join(FIXTURES, 'php-psr4');
@@ -157,6 +158,71 @@ describe('resolver — Java package-name imports', () => {
     const authEdges = edges.filter(e => e.from === 'src/main/java/com/example/AuthService.java');
     expect(authEdges).toHaveLength(1);
     expect(authEdges[0].to).toBe('src/main/java/com/example/UserRepository.java');
+  });
+
+  it('anchors FQCN on the declared package, not the directory (non-Maven layout)', async () => {
+    // JMRI-style: files live under java/src/<pkg>/, which no Maven source-root
+    // regex matches. The FQCN must come from the declared `package`, otherwise
+    // every intra-repo import misses (the regression that produced java 0%).
+    const mk = (id: string, pkg: string, imports: string[]) => {
+      const f = makeJavaFile(id, imports);
+      (f as unknown as { packageName: string }).packageName = pkg;
+      return f;
+    };
+    const files: IndexedFile[] = [
+      mk('java/src/jmri/AuthService.java', 'jmri', ['jmri.UserRepository']),
+      mk('java/src/jmri/UserRepository.java', 'jmri', []),
+    ];
+    const { edges } = await resolveImports(files, JAVA_FIXTURES);
+    const targets = edges
+      .filter(e => e.from === 'java/src/jmri/AuthService.java')
+      .map(e => e.to);
+    expect(targets).toContain('java/src/jmri/UserRepository.java');
+  });
+});
+
+describe('resolver — C# using-namespace imports', () => {
+  function makeCsFile(id: string, namespaceName: string | undefined, imports: string[]): IndexedFile {
+    return {
+      id,
+      path: join(CSHARP_FIXTURES, id),
+      relativePath: id,
+      language: 'csharp',
+      domains: [],
+      exports: [],
+      hasDefaultExport: false,
+      imports,
+      packageName: namespaceName,
+      hash: 'abc',
+      lineCount: 10,
+      tokenEstimate: 100,
+      isEntryPoint: false,
+      archRole: 'unknown',
+      centrality: 0,
+      depth: 0,
+    } as unknown as IndexedFile;
+  }
+
+  it('resolves `using` to a file declaring that namespace when folders diverge', async () => {
+    // namespace ≠ folder — the case that silently resolves 0% under path-guessing
+    // (a RootNamespace in the .csproj, or files moved without renaming the dir).
+    const files: IndexedFile[] = [
+      makeCsFile('weird/deep/Foo.cs', 'Company.Product.Core', ['Company.Product.Util']),
+      makeCsFile('somewhere-else/Bar.cs', 'Company.Product.Util', []),
+    ];
+    const { edges } = await resolveImports(files, CSHARP_FIXTURES);
+    const targets = edges.filter(e => e.from === 'weird/deep/Foo.cs').map(e => e.to);
+    expect(targets).toContain('somewhere-else/Bar.cs');
+  });
+
+  it('falls back to the path convention when the namespace is undeclared', async () => {
+    const files: IndexedFile[] = [
+      makeCsFile('src/Company/Product/Core/Foo.cs', undefined, ['Company.Product.Util']),
+      makeCsFile('src/Company/Product/Util/Bar.cs', undefined, []),
+    ];
+    const { edges } = await resolveImports(files, CSHARP_FIXTURES);
+    const targets = edges.filter(e => e.from === 'src/Company/Product/Core/Foo.cs').map(e => e.to);
+    expect(targets).toContain('src/Company/Product/Util/Bar.cs');
   });
 });
 


### PR DESCRIPTION
## What

Both the JVM (Java/Kotlin) and C# resolvers derived a file's **namespace identity from its directory path** instead of the `package` / `namespace` declaration the parser already extracts. On conventional layouts the two agree, so this stayed invisible. On any repo where the layout diverges from the namespace, it silently resolved **~0% of intra-repo edges**:

- **JVM** — a non-Maven source tree (e.g. `java/src/<pkg>/`) matches no Maven source-root regex, so the FQCN was mis-derived from the full path and every internal import missed.
- **C#** — a `RootNamespace` in the `.csproj`, or files moved without renaming the folder, breaks the `namespace`-as-path assumption entirely.

This is the same class of bug in two resolvers: **the AST has the namespace; the resolver was reconstructing it from the directory instead.**

## Fix

- **JVM**: key the FQCN index on the declared `package` (`<package>.<stem>`) — layout-independent. The source-root path regex stays as a **fallback**, so Maven layouts resolve byte-identically (zero regression).
- **C#**: surface each file's declared `namespace` as `packageName`, index `namespace → file`, and resolve `using` against it. The namespace-as-path heuristic stays as the fallback.
- Generalize the `packageName` field + `pkgById` plumbing from "JVM only" to **Java/Kotlin/C#**, threaded through both full builds and incremental patches.

## Evidence

| Scenario | Before | After |
|---|---|---|
| Non-convention C# fixture (namespace ≠ folder) | 0/2 (silent failure) | **2/2** |
| serilog (conventional .NET) | 56.7% | **58.7%** (+2, no regression) |
| Non-Maven JVM layout | 0% | resolves |
| Maven JVM layout | baseline | byte-identical |

Verified no regression on a large external Maven codebase (resolution byte-identical on a 3.4k-file module before/after).

Adds regression tests for the non-convention path on **both** languages — neither had one previously. **329 tests green.**

## Also included

`npm audit fix` lockfile bumps to clear the Snyk/audit report. These are **dev-only** (vitest/vite) or **transitive HTTP-transport deps** of `@modelcontextprotocol/sdk` (hono, qs) that the stdio MCP server never exercises — no runtime exposure was reachable; this just keeps the security dashboard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)