### PR TITLE
chore(release): scope package as @cstart/coldstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Major release. The package is renamed, the CLI is now the primary surface, and t
 process model is rebuilt around a single background keeper with stateless readers.
 
 ### Changed (BREAKING)
-- **Package renamed `coldstart-mcp` → `coldstart`.** The CLI is the primary surface
-  now; MCP is the no-shell fallback. `coldstart-mcp` on npm is deprecated and
-  redirects here. The `coldstart-mcp` binary name is retained as an alias, so
-  existing MCP configs keep working. Migrate with
-  `npm uninstall -g coldstart-mcp && npm install -g coldstart --legacy-peer-deps && coldstart init`.
+- **Package renamed `coldstart-mcp` → `@cstart/coldstart`.** The CLI is the primary
+  surface now; MCP is the no-shell fallback. `coldstart-mcp` on npm is deprecated and
+  points here. The `coldstart` and `coldstart-mcp` binary names are both retained, so
+  the CLI command is still `coldstart` and existing MCP configs keep working. Migrate with
+  `npm uninstall -g coldstart-mcp && npm install -g @cstart/coldstart --legacy-peer-deps && coldstart init`.
 - **Tools/commands renamed to `find` + `gs`** (matching the CLI verbs):
   `get-overview` → `find`, `get-structure` → `gs`. Exposed identically as CLI
   commands (`coldstart find` / `coldstart gs`, the primary path) and as MCP tools

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The notebook is the same philosophy applied to memory: coldstart still computes 
 Requires Node.js 18+.
 
 ```bash
-npm install -g coldstart --legacy-peer-deps
+npm install -g @cstart/coldstart --legacy-peer-deps
 cd your-project
 coldstart init      # navigation: coldstart.md + client wiring + background index warm-up
 coldstart kb init   # notebook: skeleton + capture/recall hooks (optional but recommended)
@@ -133,7 +133,7 @@ coldstart kb init   # notebook: skeleton + capture/recall hooks (optional but re
 ### Upgrading
 
 ```bash
-npm install -g coldstart@latest --legacy-peer-deps
+npm install -g @cstart/coldstart@latest --legacy-peer-deps
 coldstart init   # re-run in each project to refresh coldstart.md
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "coldstart",
+  "name": "@cstart/coldstart",
   "version": "2.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Fast static codebase navigation for AI agents — `find` ranks relevant files, `gs` shows a file's structure and callers. CLI-first; also a no-shell MCP server.",
   "type": "module",
   "bin": {

--- a/src/init.ts
+++ b/src/init.ts
@@ -75,11 +75,11 @@ export function coldstartMd(mode: 'cli' | 'mcp'): string {
  * or from source (`src/init.ts`); no HOME lookup, no copy.
  *
  * We point hooks and MCP config straight at this live install. `npx` is no
- * longer a supported flow (install is `npm i -g coldstart` then `coldstart
+ * longer a supported flow (install is `npm i -g @cstart/coldstart` then `coldstart
  * init`), so the running path is always stable — which makes the old
  * version-pinned copy into `~/.coldstart/versions/<v>/` pure liability:
- *   - `npm update -g coldstart` is now picked up automatically (no stale snapshot).
- *   - `npm uninstall -g coldstart` actually disables the wired hooks, instead of
+ *   - `npm update -g @cstart/coldstart` is now picked up automatically (no stale snapshot).
+ *   - `npm uninstall -g @cstart/coldstart` actually disables the wired hooks, instead of
  *     a hidden copy that keeps executing on every tool call after removal.
  */
 function installRoot(): string {
@@ -748,7 +748,7 @@ function setupOther(cwd: string, exp: Experience): void {
     }
   } else {
     out('  2. Make sure the `coldstart` CLI is on PATH so the agent can run');
-    out('     `coldstart find` / `coldstart gs` (npm i -g coldstart).');
+    out('     `coldstart find` / `coldstart gs` (npm i -g @cstart/coldstart).');
   }
   out('');
   out('  Note: behavioral hooks need a supported host. coldstart ships separate');

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -94,7 +94,7 @@ export async function migrateLegacyMcpConfig(rootDir: string): Promise<void> {
     // Resolve a stable install
     const newEntry = await buildFastEntry(rootDir);
     if (!newEntry) {
-      process.stderr.write('[coldstart] Detected legacy npx-based .mcp.json but could not resolve the running install path. Reinstall (`npm i -g coldstart`) and run `coldstart init` to migrate.\n');
+      process.stderr.write('[coldstart] Detected legacy npx-based .mcp.json but could not resolve the running install path. Reinstall (`npm i -g @cstart/coldstart`) and run `coldstart init` to migrate.\n');
       continue;
     }
 


### PR DESCRIPTION
npm blocks the unscoped name `coldstart` (too similar to the existing `cold-start`). Publishing under the **`@cstart`** org scope fixes it — scoped packages skip npm's similarity check.

**The CLI command stays `coldstart`** (the `bin` names are unchanged); only the install/publish name changes.

### Changes
- `package.json`: `name` → `@cstart/coldstart`; add `publishConfig.access: public` (scoped packages default to restricted — this makes every publish public without depending on a CLI flag).
- `README.md` / `CHANGELOG.md`: install + migrate strings → `@cstart/coldstart`.
- `src/init.ts` / `src/migrate.ts`: user-facing install hints → `@cstart/coldstart`.

### Verified
- `npm run build` clean, **522 tests pass**.
- `npm publish --dry-run` → `name: @cstart/coldstart`, `public access`, tarball `cstart-coldstart-2.0.0.tgz`.

### Before publishing (npm side)
1. Create the `@cstart` org on npmjs.com.
2. Ensure the `NPM_TOKEN` granular token includes the new org (regenerate with all-orgs/all-packages if needed) and update the secret.
3. Delete + recreate the `v2.0.0` release/tag on the updated `main` so the publish runs from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)