### PR TITLE
fix(ci): add --access public to provenance publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,6 +31,9 @@ jobs:
         run: npm run build
 
       - name: Publish package
-        run: npm publish --provenance
+        # --access public is REQUIRED alongside --provenance for a new package:
+        # npm refuses to generate provenance for a package it would otherwise
+        # create as private/restricted.
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The first publish of `coldstart@2.0.0` failed with:

```
npm error code EUSAGE
Can't generate provenance for new or private package, you must set \`access\` to public.
```

`npm publish --provenance` on a brand-new package requires `--access public` explicitly (unscoped packages are public by default, but provenance won't assume it). This adds the flag.

**Not a token problem** — the `NPM_TOKEN` authenticated and built the tarball fine; it only tripped on this flag.

### After merge — recreate the tag so the fixed workflow runs
The `release: created` job reads the workflow file from the tag's commit, so `v2.0.0` must be recreated on the fixed `main`:
```
gh release delete v2.0.0 --cleanup-tag --yes
git fetch && gh release create v2.0.0 --target main --title "…" --notes "…"
```
`coldstart@2.0.0` was never published (the publish call failed), so reusing the version is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)