### PR TITLE
chore(release): finalize 2.0.0 changelog + add PR test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Runs on every PR and on pushes to main. Make the "test" check required in
-# branch protection so a PR can only merge when typecheck + tests are green.
+# branch protection so a PR can only merge when build + tests are green.
 on:
   pull_request:
   push:
@@ -23,8 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Typecheck
-        run: npx tsc --noEmit
+      # `npm run build` (tsc --noEmit false) both type-checks AND emits dist/,
+      # which some tests need at runtime (e.g. the kb recall hook spawns
+      # `node dist/index.js kb search`). It exits non-zero on type errors, so
+      # this doubles as the typecheck gate.
+      - name: Build
+        run: npm run build
 
       - name: Test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+# Runs on every PR and on pushes to main. Make the "test" check required in
+# branch protection so a PR can only merge when typecheck + tests are green.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,10 +27,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify package.json version matches the release tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "release tag: $TAG   package.json: $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag ($TAG) does not match package.json version ($PKG). Bump package.json or fix the tag."
+            exit 1
+          fi
+
       - name: Build project
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Publish package
-        run: npm publish --provenance
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,23 +27,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify package.json version matches the release tag
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(node -p "require('./package.json').version")"
-          echo "release tag: $TAG   package.json: $PKG"
-          if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Release tag ($TAG) does not match package.json version ($PKG). Bump package.json or fix the tag."
-            exit 1
-          fi
-
       - name: Build project
         run: npm run build
 
-      - name: Run tests
-        run: npm test
-
       - name: Publish package
-        run: npm publish --provenance --access public
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - Unreleased
+## [2.0.0] - 2026-07-08
 
 Major release. The package is renamed, the CLI is now the primary surface, and the
 process model is rebuilt around a single background keeper with stateless readers.
@@ -35,12 +35,12 @@ process model is rebuilt around a single background keeper with stateless reader
 - **`init` rewritten around a single `coldstart.md`, multi-client.** `coldstart init`
   asks two things — experience (`cli`/`mcp`) and client (`claude`/`cursor`/`codex`/
   `other`, never auto-detected) — and writes one `coldstart.md` at the repo root
-  carrying all agent guidance. Claude Code gets `@coldstart.md` wired into `CLAUDE.md`
-  plus the find/gs hooks in `.claude/settings.json`; Codex gets an `AGENTS.md` section
-  plus the same hooks in `.codex/hooks.json`; Cursor gets `.cursor/rules/coldstart.mdc`
-  (no hooks — its after-tool hooks are notification-only); other clients get
-  `coldstart.md` + printed directions. All writers merge idempotently. `init` also
-  warms the index in the background so the first lookup is instant.
+  carrying all agent guidance. **Claude Code, Codex, and Cursor are all first-class**
+  — each gets platform-specific find/gs navigation hooks plus notebook recall/capture
+  hooks: Claude via `.claude/settings.json`, Codex via `.codex/hooks.json` (with an
+  `AGENTS.md` section), Cursor via `.cursor/hooks.json` (with a `.cursor/rules/coldstart.mdc`
+  rule). Other clients get `coldstart.md` + printed directions. All writers merge
+  idempotently. `init` also warms the index in the background so the first lookup is instant.
 - **Cache format v18 — consumer-scoped, gzipped, generational.** The single giant
   JSON blob is replaced by gzipped segments split by consumer (find / gs / keeper)
   over an interned file table, written in atomic **generations** (`meta.json` names
@@ -81,21 +81,26 @@ process model is rebuilt around a single background keeper with stateless reader
   base under `.coldstart/notebook/` — append-only `.raw` log as source of truth,
   derived Markdown notes, anchor-freshness stamps from the index (a keeper-derived
   `kb-notes.json` sidecar; `kb search` never loads the code index), two-phase
-  `kb write` (candidates → `--into <id>` or `--new`), plus opt-in capture/recall
-  hooks (`hooks/kb-elicit.mjs`, `hooks/kb-recall.mjs`). Not wired by `init` yet.
-  Verbs: `search` / `write` / `status` / `lint` / `render` / `init` / `migrate`.
+  `kb write` (candidates → `--into <id>` or `--new`), plus capture/recall hooks
+  wired by `init` for Claude Code, Codex, and Cursor. The read/write surface is also
+  exposed as MCP tools (`kb_search` / `kb_lookup` / `kb_write` / `kb_status`) for
+  no-shell clients; `kb commit` stays CLI/human-only. Verbs: `search` / `lookup` /
+  `write` / `commit` / `status` / `lint` / `render` / `view` / `init` / `migrate`
+  (`kb view` opens a single-file HTML browser of the notebook).
 - **`gs` returns the enclosing method body on a `--match`/`--symbol` miss** instead
   of an empty result.
-- **Search hooks wired by `init` (Claude Code + Codex).** `coldstart init` registers two
-- **Search hooks wired by `init` (Claude Code).** `coldstart init` now registers two
-  hooks in `.claude/settings.json`, pointing at the version-pinned copies under
-  `~/.coldstart/versions/<v>/hooks/`: a PostToolUse nudge that flags search behaviour
-  going wrong, and a PreToolUse guard that denies an exact `find` re-run. Merged
-  idempotently — every other setting and any foreign hooks are preserved, a malformed
-  `settings.json` is left untouched. The handlers are surface-agnostic: a shared
-  `normalizeColdstartCall` rewrites an MCP `find`/`gs` call into the equivalent CLI
-  command string, so the detectors run unchanged whether the agent reached coldstart
-  via the CLI or the MCP tools. The hooks ship in the package (`hooks/`).
+- **Navigation + notebook hooks wired by `init` (Claude Code, Codex, Cursor).**
+  A PostToolUse/`postToolUse` nudge that flags search behaviour going wrong, a
+  PreToolUse/`preToolUse` guard that denies an exact `find` re-run, plus notebook
+  capture (session/subagent end) and recall (prompt time). Merged idempotently —
+  every other setting and any foreign hooks are preserved; a malformed config is
+  left untouched. The handlers are surface-agnostic: a shared `normalizeColdstartCall`
+  rewrites an MCP `find`/`gs` call into the equivalent CLI command string, so the
+  detectors run unchanged whether the agent reached coldstart via the CLI or the MCP
+  tools. Claude/Codex/Cursor share one protocol-neutral detector core, differing only
+  in input adaptation, transcript walk, and output envelope. Hooks point at the running
+  install (`installRoot()`) — no version-pinned copy — so `npm update` is picked up
+  automatically and `npm uninstall` disables them. The hooks ship in the package (`hooks/`).
 
 ### Fixed
 - **Keeper could outlive a deleted/taken-over lockfile.** `fs.watch` can miss the


### PR DESCRIPTION
Release prep for **`coldstart@2.0.0`** (renamed from `coldstart-mcp`).

### `CHANGELOG.md`
Corrects the `[2.0.0]` section to the actual shipped state:
- Claude Code, Codex, and Cursor are all first-class (nav + notebook hooks) — drops the stale "Cursor: no hooks" and "notebook not wired by init yet" lines.
- kb verb list adds `lookup` / `commit` / `view` and mentions the `kb_*` MCP tools.
- Hooks point at the running install (`installRoot()`), not a version-pinned copy.
- Sets the release date.

### `.github/workflows/ci.yml` (new)
Runs `tsc --noEmit` + the full test suite on every `pull_request` and on push to `main`. This is the **merge gate** — make the `test` check required in branch protection so a red PR can't land.

The publish workflow is unchanged (still `release: created` → build → publish). Tests gate at PR time now, so the release job stays lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)