### PR TITLE
Add GitHub Pages marketing site + docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy site to Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**', '.github/workflows/pages.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,4 @@ Key files:
 - `src/keeper-state.ts` — keeper-state.json + repair.jsonl (observability beside the cache)
 - `src/kb/` — notebook: store / raw-log / fold / render / search / write / freshness / notes-index / lint / cli
 - `src/types.ts`, `src/constants.ts`
+- `site/` — the GitHub Pages marketing site (`index.html` + `docs.html`, shared `styles.css`, `llms.txt`), deployed by `.github/workflows/pages.yml` on push to `main`. **When a change is meaningful to an outside user** (a command's behavior/flags change, a new `kb` subcommand ships, the notebook's guarantees change, the npm package name changes) — update `site/docs.html` (and `site/index.html` if it affects the pitch). Routine internal refactors don't need a site update.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # coldstart
 
+**[Website](https://akashgoenka.github.io/coldstart/) · [Docs](https://akashgoenka.github.io/coldstart/docs.html) · [npm](https://www.npmjs.com/package/@cstart/coldstart)**
+
 Codebase navigation **and a codebase notebook** for AI agents.
 
 Two layers, one tool:

--- a/site/docs.html
+++ b/site/docs.html
@@ -1,0 +1,405 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>coldstart docs — commands, notebook, architecture</title>
+<meta name="description" content="coldstart command reference: find, gs, the kb notebook family, sharing a notebook with a team, and how the index stays fresh." />
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body class="docs-page">
+
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="index.html"><span class="dot"></span>coldstart <span class="tag">docs</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="index.html#notebook">Notebook</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+
+<div class="docs">
+  <!-- SIDEBAR -->
+  <aside class="side">
+    <div class="side-group">
+      <div class="gh">Getting started</div>
+      <a href="#overview">Overview</a>
+      <a href="#install">Install &amp; setup</a>
+      <a href="#flow">The intended flow</a>
+    </div>
+    <div class="side-group">
+      <div class="gh">Navigation</div>
+      <a href="#find"><code>find</code></a>
+      <a href="#gs"><code>gs</code></a>
+    </div>
+    <div class="side-group">
+      <div class="gh">Notebook</div>
+      <a href="#notebook">The notebook, in depth</a>
+      <a href="#kb-search"><code>kb search</code></a>
+      <a href="#kb-lookup"><code>kb lookup</code></a>
+      <a href="#kb-write"><code>kb write</code></a>
+      <a href="#kb-commit"><code>kb commit</code></a>
+      <a href="#kb-view"><code>kb view</code></a>
+      <a href="#kb-maint"><code>kb status / lint / render</code></a>
+      <a href="#sharing">Sharing with a team</a>
+    </div>
+    <div class="side-group">
+      <div class="gh">Under the hood</div>
+      <a href="#freshness">How the index stays fresh</a>
+      <a href="#lifecycle">Lifecycle commands</a>
+      <a href="#mcp">MCP tools</a>
+      <a href="#semantics">Bring your own semantics</a>
+      <a href="#languages">Supported languages</a>
+    </div>
+  </aside>
+
+  <!-- CONTENT -->
+  <main class="content">
+    <section id="overview" class="doc-sec">
+      <div class="kicker">Documentation</div>
+      <h1>coldstart, command by command.</h1>
+      <p class="lead-p">coldstart is one binary with two front doors — a <b>CLI</b> (the fast path for any shell-capable agent) and an <b>MCP server</b> (for no-shell clients), with byte-identical output. This page covers the stable core surface; for exhaustive flags, versioned changes, and internals, see the <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">README and docs on GitHub</a> — the source of truth.</p>
+      <div class="callout"><span class="ct">The shape of it</span>Two operations answer navigation — <code>find</code> (which files?) and <code>gs</code> (what is this file, who uses it?) — and the <code>kb</code> family is the notebook: durable, agent-written notes kept honest by the index. That's the whole surface.</div>
+    </section>
+
+    <!-- GETTING STARTED -->
+    <section id="install" class="doc-sec">
+      <h2>Install &amp; setup</h2>
+      <p>Requires Node.js 18+. Install globally, then run <code>init</code> once per project.</p>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">your-project</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">npm install -g @cstart/coldstart</span> <span class="c-flag">--legacy-peer-deps</span></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">cd</span> your-project</span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span>   <span class="c-dim"># coldstart.md + client wiring + notebook + hooks + warm-up</span></span>
+        </div>
+      </div>
+      <div class="callout"><span class="ct">Why --legacy-peer-deps</span>The tree-sitter grammar packages under-declare their peer-dep ranges. Without the flag, npm's strict resolver enters a long retry loop on a cold cache and can appear to hang. The flag tells npm to use our tested versions as-is; we can't set it from inside the package.</div>
+      <p style="margin-top:22px"><code>init</code> asks two things — the <b>experience</b> (<code>cli</code>, recommended, or <code>mcp</code>) and the <b>client</b> (<code>claude</code> / <code>cursor</code> / <code>codex</code> / <code>other</code>) — then writes a single <code>coldstart.md</code> at your repo root and wires the client. It also creates the notebook and, for Claude Code / Codex / Cursor, registers the navigation and notebook hooks. Pass <code>--experience</code> / <code>--client</code> to skip the prompts; the client is never auto-detected.</p>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--experience cli|mcp</span><span class="fv">The surface to wire. <b>cli</b> is the fast path; <b>mcp</b> also writes an MCP server entry.</span></div>
+        <div class="flag-row"><span class="fk">--client NAME</span><span class="fv"><b>claude</b>, <b>cursor</b>, <b>codex</b>, or <b>other</b>. Determines which config files get wired.</span></div>
+        <div class="flag-row"><span class="fk">--commit-notebook</span><span class="fv">Opt in to committing the notebook <code>.raw</code> logs so the team can share it. Private by default — see <a href="#sharing" style="color:var(--frost)">Sharing</a>.</span></div>
+      </div>
+      <p style="margin-top:20px"><b>Upgrading:</b> <code>npm install -g @cstart/coldstart@latest --legacy-peer-deps</code>, then re-run <code>coldstart init</code> in each project. A version stamp in the keeper's lockfile shuts the old background process down on the next lookup; a fresh one spawns from the new binary.</p>
+    </section>
+
+    <section id="flow" class="doc-sec">
+      <h2>The intended flow</h2>
+      <p><code>find</code> → <code>gs</code> → <code>Read</code>. Orient with two cheap calls before spending a token reading. Notebook summaries ride along on <code>find</code>, so the orientation step often answers itself.</p>
+      <ul class="tight">
+        <li><b>find a concept</b> → ranked candidate files, each with the evidence for why it ranked.</li>
+        <li><b>gs the best file</b> → its symbols, importers, and per-symbol callers, in one call.</li>
+        <li><b>Read only the method body</b> you actually need — not the whole file.</li>
+      </ul>
+    </section>
+
+    <!-- NAVIGATION -->
+    <div class="grp-head"><div class="kicker">Navigation</div></div>
+
+    <section id="find" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart find</span> <span class="badge">navigation</span></div>
+        <div class="sig">coldstart find &lt;term&gt; [term…] [flags]</div>
+        <div class="desc"><b>Which files are about this?</b> Ranks files by how many of your query terms each covers — filenames, path segments, exported symbols, plus a repo-wide name-reference pass — and shows <em>why</em> each ranked: which terms it defines vs. imports.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart find</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart find</span> auth session cookie</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-frost">src/auth/service.ts</span>  <span class="c-hit">3/3</span> <span class="c-dim">defines</span> auth, session, cookie</span>
+<span class="ln">  <span class="c-ember">Summary</span> <span class="c-dim">[fresh]</span> Signs and verifies session cookies.</span>
+<span class="ln"><span class="c-frost">src/middleware/session.ts</span>  <span class="c-hit">2/3</span> <span class="c-dim">imports</span> session, cookie</span>
+        </div>
+      </div>
+      <p style="margin-top:16px">Pass <b>every salient identifier</b> from your task — the symbol, the domain noun, the rare token you half-remember — not one distilled keyword. <code>find</code> ranks by coverage and shows where the terms cluster, so often that's enough to answer without opening anything. Its reference pass runs on ripgrep, so it competes with raw grep on speed.</p>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--path GLOB</span><span class="fv">Scope to matching paths. Comma-combine; prefix <code>!</code> to exclude.</span></div>
+        <div class="flag-row"><span class="fk">--tests</span><span class="fv">Include test files (excluded by default).</span></div>
+        <div class="flag-row"><span class="fk">--via</span><span class="fv">Show name-reference relations — where the terms are referenced, not just declared.</span></div>
+        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
+      </div>
+      <div class="callout"><span class="ct">When find says "no indexed file contains any of […]"</span>Those identifiers aren't in the repo. Don't grep spelling variants — trust the negative.</div>
+    </section>
+
+    <section id="gs" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart gs</span> <span class="badge">navigation</span></div>
+        <div class="sig">coldstart gs &lt;file&gt; [flags]</div>
+        <div class="desc"><b>What is this file, and who uses it?</b> Returns the file's top-level symbols (with line ranges), its 1-hop internal imports, who imports it, and per-symbol cross-file callers — in one call. This is the answer to "who calls this?", not a grep.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart gs</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart gs</span> src/auth/service.ts</span>
+<span class="ln"><span class="c-dim">symbols</span>  signCookie <span class="c-dim">L12</span> · verify <span class="c-dim">L34</span> · rotate <span class="c-dim">L61</span></span>
+<span class="ln"><span class="c-dim">callers</span>  verify ← <span class="c-file">middleware/session.ts</span>, <span class="c-file">routes/login.ts</span></span>
+<span class="ln"><span class="c-dim">imported by</span>  4 files</span>
+        </div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--symbol a,b</span><span class="fv">Deliver the named method bodies inline — skip a separate Read.</span></div>
+        <div class="flag-row"><span class="fk">--match TERM</span><span class="fv">Filter a god-file to one area. <code>a|b</code> = OR, <code>/regex/</code> = regex.</span></div>
+        <div class="flag-row"><span class="fk">--view V</span><span class="fv">One of <code>symbols</code> / <code>imports</code> / <code>importers</code> / <code>callers</code>. Default returns all.</span></div>
+        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
+      </div>
+      <div class="callout"><span class="ct">Scope</span>Callers are one-hop and file-scoped. Named function/constant calls resolve cross-file; member-expression calls (<code>this.method()</code>, <code>api.method()</code>) don't. Chase further hops by running <code>gs</code> on the caller file.</div>
+    </section>
+
+    <!-- NOTEBOOK -->
+    <div class="grp-head"><div class="kicker">Notebook</div></div>
+
+    <section id="notebook" class="doc-sec">
+      <h2>The notebook, in depth</h2>
+      <p class="lead-p">A repo-local knowledge base, written and read by agents, living in <code>.coldstart/notebook/</code>. It's the one place semantics belong: authored by the agent that just did the work, kept honest by the index, and recalled when a later task matches. <b>No human writes or grooms it.</b></p>
+
+      <h4 class="subhead">What a note is</h4>
+      <div class="types">
+        <div class="tcard file"><div class="tt">File note</div><p>What a file is for — a single summary, or per-symbol facets for hub files.</p></div>
+        <div class="tcard flow"><div class="tt">Flow note</div><p>A cross-file story: ordered steps and the invariants that hold across them.</p></div>
+        <div class="tcard lesson"><div class="tt">Lesson</div><p>A trap, rule, bug-cause, rationale, or a confirmed <em>absence</em>.</p></div>
+      </div>
+      <p style="margin-top:18px">Every note carries <b>anchors</b> — the concrete file paths and symbols its claims rest on. Anchors are what make a note checkable rather than a floating assertion.</p>
+
+      <h4 class="subhead">Where notes reach the agent</h4>
+      <ul class="tight">
+        <li><b>Summary lines on <code>find</code> results</b> — a past agent's verified overview, right where the file ranks. <span class="pill fresh"><span class="d"></span>fresh</span> means the file is byte-identical to when the summary was verified, so the agent can rely on it without re-reading.</li>
+        <li><b>Recall at prompt time</b> (optional hook) — notes whose titles, aliases, or anchors match the prompt surface as a compact, hard-capped block. Nothing matches → nothing injected.</li>
+        <li><b><code>kb search</code> / <code>kb lookup</code></b> — a search engine over the notebook, and an exact-address lookup before editing a file.</li>
+      </ul>
+
+      <h4 class="subhead">Why it can be trusted</h4>
+      <ul class="tight">
+        <li><b>Freshness is mechanical.</b> Every anchor is stamped with a content hash at write time; the index re-checks it as the code changes. A drifted note renders <span class="pill changed"><span class="d"></span>evidence changed</span> and the guidance says re-verify — stale knowledge degrades into a labeled hypothesis, not a confident lie.</li>
+        <li><b>The log is the truth.</b> Notes live in an append-only <code>.raw</code> event log; the Markdown notes are derived and regenerated mechanically. A note is a pure fold of its log.</li>
+        <li><b>Writes go through a gate.</b> A new note's concept is searched against existing notes first — the agent must merge into a match or declare it new. Duplicates are caught at write time.</li>
+        <li><b>Concurrent sessions are safe.</b> Per-note append-only logs, exclusive creation of new ids, lossless union-merge of shared notes, atomic renders — concurrent writers never silently merge or lose a note.</li>
+        <li><b>Corrections happen in-session.</b> An agent that finds a note wrong while the evidence is in context is told to fix or retract it right then.</li>
+      </ul>
+
+      <div class="callout warm"><span class="ct">On token savings</span>Because the next agent recalls a verified note instead of re-deriving it, repeated tasks re-spend far fewer tokens orienting. We're holding published benchmark figures until they're reproducible enough to stand behind — the mechanism is the point: recall a fact once written, don't pay to re-derive it.</div>
+
+      <p style="margin-top:22px"><b>Language-agnostic.</b> The freshness machinery is content-hash based, so the notebook works on any codebase — including languages the navigation index doesn't parse. Where the index does parse, notes additionally get symbol-level freshness.</p>
+    </section>
+
+    <section id="kb-search" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb search</span> <span class="badge">notebook</span></div>
+        <div class="sig">coldstart kb search &lt;terms…&gt; [--max N]</div>
+        <div class="desc">Search the notebook with plain task words, symbols, or file names. Returns ranked notes — the mid-task tool when your vocabulary shifts.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb search</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb search</span> tile save lifecycle</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-ember">tile-save-lifecycle</span>  <span class="c-dim">flow · [fresh]</span></span>
+<span class="ln"><span class="c-ember">src/models.py · Tile</span>  <span class="c-dim">file · [fresh]</span></span>
+        </div>
+      </div>
+    </section>
+
+    <section id="kb-lookup" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb lookup</span> <span class="badge">notebook</span></div>
+        <div class="sig">coldstart kb lookup &lt;path&gt; [symbol]</div>
+        <div class="desc">Everything known at one exact address. Run it before editing a file to pull the note (and per-symbol facets) that apply to exactly that path.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb lookup</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb lookup</span> src/models.py Tile</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="kb-write" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb write</span> <span class="badge">notebook · the gate</span></div>
+        <div class="sig">coldstart kb write &lt;spec.json | -&gt; [--into &lt;id&gt; | --new]</div>
+        <div class="desc">The write gate. A two-phase, dedup-first path: the note's concept is checked against existing notes before anything is written.</div>
+      </div>
+      <ul class="tight">
+        <li>First call <b>exits 3</b> with candidate matches. Resolve it with <code>--into &lt;id&gt;</code> (merge into an existing note) or <code>--new</code> (declare it genuinely new).</li>
+        <li>Reads a spec file, or <code>-</code> to stream the spec from stdin.</li>
+        <li>Freshly-coined ids are created exclusively — a same-moment duplicate becomes two visible notes, never a silent merge.</li>
+      </ul>
+      <div class="callout warm"><span class="ct">Agent-facing</span>This is the command the capture hook drives at the end of a session. You rarely type it by hand.</div>
+    </section>
+
+    <section id="kb-commit" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb commit</span> <span class="badge">notebook · human-only</span></div>
+        <div class="sig">coldstart kb commit</div>
+        <div class="desc">The one sanctioned git path for the notebook. Commits only the <code>.raw</code> logs and skeleton — never your feature code, and notes never ride along in a feature commit.</div>
+      </div>
+      <div class="callout warm"><span class="ct">Never an agent action</span><code>kb commit</code> is CLI/human-only and is <b>not</b> exposed as an MCP tool. Publishing notes to git is a human decision.</div>
+    </section>
+
+    <section id="kb-view" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb view</span> <span class="badge">notebook · human-only</span></div>
+        <div class="sig">coldstart kb view [--no-open]</div>
+        <div class="desc">Generate a single self-contained HTML browser of the whole notebook and open it in your default browser. No server — one file, generated fresh, freshness stamped at generation time.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb view</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb view</span></span>
+<span class="ln"><span class="c-hit">✓</span> <span class="c-dim">kb view: wrote .coldstart/notebook/index.html — opening in browser</span></span>
+        </div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--no-open</span><span class="fv">Write <code>index.html</code> but don't launch the browser.</span></div>
+      </div>
+      <div class="callout warm"><span class="ct">For the human</span>Agents use <code>kb search</code> / <code>lookup</code>; this is the view for a person who wants to browse what the agents have been keeping. The generated file self-registers in the notebook's <code>.gitignore</code>.</div>
+    </section>
+
+    <section id="kb-maint" class="doc-sec">
+      <div class="cmd">
+        <div class="name warm"><span class="c">coldstart kb status / lint / render</span> <span class="badge">notebook</span></div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">kb status</span><span class="fv">Notebook health: note counts and per-note freshness at a glance.</span></div>
+        <div class="flag-row"><span class="fk">kb lint</span><span class="fv">Check the notebook for structural problems (broken anchors, malformed notes).</span></div>
+        <div class="flag-row"><span class="fk">kb render</span><span class="fv">Regenerate the derived Markdown notes from the <code>.raw</code> logs.</span></div>
+        <div class="flag-row"><span class="fk">kb init</span><span class="fv">Notebook-only setup — skeleton + hooks. Redundant if you ran <code>coldstart init</code>, which already does this.</span></div>
+        <div class="flag-row"><span class="fk">kb migrate</span><span class="fv">Upgrade an older notebook's on-disk format.</span></div>
+      </div>
+    </section>
+
+    <section id="sharing" class="doc-sec">
+      <h2>Sharing with a team</h2>
+      <p>The notebook is <b>private by default</b> — <code>.coldstart/</code> is gitignored. Opt in to sharing and the whole team's agents contribute to one growing corpus.</p>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">share the notebook</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span> <span class="c-flag">--commit-notebook</span>   <span class="c-dim"># make .raw committable</span></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb commit</span>              <span class="c-dim"># publish notes to git</span></span>
+        </div>
+      </div>
+      <p style="margin-top:16px">Once committed, the <code>.raw</code> logs travel with the repo and <b>union-merge across branches and machines</b> — parallel branches of notes reconcile without conflicts. Every teammate's agent both reads from and writes to the same notebook, so the corpus grows at the speed of the whole team, not one person.</p>
+      <div class="callout warm"><span class="ct">Bigger notebooks, faster</span>The corpus grows exactly where the codebase gets worked. On a shared repo, that's every engineer's sessions feeding one knowledge base — and because each note stays anchored to the code, growth stays true instead of rotting.</div>
+    </section>
+
+    <!-- UNDER THE HOOD -->
+    <div class="grp-head"><div class="kicker">Under the hood</div></div>
+
+    <section id="freshness" class="doc-sec">
+      <h2>How the index stays fresh</h2>
+      <p>coldstart is <b>one keeper, thin readers</b>. A single background keeper watches the repo and keeps an on-disk cache current; the readers (<code>find</code>, <code>gs</code>, the MCP server) are stateless and never build. There is no cache TTL — the index is never discarded for being old, it's kept <em>correct</em>.</p>
+      <div class="diagram">
+        <svg viewBox="0 0 900 300" role="img" aria-label="Architecture: a single keeper watches the repo and saves an on-disk cache; three stateless readers read that cache">
+          <defs><marker id="ah2" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path class="d-arrowhead" d="M0,0 L9,4.5 L0,9 z"/></marker></defs>
+          <rect class="d-box d-frost" x="250" y="20" width="400" height="76" rx="10" stroke-width="2"/>
+          <text class="d-label" x="270" y="50">keeper — coldstart --daemon</text>
+          <text class="d-sub" x="270" y="74">watches repo → patch/rebuild → saves cache · serves nothing</text>
+          <rect class="d-box" x="370" y="130" width="160" height="44" rx="8"/>
+          <text class="d-cmd" x="450" y="157" text-anchor="middle">on-disk cache</text>
+          <path class="d-arrow" d="M450,98 L450,128" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L180,224" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L450,224" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L720,224" marker-end="url(#ah2)"/>
+          <rect class="d-box" x="70" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="175" y="252" text-anchor="middle">coldstart find</text><text class="d-sub" x="175" y="270" text-anchor="middle">reads cache, prints</text>
+          <rect class="d-box" x="345" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="450" y="252" text-anchor="middle">coldstart gs</text><text class="d-sub" x="450" y="270" text-anchor="middle">reads cache, prints</text>
+          <rect class="d-box" x="620" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="725" y="252" text-anchor="middle">MCP server</text><text class="d-sub" x="725" y="270" text-anchor="middle">reads cache, stdio</text>
+        </svg>
+      </div>
+      <div class="fgrid">
+        <div class="fcard"><div class="fnum">WHILE RUNNING</div><h4>Patched as you type</h4><p>Edits debounce (400 ms), then patch incrementally (~2–5 ms/file) or trigger a background rebuild. Re-saved in atomic generations — a reader never loads a half-written mix.</p></div>
+        <div class="fcard"><div class="fnum">ON START</div><h4>Reconciled, not rebuilt</h4><p>Stat-checks every file against its fingerprint plus a git diff, and patches exactly what changed. A branch switch that used to force a full rebuild is now typically a few seconds.</p></div>
+        <div class="fcard"><div class="fnum">AS A BACKSTOP</div><h4>Linted &amp; audited</h4><p>Every patch is checked against index invariants (a violation auto-rebuilds), and a rotating fingerprint audit after each save catches watcher-missed drift.</p></div>
+      </div>
+      <div class="callout"><span class="ct">Full internals</span>The exact pipeline (walk → parse → resolve → graph → cache) and per-language resolver notes live in <b>ARCHITECTURE.md</b> on <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">GitHub</a>.</div>
+    </section>
+
+    <section id="lifecycle" class="doc-sec">
+      <h2>Lifecycle commands</h2>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">coldstart status</span><span class="fv">Keepers on this machine: alive? fresh? last patch/rebuild/save? repairs?</span></div>
+        <div class="flag-row"><span class="fk">coldstart restart</span><span class="fv">Kill the current repo's keeper (respawns on next lookup). <code>--root DIR</code> targets another repo; <code>--all</code> kills every keeper.</span></div>
+        <div class="flag-row"><span class="fk">coldstart index</span><span class="fv">Build + save the cache once, up front (single-writer prep).</span></div>
+      </div>
+      <div class="callout"><span class="ct">When anything feels stale</span><code>coldstart restart</code> — a fresh keeper reconciles on start, so it comes back <em>correct</em>, not just alive. If something looks structurally wrong, <b>TROUBLESHOOTING.md</b> on GitHub has recovery steps.</div>
+    </section>
+
+    <section id="mcp" class="doc-sec">
+      <h2>MCP tools</h2>
+      <p>For no-shell clients (like Claude Desktop), the same engine is exposed as MCP tools with byte-identical output to the CLI.</p>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">find · gs</span><span class="fv">The two navigation operations.</span></div>
+        <div class="flag-row"><span class="fk">kb_search · kb_lookup</span><span class="fv">Read the notebook.</span></div>
+        <div class="flag-row"><span class="fk">kb_write · kb_status</span><span class="fv">Write to and inspect the notebook — the MCP server is a writer for <code>kb_write</code>.</span></div>
+      </div>
+      <div class="callout"><span class="ct">Not exposed</span><code>kb commit</code> and <code>kb view</code> stay CLI/human-only — publishing to git and opening a browser are never agent actions.</div>
+    </section>
+
+    <section id="semantics" class="doc-sec">
+      <h2>Bring your own semantics</h2>
+      <p>coldstart has no embeddings, no generated summaries, no semantic layer computed at index time — <b>on purpose. The semantic layer is the agent.</b> Every consumer is already a frontier model; pre-computing meaning at index time only duplicates that, worse and stale. So the index keeps what's cheap to keep <em>exact</em> — paths, symbols, exports, the import/call graph — and returns <em>why</em> each file ranked. The notebook applies the same rule to memory: it stores and freshness-checks the meaning agents author, and computes none of its own.</p>
+      <div class="callout"><span class="ct">Read the argument</span>The full case is in <b>PHILOSOPHY.md</b> on <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">GitHub</a>.</div>
+    </section>
+
+    <section id="languages" class="doc-sec">
+      <h2>Supported languages</h2>
+      <p>Tree-sitter for the parsed set; the notebook's content-hash freshness works on all of them — notes on a Swift repo are as trustworthy as notes on a TypeScript one (they just lack symbol-level freshness).</p>
+      <div class="langs">
+        <span class="chip hot">TypeScript</span><span class="chip hot">JavaScript</span><span class="chip hot">JSX / TSX</span>
+        <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
+        <span class="chip hot">Python</span><span class="chip hot">Ruby (Rails)</span><span class="chip hot">Go</span><span class="chip hot">Rust</span>
+        <span class="chip">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
+        <span class="chip">Groovy / Gradle</span><span class="chip">GraphQL</span><span class="chip">YAML</span><span class="chip">TOML</span><span class="chip">XML</span><span class="chip">.env</span>
+      </div>
+      <p style="margin-top:16px;font-size:14px"><b>Not indexed:</b> Swift, Dart — no extension mapping; these files aren't walked or parsed. The notebook still works on them.</p>
+    </section>
+  </main>
+</div>
+
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="index.html" style="font-size:15px"><span class="dot"></span>coldstart</a> — docs · MIT</span>
+    <div class="foot-links">
+      <a href="index.html">Home</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+      <a href="#notebook">Notebook</a>
+      <a href="#install">Install</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // Sidebar scrollspy — highlight the section in view. Guarded + no-op if unsupported.
+  (function () {
+    var links = Array.prototype.slice.call(document.querySelectorAll('.side a[href^="#"]'));
+    if (!links.length || !('IntersectionObserver' in window)) return;
+    var byId = {};
+    links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
+    var visible = new Set();
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) visible.add(e.target.id); else visible.delete(e.target.id);
+      });
+      var top = null, topY = Infinity;
+      visible.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        var y = el.getBoundingClientRect().top;
+        if (y < topY) { topY = y; top = id; }
+      });
+      links.forEach(function (a) { a.classList.remove('active'); });
+      if (top && byId[top]) byId[top].classList.add('active');
+    }, { rootMargin: '-70px 0px -70% 0px', threshold: 0 });
+    document.querySelectorAll('.doc-sec').forEach(function (s) { obs.observe(s); });
+  })();
+</script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,376 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>coldstart — codebase memory &amp; navigation for AI agents</title>
+<meta name="description" content="coldstart is a fast static index that tells agents which files matter, plus a notebook the agent writes and maintains itself. No embeddings, no separate API key." />
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+
+<nav>
+  <div class="nav-in">
+    <span class="brand"><span class="dot"></span>coldstart</span>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="#notebook">Notebook</a>
+      <a href="#flow">The&nbsp;flow</a>
+      <a href="#semantics">Philosophy</a>
+      <a href="docs.html">Docs</a>
+    </div>
+    <a class="nav-cta" href="#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow">Codebase memory &amp; navigation for AI agents</div>
+    <h1 class="hero-title">Your agent lands <span class="cold">cold</span> in every repo.</h1>
+    <p class="hero-sub">coldstart is the layer that warms it up — a <strong>fast static index</strong> that answers <em>which files matter</em> in milliseconds, and a <strong>notebook the agent writes and maintains itself</strong> — a knowledge base that grows as the repo gets worked, so each agent starts with more context and wastes less effort re-deriving what's already known. No embeddings. No model to run. No service to babysit.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="#install">Get started →</a>
+      <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">View on GitHub →</a>
+      <span class="hero-note">MIT · Node 18+ · no separate API key</span>
+    </div>
+
+    <div class="term" role="img" aria-label="Terminal showing a coldstart find command and its ranked, evidence-backed results">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">agent — coldstart</span></div>
+      <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart find</span> <span class="c-cmd">auth session cookie</span></span>
+<span class="gap"></span>
+<span class="ln"><span class="c-frost">src/auth/service.ts</span>  <span class="c-dim">·······</span> <span class="c-hit">3/3</span> <span class="c-dim">defines</span> auth, session, cookie</span>
+<span class="ln">  <span class="c-ember">Summary</span> <span class="c-dim">[fresh]</span> Signs and verifies session cookies; entry for login/logout.</span>
+<span class="ln"><span class="c-frost">src/middleware/session.ts</span>  <span class="c-dim">·</span> <span class="c-hit">2/3</span> <span class="c-dim">imports</span> session, cookie</span>
+<span class="ln"><span class="c-frost">src/routes/login.ts</span>  <span class="c-dim">·······</span> <span class="c-hit">2/3</span> <span class="c-dim">defines</span> auth · <span class="c-dim">imports</span> session</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart gs</span> <span class="c-cmd">src/auth/service.ts</span></span>
+<span class="ln"><span class="c-dim">symbols</span>  signCookie <span class="c-dim">L12</span> · verify <span class="c-dim">L34</span> · rotate <span class="c-dim">L61</span></span>
+<span class="ln"><span class="c-dim">callers</span>  verify ← <span class="c-file">middleware/session.ts</span>, <span class="c-file">routes/login.ts</span></span>
+<span class="ln"><span class="c-dim">imported by</span>  4 files <span class="c-dim">·</span> <span class="c-frost">→ Read only the method body you need</span></span>
+      </div>
+    </div>
+  </div>
+</header>
+
+<section class="band">
+  <div class="wrap">
+    <div class="prob-grid">
+      <div>
+        <div class="sec-eyebrow">The cold-start tax</div>
+        <div class="prob-stat">Find, not read.</div>
+      </div>
+      <div class="prob-list">
+        <div class="prob-item"><span class="x">✕</span><p><strong>Agents already read code well.</strong> That was never the bottleneck.</p></div>
+        <div class="prob-item"><span class="x">✕</span><p>They burn tokens <strong>finding</strong> the right file — speculative greps, three wrong reads before the right one.</p></div>
+        <div class="prob-item"><span class="x">✕</span><p>And they <strong>re-derive</strong> what a past session already figured out, every single time.</p></div>
+        <div class="prob-item"><span class="x">✕</span><p>coldstart does exactly those two things — <strong>cutting the tokens agents spend orienting</strong>, and getting out of the way.</p></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="layers">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-eyebrow">Two layers, one tool</div>
+      <h2>Exact structure, plus honest memory.</h2>
+      <p class="sec-lead">The cold layer keeps facts <em>exact</em>. The warm layer keeps judgment <em>honest</em>. The agent supplies both — you maintain neither.</p>
+    </div>
+    <div class="layers">
+      <div class="layer cold">
+        <div class="tag">❄ Navigation · the index</div>
+        <h3>Find the file. Fast.</h3>
+        <p>A static index over paths, symbols, exports, and the import/call graph. Deterministic, offline, free — no API key, no GPU, no inference.</p>
+        <div class="op"><div class="opname"><span class="cold">find</span> &lt;terms&gt;</div><p>Ranks files by how many of your query terms each covers — and shows <em>why</em> it ranked: which terms it defines vs. imports.</p></div>
+        <div class="op"><div class="opname"><span class="cold">gs</span> &lt;file&gt;</div><p>One file's shape: symbols with line ranges, who imports it, who calls each symbol. Not a grep — the answer to "who uses this?"</p></div>
+      </div>
+      <div class="layer warm">
+        <div class="tag">✦ Notebook · the memory</div>
+        <h3>Remember what was learned.</h3>
+        <p>Durable notes about how <em>this</em> repo actually works — written by the agent after real tasks, recalled when a later task matches. You never touch it.</p>
+        <div class="op"><div class="opname"><span class="warm">Anchored</span> to real files</div><p>Every note cites concrete paths and symbols. The index re-checks each anchor's hash as code changes.</p></div>
+        <div class="op"><div class="opname"><span class="warm">Kept honest</span>, never stale</div><p>A note whose evidence drifted renders <code>[evidence changed]</code> — degraded to a labeled hypothesis, not served as a confident lie.</p></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ NOTEBOOK CENTERPIECE ============ -->
+<section id="notebook" class="nb-band">
+  <div class="wrap">
+    <div class="sec-head nb-head">
+      <div class="sec-eyebrow">The notebook · written and maintained by the agent</div>
+      <h2>A memory your agent keeps — <span class="warm">so you don't have to.</span></h2>
+      <p class="sec-lead">Most "knowledge bases" rot because a human has to feed them. coldstart's notebook is written by the agent that just did the work, kept honest by the index automatically, and recalled the moment it's relevant. There is no human in the maintenance loop — and that's the point.</p>
+    </div>
+
+    <div class="beats">
+
+      <!-- BEAT 1 — the agent writes -->
+      <div class="beat">
+        <div class="beat-text">
+          <div class="beat-step"><span class="n">1</span>The agent writes it</div>
+          <h3>Authored after a real task.</h3>
+          <p>The reasoner that just solved something writes down what it learned — a file's purpose, a cross-file flow, a trap — with concrete citations, while the full context is still in hand. A write gate dedupes by concept, and concurrent agents never silently merge or lose a note.</p>
+          <div class="notyou"><s>You write the docs.</s> &nbsp;<b>The agent does.</b></div>
+        </div>
+        <div class="beat-visual">
+          <div class="notecard">
+            <div class="nc-top">
+              <div class="nc-kicker">
+                <span class="type-pill">File note</span>
+                <span class="pill fresh"><span class="d"></span>fresh</span>
+              </div>
+              <div class="nc-title">src/models.py · Tile</div>
+            </div>
+            <div class="nc-body">
+              <p>Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps <span class="link">bbox</span> from the geometry before insert, so callers must never set bbox by hand.</p>
+              <p>Part of the <span class="link">[[tile-save-lifecycle]]</span> flow.</p>
+              <div class="nc-anchors">
+                <div class="panel-label">Anchors — the files this note rests on</div>
+                <div class="anchors">
+                  <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                  <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- BEAT 2 — the index keeps it honest (visual on left) -->
+      <div class="beat rev">
+        <div class="beat-text">
+          <div class="beat-step"><span class="n">2</span>The index keeps it honest</div>
+          <h3>Freshness is mechanical, not hoped-for.</h3>
+          <p>Every anchor is stamped with a content hash. The background keeper re-checks it as the code moves — no one has to remember to. When the evidence drifts, the note flips to <code>[evidence changed]</code> automatically: degraded to a labeled hypothesis, never served as a confident lie.</p>
+          <div class="notyou"><s>You prune stale docs.</s> &nbsp;<b>The hash does.</b></div>
+        </div>
+        <div class="beat-visual">
+          <div class="notecard">
+            <div class="nc-top">
+              <div class="nc-kicker">
+                <span class="type-pill">File note</span>
+                <span class="pill changed"><span class="d"></span>evidence changed</span>
+              </div>
+              <div class="nc-title">src/models.py · Tile</div>
+            </div>
+            <div class="nc-body">
+              <p>Persists a map tile and its geometry. <b>save()</b> is the single write path…</p>
+              <div class="nc-changed-note">⚠ evidence changed: src/models.py — re-verify before relying on this note.</div>
+              <div class="nc-anchors">
+                <div class="panel-label">Anchors</div>
+                <div class="anchors">
+                  <span class="anchor changed"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                  <span class="anchor changed"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- BEAT 3 — the next agent recalls (visual = the kb view browser) -->
+      <div class="beat">
+        <div class="beat-text">
+          <div class="beat-step"><span class="n">3</span>The next agent recalls it</div>
+          <h3>Surfaced when it's relevant — not searched for.</h3>
+          <p>A matching prompt pulls the note in automatically, and a fresh <code>Summary</code> rides along on every <code>find</code>. The second time any question comes up, the answer is one <code>Read</code> away instead of a re-derivation.</p>
+          <p>And when a human wants to see what the agents have been keeping, <code>coldstart kb view</code> opens the whole notebook as one HTML file — no server.</p>
+          <div class="notyou"><s>You go looking.</s> &nbsp;<b>It comes to you.</b></div>
+        </div>
+        <div class="beat-visual">
+          <div class="viewer" role="img" aria-label="Mock of the coldstart kb view notebook browser: a file tree on the left with per-file freshness dots, and a note pane on the right">
+            <div class="vw-chrome">
+              <span class="tl"></span><span class="tl"></span><span class="tl"></span>
+              <span class="vw-url">file:///arches/.coldstart/notebook/index.html</span>
+            </div>
+            <div class="vw-app">
+              <div class="vw-topbar">
+                <div>
+                  <div class="vw-kicker">coldstart notebook</div>
+                  <div class="vw-repo">arches</div>
+                </div>
+                <div class="vw-tabs" style="margin-left:20px">
+                  <span class="vw-tab on">Files</span>
+                  <span class="vw-tab">Flows</span>
+                </div>
+                <span class="vw-count">111 notes · 108 fresh</span>
+              </div>
+              <div class="vw-tree">
+                <div class="vw-row dir"><span class="tw">▾</span>src</div>
+                <div class="vw-row file on vw-ind"><span class="tw">•</span>models.py<span class="dd fresh"></span></div>
+                <div class="vw-row file vw-ind"><span class="tw">•</span>search.py<span class="dd fresh"></span></div>
+                <div class="vw-row dir vw-ind"><span class="tw">▾</span>views</div>
+                <div class="vw-row file vw-ind2"><span class="tw">•</span>tile.py<span class="dd changed"></span></div>
+                <div class="vw-row file vw-ind2"><span class="tw">•</span>map.py<span class="dd fresh"></span></div>
+                <div class="vw-row dir"><span class="tw">▸</span>api</div>
+              </div>
+              <div class="vw-pane">
+                <div class="nc-kicker">
+                  <span class="type-pill">File note</span>
+                  <span class="pill fresh"><span class="d"></span>fresh</span>
+                </div>
+                <div class="nc-title">src/models.py · Tile</div>
+                <p style="margin-top:10px">Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps bbox from the geometry before insert.</p>
+                <div class="nc-anchors">
+                  <div class="panel-label">Anchors</div>
+                  <div class="anchors">
+                    <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                    <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="keynote nb-share">
+      <span class="kk">Shared, it compounds faster</span>
+      <p><b>Commit the notebook to your repo and the whole team feeds one corpus.</b> The append-only logs union-merge across branches and machines — no conflicts — so every teammate's agent both reads from and adds to the same notebook. Private by default; opt in with <code>coldstart init --commit-notebook</code>. More sessions in, bigger notebook out.</p>
+    </div>
+
+    <div class="nb-foot">
+      <p class="lead">A knowledge base that compounds as the repo gets worked — more context for the next agent, less effort spent re-deriving what's already known.</p>
+      <p class="sub">Every note stays anchored to the code, so the <b>codebase remains the single source of truth</b> — the notebook only remembers what was learned about it, and the index keeps the two in sync.</p>
+    </div>
+
+    <div style="text-align:center;margin-top:30px">
+      <a class="btn btn-ghost" href="docs.html#notebook">Read more about the notebook →</a>
+    </div>
+  </div>
+</section>
+
+<section id="flow">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-eyebrow">The intended flow</div>
+      <h2>find → gs → Read.</h2>
+      <p class="sec-lead">Orient with two cheap calls before you spend a single token reading. Notebook summaries ride along on <code style="font-family:var(--mono)">find</code>, so the orientation step often answers itself.</p>
+    </div>
+    <div class="diagram">
+      <svg viewBox="0 0 900 260" role="img" aria-label="Flow diagram: find ranks candidate files, gs reveals one file's structure and callers, then Read opens only the needed method body">
+        <defs>
+          <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path class="d-arrowhead" d="M0,0 L9,4.5 L0,9 z"/></marker>
+        </defs>
+        <rect class="d-box d-frost" x="24" y="70" width="230" height="120" rx="10" stroke-width="2"/>
+        <text class="d-cmd" x="44" y="102">coldstart find</text>
+        <text class="d-label" x="44" y="132">Which files?</text>
+        <text class="d-sub" x="44" y="156">Ranked candidates,</text>
+        <text class="d-sub" x="44" y="174">each with its evidence.</text>
+        <text class="d-note" x="44" y="52">＋ notebook Summary [fresh]</text>
+        <path class="d-arrow" d="M262,130 L322,130" marker-end="url(#ah)"/>
+        <rect class="d-box d-frost" x="332" y="70" width="230" height="120" rx="10" stroke-width="2"/>
+        <text class="d-cmd" x="352" y="102">coldstart gs</text>
+        <text class="d-label" x="352" y="132">What is it?</text>
+        <text class="d-sub" x="352" y="156">Symbols, importers,</text>
+        <text class="d-sub" x="352" y="174">per-symbol callers.</text>
+        <path class="d-arrow" d="M570,130 L630,130" marker-end="url(#ah)"/>
+        <rect class="d-box d-ember" x="640" y="70" width="236" height="120" rx="10" stroke-width="2"/>
+        <text class="d-cmd" x="660" y="102" style="fill:var(--ember)">Read</text>
+        <text class="d-label" x="660" y="132">Just the body.</text>
+        <text class="d-sub" x="660" y="156">Open only the one</text>
+        <text class="d-sub" x="660" y="174">method you need.</text>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<section id="semantics" class="band">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-eyebrow">Bring your own semantics</div>
+      <h2>No embeddings. On purpose.</h2>
+      <p class="sec-lead">Every consumer is already a frontier model — the best semantic reasoner in the loop. Pre-computing meaning at index time only duplicates that, worse and stale. So coldstart keeps what's cheap to keep <em>exact</em>, and leaves meaning to the reasoner holding the task.</p>
+    </div>
+    <div class="compare">
+      <div class="cmp them">
+        <h4>Embedding-based code search</h4>
+        <ul>
+          <li><span class="mk">✕</span><span>Freezes <b>one interpretation</b> of a file at index time, blind to the task.</span></li>
+          <li><span class="mk">✕</span><span>A stale vector <b>fails silently</b> — a confident wrong answer you can't spot.</span></li>
+          <li><span class="mk">✕</span><span>Returns a <b>cosine score</b> the agent has to trust blindly or re-verify.</span></li>
+          <li><span class="mk">✕</span><span>Needs an API key, a GPU, inference on every query.</span></li>
+        </ul>
+      </div>
+      <div class="cmp us">
+        <h4>coldstart</h4>
+        <ul>
+          <li><span class="mk">✓</span><span>The agent judges relevance <b>in context</b>, against the actual goal.</span></li>
+          <li><span class="mk">✓</span><span>A background keeper patches facts in <b>milliseconds</b> — the index never lies about the tree.</span></li>
+          <li><span class="mk">✓</span><span>Returns <b>checkable evidence</b> — this term is defined here, imported there.</span></li>
+          <li><span class="mk">✓</span><span>Runs on <b>the agent you already pay for</b> — deterministic, offline, no key, no GPU.</span></li>
+        </ul>
+      </div>
+    </div>
+    <div class="keynote">
+      <span class="kk">No second bill</span>
+      <p><b>coldstart runs on the agent you already pay for.</b> The semantic layer <em>is</em> your Claude Code, Codex, or Cursor subscription — coldstart adds no inference of its own, so there's <b>no separate API key, no metered embeddings, nothing new to provision.</b> Most code-search tools bill you twice: once for the agent, again for their own model. This one doesn't.</p>
+    </div>
+  </div>
+</section>
+
+<section id="languages">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-eyebrow">Supported languages</div>
+      <h2>Parses 20+ languages. The notebook works on all of them.</h2>
+      <p class="sec-lead">Tree-sitter for the parsed set; content-hash freshness for the notebook means notes on a Swift repo are as trustworthy as notes on a TypeScript one.</p>
+    </div>
+    <div class="langs">
+      <span class="chip hot">TypeScript</span><span class="chip hot">JavaScript</span><span class="chip hot">JSX / TSX</span>
+      <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
+      <span class="chip hot">Python</span><span class="chip hot">Ruby (Rails)</span><span class="chip hot">Go</span><span class="chip hot">Rust</span>
+      <span class="chip">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
+      <span class="chip">Groovy / Gradle</span><span class="chip">GraphQL</span><span class="chip">YAML</span><span class="chip">TOML</span><span class="chip">XML</span><span class="chip">.env</span>
+    </div>
+  </div>
+</section>
+
+<section id="install">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="sec-eyebrow">Get started</div>
+      <h2>Two commands to warm the repo.</h2>
+      <p class="sec-lead">Works best with <strong>Claude Code</strong>, <strong>Codex</strong>, and <strong>Cursor</strong> — all get the fast CLI path <em>and</em> the notebook capture/recall hooks auto-wired by <code style="font-family:var(--mono)">init</code>.</p>
+    </div>
+    <div class="term install-term">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">your-project</span></div>
+      <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">npm install -g @cstart/coldstart</span> <span class="c-flag">--legacy-peer-deps</span></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">cd</span> your-project</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span>   <span class="c-dim"># coldstart.md + client wiring + notebook + capture/recall hooks</span></span>
+<span class="gap"></span>
+<span class="ln"><span class="c-hit">✓</span> <span class="c-dim">index warming in the background — your first lookup is instant.</span></span>
+      </div>
+    </div>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="docs.html">Read the docs →</a>
+      <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a class="btn btn-ghost" href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+  </div>
+</section>
+
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><span class="brand" style="font-size:15px"><span class="dot"></span>coldstart</span> — codebase memory &amp; navigation for AI agents · MIT</span>
+    <div class="foot-links">
+      <a href="docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+      <a href="#notebook">Notebook</a>
+      <a href="#semantics">Philosophy</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,28 @@
+# coldstart
+
+> Codebase navigation and a codebase notebook for AI agents. A fast static index answers "which files are relevant to this task?" in milliseconds with checkable evidence instead of a similarity score. A durable, agent-written notebook remembers what a past session figured out about the codebase, kept honest by content-hash freshness checks. No embeddings, no model to run, no service to babysit — the consuming agent is the semantic layer.
+
+coldstart ships as an npm package (`@cstart/coldstart`) providing the `coldstart` CLI binary, and an MCP server for no-shell clients. Two front doors, byte-identical output.
+
+## Core operations
+
+- `coldstart find <terms>` — ranks files by how many query terms each covers (filenames, path segments, exported symbols, plus a repo-wide reference scan), showing the evidence for each ranking.
+- `coldstart gs <file>` — one file's symbols (with line ranges), its imports, who imports it, and per-symbol cross-file callers, in one call.
+- `coldstart kb search|lookup|write|commit|view|status|lint|render` — the notebook: durable, agent-written notes anchored to real files and content-hash freshness-checked. `kb commit` and `kb view` are human-only, never MCP tools.
+- `coldstart init` — one-time setup: writes `coldstart.md`, wires the CLI/MCP client (Claude Code, Codex, Cursor, or other), creates the notebook, and registers navigation + notebook hooks.
+
+## Docs
+
+- [Home](https://akashgoenka.github.io/coldstart/): pitch, the two-layer model (index + notebook), how the notebook works, install.
+- [Docs](https://akashgoenka.github.io/coldstart/docs.html): full command reference for `find`, `gs`, and the `kb` family; sharing a notebook with a team; how the index stays fresh.
+- [README](https://github.com/AkashGoenka/coldstart/blob/main/README.md): authoritative reference — every flag, install details, limitations.
+- [PHILOSOPHY.md](https://github.com/AkashGoenka/coldstart/blob/main/PHILOSOPHY.md): why coldstart has no embeddings or generated semantics — the consuming agent is the semantic layer.
+- [ARCHITECTURE.md](https://github.com/AkashGoenka/coldstart/blob/main/ARCHITECTURE.md): the index pipeline, keeper/reader process model, and notebook internals.
+- [TROUBLESHOOTING.md](https://github.com/AkashGoenka/coldstart/blob/main/TROUBLESHOOTING.md): recovery procedures.
+
+## For agents evaluating or using coldstart
+
+- Install: `npm install -g @cstart/coldstart --legacy-peer-deps`, then `coldstart init` in the target repo.
+- Prefer `find` and `gs` over speculative `grep`/`glob` when orienting in an unfamiliar repo — they return ranked, evidence-backed results from a pre-built index, not a live scan.
+- Notebook notes are marked `[fresh]` (safe to trust without re-reading the file) or `[evidence changed]` (re-verify before relying on it) — never presented as unqualified fact.
+- `kb commit` and `kb view` are human-only actions and are not exposed via MCP; do not attempt to invoke them as an agent tool.

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,401 @@
+/* coldstart site — shared design system (frost = navigation/index, ember = notebook/memory) */
+
+:root {
+  --bg: #eaeef4;
+  --surface: #ffffff;
+  --surface-2: #f3f6fa;
+  --ink: #0d1520;
+  --muted: #55617a;
+  --frost: #16708f;
+  --frost-bright: #1f93b8;
+  --ember: #c26714;
+  --ember-bright: #d9781f;
+  --line: #d3dae6;
+  --term-bg: #0a0e15;
+  --term-ink: #cbd6e6;
+  --ok: #2f8f57;
+  --ok-bg: #e4f2ea;
+  --warn: #a85a06;
+  --warn-bg: #fbeede;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --wrap: 1080px;
+  --nav-wrap: 1080px;
+  --radius: 12px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #080b11; --surface: #0f151f; --surface-2: #0c1119; --ink: #dfe7f2;
+    --muted: #8b98b0; --frost: #5fc8e8; --frost-bright: #7ad6f0; --ember: #f6a340;
+    --ember-bright: #ffb35a; --line: #1c2634; --term-bg: #05080d; --term-ink: #cbd6e6;
+    --ok: #5fca8c; --ok-bg: #10241a; --warn: #f6a340; --warn-bg: #2a1e0c;
+  }
+}
+:root[data-theme="dark"] {
+  --bg: #080b11; --surface: #0f151f; --surface-2: #0c1119; --ink: #dfe7f2;
+  --muted: #8b98b0; --frost: #5fc8e8; --frost-bright: #7ad6f0; --ember: #f6a340;
+  --ember-bright: #ffb35a; --line: #1c2634; --term-bg: #05080d; --term-ink: #cbd6e6;
+  --ok: #5fca8c; --ok-bg: #10241a; --warn: #f6a340; --warn-bg: #2a1e0c;
+}
+:root[data-theme="light"] {
+  --bg: #eaeef4; --surface: #ffffff; --surface-2: #f3f6fa; --ink: #0d1520;
+  --muted: #55617a; --frost: #16708f; --frost-bright: #1f93b8; --ember: #c26714;
+  --ember-bright: #d9781f; --line: #d3dae6; --term-bg: #0a0e15; --term-ink: #cbd6e6;
+  --ok: #2f8f57; --ok-bg: #e4f2ea; --warn: #a85a06; --warn-bg: #fbeede;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; background: var(--bg); color: var(--ink);
+  font-family: var(--sans); line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "kern" 1;
+}
+.wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 24px; }
+a { color: inherit; }
+h1, h2, h3, h4 { text-wrap: balance; margin: 0; }
+p { margin: 0; }
+code { font-family: var(--mono); }
+
+.thread {
+  height: 2px; border: 0; margin: 0;
+  background: linear-gradient(90deg, var(--frost) 0%, var(--frost) 30%, var(--ember) 100%);
+  opacity: .55;
+}
+
+/* ---- NAV (shared; --nav-wrap lets docs.html run a wider bar) ---- */
+nav {
+  position: sticky; top: 0; z-index: 30;
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; }
+.brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.02em; display: flex; align-items: center; gap: 9px; text-decoration: none; color: var(--ink); }
+.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, var(--ember-bright), var(--frost)); box-shadow: 0 0 10px color-mix(in srgb, var(--frost) 50%, transparent); }
+.brand .tag { font-size: 12px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
+.nav-spacer { flex: 1; }
+.nav-links { display: flex; gap: 22px; font-size: 14px; font-family: var(--mono); }
+.nav-links a { color: var(--muted); text-decoration: none; transition: color .15s; }
+.nav-links a:hover { color: var(--ink); }
+.nav-cta { font-family: var(--mono); font-size: 13px; text-decoration: none; padding: 7px 14px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink); transition: border-color .15s, background .15s; }
+.nav-cta:hover { border-color: var(--frost); background: color-mix(in srgb, var(--frost) 8%, transparent); }
+@media (max-width: 860px) { .nav-links { display: none; } }
+
+/* ---- HERO ---- */
+.hero { padding: 76px 0 30px; }
+.eyebrow { font-family: var(--mono); font-size: 12.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 20px; display: flex; align-items: center; gap: 10px; }
+.eyebrow::before { content: ""; width: 26px; height: 1px; background: var(--frost); display: inline-block; }
+h1.hero-title {
+  font-family: var(--mono); font-weight: 700;
+  font-size: clamp(34px, 6vw, 58px); line-height: 1.04; letter-spacing: -.035em;
+  max-width: 15ch;
+}
+h1.hero-title .warm { color: var(--ember); }
+h1.hero-title .cold { color: var(--frost); }
+.hero-sub { margin-top: 24px; font-size: clamp(17px, 2.1vw, 20px); color: var(--muted); max-width: 56ch; }
+.hero-sub strong { color: var(--ink); font-weight: 600; }
+.cta-row { margin-top: 34px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+.btn { font-family: var(--mono); font-size: 14.5px; text-decoration: none; padding: 12px 20px; border-radius: 9px; display: inline-flex; align-items: center; gap: 9px; transition: transform .12s, box-shadow .2s, background .2s; }
+.btn-primary { background: var(--ink); color: var(--bg); }
+.btn-primary:hover { transform: translateY(-1px); box-shadow: 0 8px 24px color-mix(in srgb, var(--frost) 30%, transparent); }
+.btn-ghost { color: var(--ink); border: 1px solid var(--line); }
+.btn-ghost:hover { border-color: var(--frost); }
+.hero-note { font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
+
+/* ---- TERMINAL (shared by home hero + docs command blocks) ---- */
+.term {
+  margin-top: 52px; background: var(--term-bg); border: 1px solid var(--line);
+  border-radius: var(--radius); overflow: hidden;
+}
+.hero .term, .install-term { box-shadow: 0 30px 70px -30px rgba(3,10,22,.6); }
+.term-bar { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,.06); }
+.term-bar .tl { width: 11px; height: 11px; border-radius: 50%; }
+.term-bar .tl:nth-child(1) { background: #ff5f57; }
+.term-bar .tl:nth-child(2) { background: #febc2e; }
+.term-bar .tl:nth-child(3) { background: #28c840; }
+.term-bar .title { margin-left: 10px; font-family: var(--mono); font-size: 12px; color: #6b7a90; }
+.term-body { padding: 20px 22px 26px; font-family: var(--mono); font-size: 13.5px; line-height: 1.75; color: var(--term-ink); overflow-x: auto; }
+.term-body .ln { white-space: pre; }
+.c-prompt { color: #4fd18b; }
+.c-cmd { color: #eaeef4; }
+.c-flag { color: #f6a340; }
+.c-dim { color: #6b7a90; }
+.c-frost { color: #7ad6f0; }
+.c-ember { color: #ffb35a; }
+.c-file { color: #cbd6e6; }
+.c-hit { color: #4fd18b; }
+.term-body .gap { display: block; height: 10px; }
+
+/* docs.html uses smaller inline terminals — scope a compact variant */
+.doc-sec .term { margin-top: 18px; box-shadow: none; }
+.doc-sec .term-bar { padding: 10px 14px; }
+.doc-sec .term-bar .tl { width: 10px; height: 10px; }
+.doc-sec .term-bar .title { margin-left: 8px; font-size: 11.5px; }
+.doc-sec .term-body { padding: 16px 18px; font-size: 13px; line-height: 1.7; }
+.doc-sec .term-body .gap { height: 9px; }
+
+/* ---- SECTION SCAFFOLD (home) ---- */
+section { padding: 84px 0; }
+.sec-head { max-width: 62ch; margin-bottom: 44px; }
+.sec-eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .16em; text-transform: uppercase; color: var(--muted); margin-bottom: 14px; }
+h2 { font-family: var(--mono); font-size: clamp(26px, 4vw, 38px); letter-spacing: -.03em; line-height: 1.1; }
+.sec-lead { margin-top: 18px; font-size: 18px; color: var(--muted); max-width: 60ch; }
+
+/* ---- PROBLEM STRIP ---- */
+.band { background: var(--surface-2); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.prob-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: center; }
+@media (max-width: 760px) { .prob-grid { grid-template-columns: 1fr; gap: 28px; } }
+.prob-stat { font-family: var(--mono); font-size: clamp(40px, 8vw, 72px); font-weight: 700; letter-spacing: -.04em; line-height: 1; background: linear-gradient(120deg, var(--frost), var(--ember)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.prob-list { display: flex; flex-direction: column; gap: 18px; }
+.prob-item { display: flex; gap: 14px; }
+.prob-item .x { font-family: var(--mono); color: var(--ember); flex: none; }
+.prob-item p { color: var(--muted); }
+.prob-item strong { color: var(--ink); }
+
+/* ---- TWO LAYERS ---- */
+.layers { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+@media (max-width: 820px) { .layers { grid-template-columns: 1fr; } }
+.layer { border: 1px solid var(--line); border-radius: var(--radius); padding: 32px; background: var(--surface); position: relative; overflow: hidden; }
+.layer::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 3px; }
+.layer.cold::before { background: var(--frost); }
+.layer.warm::before { background: var(--ember); }
+.layer .tag { font-family: var(--mono); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; }
+.layer.cold .tag { color: var(--frost); }
+.layer.warm .tag { color: var(--ember); }
+.layer h3 { font-family: var(--mono); font-size: 22px; margin: 14px 0 12px; letter-spacing: -.02em; }
+.layer > p { color: var(--muted); margin-bottom: 20px; }
+.layer code { font-family: var(--mono); font-size: 13px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
+.op { border-top: 1px solid var(--line); padding-top: 16px; margin-top: 16px; }
+.op .opname { font-family: var(--mono); font-weight: 700; }
+.op .opname .cold { color: var(--frost); }
+.op .opname .warm { color: var(--ember); }
+.op p { font-size: 14.5px; color: var(--muted); margin-top: 4px; }
+
+/* ---- NOTEBOOK CENTERPIECE ---- */
+.nb-band { background:
+    radial-gradient(120% 100% at 85% 0%, color-mix(in srgb, var(--ember) 9%, transparent), transparent 60%),
+    var(--surface-2);
+  border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.nb-head .sec-eyebrow { color: var(--ember); }
+.nb-head h2 .warm { color: var(--ember); }
+
+.beats { display: flex; flex-direction: column; gap: 72px; }
+.beat { display: grid; grid-template-columns: 0.9fr 1.1fr; gap: 52px; align-items: center; }
+.beat.rev .beat-visual { order: -1; }
+@media (max-width: 820px) { .beat { grid-template-columns: 1fr; gap: 26px; } .beat.rev .beat-visual { order: 0; } }
+.beat-step { font-family: var(--mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: var(--ember); display: flex; align-items: center; gap: 12px; }
+.beat-step .n { width: 26px; height: 26px; border-radius: 50%; border: 1px solid color-mix(in srgb, var(--ember) 45%, var(--line)); display: grid; place-items: center; font-size: 12px; flex: none; }
+.beat h3 { font-family: var(--mono); font-size: clamp(22px, 3vw, 27px); letter-spacing: -.025em; margin: 20px 0 14px; }
+.beat-text > p { color: var(--muted); font-size: 15.5px; }
+.beat-text > p + p { margin-top: 12px; }
+.beat-text code { font-family: var(--mono); font-size: 13px; background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
+.beat .notyou { margin-top: 20px; font-family: var(--mono); font-size: 13px; color: var(--muted); }
+.beat .notyou s { color: color-mix(in srgb, var(--muted) 62%, transparent); }
+.beat .notyou b { color: var(--ember); font-weight: 600; }
+.nb-foot { margin-top: 64px; max-width: 62ch; margin-left: auto; margin-right: auto; text-align: center; }
+.nb-foot .lead { font-family: var(--mono); font-size: clamp(17px, 2.2vw, 21px); letter-spacing: -.02em; color: var(--ink); line-height: 1.4; }
+.nb-foot .sub { margin-top: 14px; font-size: 15px; color: var(--muted); }
+.nb-foot b { color: var(--ember); font-weight: 600; }
+
+.panel-label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-bottom: 12px; }
+
+/* note card (mirrors the kb note shape) */
+.notecard { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow: hidden; box-shadow: 0 18px 44px -30px rgba(3,10,22,.4); }
+.nc-top { padding: 18px 20px 16px; border-bottom: 1px solid var(--line); }
+.nc-kicker { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.type-pill { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; border: 1px solid color-mix(in srgb, var(--ember) 40%, var(--line)); color: var(--ember); }
+.type-pill.flow { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
+.pill { font-family: var(--mono); font-size: 11px; padding: 3px 9px 3px 8px; border-radius: 999px; display: inline-flex; align-items: center; gap: 6px; font-weight: 600; vertical-align: middle; }
+.pill .d { width: 7px; height: 7px; border-radius: 50%; }
+.pill.fresh { background: var(--ok-bg); color: var(--ok); }
+.pill.fresh .d { background: var(--ok); }
+.pill.changed { background: var(--warn-bg); color: var(--warn); }
+.pill.changed .d { background: var(--warn); }
+.nc-title { font-family: var(--mono); font-size: 17px; font-weight: 700; letter-spacing: -.02em; margin-top: 12px; }
+.nc-body { padding: 16px 20px 20px; }
+.nc-body p { font-size: 14px; color: var(--ink); }
+.nc-body p + p { margin-top: 10px; }
+.nc-body .link { color: var(--frost); font-family: var(--mono); font-size: 13.5px; }
+.nc-changed-note { margin-top: 12px; font-family: var(--mono); font-size: 12px; color: var(--warn); background: var(--warn-bg); border-radius: 8px; padding: 9px 11px; }
+.nc-anchors { margin-top: 16px; border-top: 1px solid var(--line); padding-top: 14px; }
+.nc-anchors .panel-label { margin-bottom: 10px; }
+.anchors { display: flex; flex-wrap: wrap; gap: 8px; }
+.anchor { font-family: var(--mono); font-size: 12px; padding: 4px 9px; border: 1px solid var(--line); border-radius: 7px; background: var(--surface-2); color: var(--ink); display: inline-flex; align-items: center; gap: 7px; }
+.anchor .d { width: 6px; height: 6px; border-radius: 50%; }
+.anchor.fresh .d { background: var(--ok); }
+.anchor.changed .d { background: var(--warn); }
+.anchor .sym { color: var(--muted); }
+
+/* viewer mock (kb view browser) */
+.viewer { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow: hidden; box-shadow: 0 18px 44px -30px rgba(3,10,22,.4); }
+.vw-chrome { display: flex; align-items: center; gap: 8px; padding: 10px 14px; background: var(--surface-2); border-bottom: 1px solid var(--line); }
+.vw-chrome .tl { width: 10px; height: 10px; border-radius: 50%; }
+.vw-chrome .tl:nth-child(1){ background:#ff5f57;} .vw-chrome .tl:nth-child(2){ background:#febc2e;} .vw-chrome .tl:nth-child(3){ background:#28c840;}
+.vw-url { margin-left: 10px; font-family: var(--mono); font-size: 11.5px; color: var(--muted); background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 3px 10px; flex: 1; }
+.vw-app { display: grid; grid-template-columns: 210px 1fr; min-height: 340px; }
+@media (max-width: 480px) { .vw-app { grid-template-columns: 1fr; } .vw-tree { display: none; } }
+.vw-topbar { grid-column: 1 / -1; display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
+.vw-kicker { font-family: var(--mono); font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); }
+.vw-repo { font-family: var(--mono); font-weight: 700; font-size: 14px; }
+.vw-count { margin-left: auto; font-family: var(--mono); font-size: 11.5px; color: var(--muted); }
+.vw-tabs { display: flex; gap: 6px; }
+.vw-tab { font-family: var(--mono); font-size: 11px; padding: 3px 10px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted); }
+.vw-tab.on { color: var(--frost); border-color: color-mix(in srgb,var(--frost) 45%,var(--line)); background: color-mix(in srgb,var(--frost) 8%,transparent); }
+.vw-tree { border-right: 1px solid var(--line); padding: 10px 8px; font-family: var(--mono); font-size: 12.5px; background: var(--surface-2); }
+.vw-row { display: flex; align-items: center; gap: 7px; padding: 4px 8px; border-radius: 6px; color: var(--ink); white-space: nowrap; }
+.vw-row .tw { color: var(--muted); width: 10px; display: inline-block; }
+.vw-row.dir { color: var(--muted); }
+.vw-row.file.on { background: color-mix(in srgb,var(--frost) 10%,transparent); color: var(--ink); }
+.vw-row .dd { width: 6px; height: 6px; border-radius: 50%; margin-left: auto; }
+.vw-row .dd.fresh { background: var(--ok); } .vw-row .dd.changed { background: var(--warn); }
+.vw-ind { padding-left: 16px; } .vw-ind2 { padding-left: 30px; }
+.vw-pane { padding: 18px 20px; }
+.vw-pane .nc-kicker { margin-bottom: 10px; }
+.vw-pane .nc-title { margin: 0 0 10px; }
+.vw-pane p { font-size: 13.5px; color: var(--ink); }
+
+/* ---- FLOW / ARCHITECTURE DIAGRAM ---- */
+.diagram { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 30px; overflow-x: auto; }
+.diagram svg { display: block; width: 100%; height: auto; min-width: 540px; }
+.d-box { fill: var(--surface-2); stroke: var(--line); }
+.d-frost { fill: none; stroke: var(--frost); }
+.d-ember { fill: none; stroke: var(--ember); }
+.d-label { fill: var(--ink); font-family: var(--mono); font-size: 15px; font-weight: 700; }
+.d-sub { fill: var(--muted); font-family: var(--sans); font-size: 12.5px; }
+.d-cmd { fill: var(--frost); font-family: var(--mono); font-size: 13px; }
+.d-arrow { stroke: var(--muted); stroke-width: 1.6; fill: none; }
+.d-arrowhead { fill: var(--muted); }
+.d-note { fill: var(--ember); font-family: var(--mono); font-size: 12px; }
+.doc-sec .diagram { padding: 24px; margin-top: 20px; }
+.doc-sec .diagram svg { min-width: 540px; }
+.doc-sec .d-label { font-size: 14px; }
+.doc-sec .d-sub, .doc-sec .d-cmd { font-size: 12px; }
+
+/* ---- COMPARISON ---- */
+.compare { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+@media (max-width: 760px) { .compare { grid-template-columns: 1fr; } }
+.cmp { border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; background: var(--surface); }
+.cmp.them { opacity: .82; }
+.cmp h4 { font-family: var(--mono); font-size: 15px; margin: 0 0 16px; letter-spacing: .02em; }
+.cmp.them h4 { color: var(--muted); }
+.cmp.us h4 { color: var(--frost); }
+.cmp ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px; }
+.cmp li { display: flex; gap: 11px; font-size: 14.5px; color: var(--muted); }
+.cmp li b { color: var(--ink); font-weight: 600; }
+.cmp .mk { font-family: var(--mono); flex: none; }
+.cmp.them .mk { color: #b0574f; }
+.cmp.us .mk { color: #3f9d6b; }
+
+/* ---- KEYNOTE callouts (home) ---- */
+.keynote { margin-top: 30px; border: 1px solid color-mix(in srgb, var(--frost) 42%, var(--line)); background: color-mix(in srgb, var(--frost) 6%, var(--surface)); border-radius: var(--radius); padding: 22px 26px; display: flex; gap: 22px; align-items: baseline; }
+.keynote .kk { font-family: var(--mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: var(--frost); white-space: nowrap; flex: none; }
+.keynote p { font-size: 15px; color: var(--ink); line-height: 1.65; }
+.keynote b { font-weight: 600; }
+@media (max-width: 640px) { .keynote { flex-direction: column; gap: 10px; } }
+.keynote code { font-family: var(--mono); font-size: 13px; background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
+.keynote.nb-share { border-color: color-mix(in srgb, var(--ember) 42%, var(--line)); background: color-mix(in srgb, var(--ember) 6%, var(--surface)); }
+.keynote.nb-share .kk { color: var(--ember); }
+
+/* ---- FRESHNESS / feature cards ---- */
+.fgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+@media (max-width: 820px) { .fgrid { grid-template-columns: 1fr; } }
+.fcard { border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; background: var(--surface); }
+.fcard .fnum { font-family: var(--mono); font-size: 12px; color: var(--frost); letter-spacing: .1em; }
+.fcard h4 { font-family: var(--mono); font-size: 16px; margin: 10px 0 8px; letter-spacing: -.01em; }
+.fcard p { font-size: 14.5px; color: var(--muted); }
+.doc-sec .fgrid { gap: 16px; margin-top: 20px; }
+.doc-sec .fcard { padding: 20px; }
+.doc-sec .fcard .fnum { font-size: 11.5px; }
+.doc-sec .fcard h4 { font-size: 15px; margin: 9px 0 7px; }
+.doc-sec .fcard p { font-size: 14px; }
+
+/* ---- LANGS ---- */
+.langs { display: flex; flex-wrap: wrap; gap: 9px; }
+.chip { font-family: var(--mono); font-size: 12.5px; padding: 5px 11px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); background: var(--surface); }
+.chip.hot { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
+.doc-sec .langs { margin-top: 20px; gap: 8px; }
+
+/* ---- INSTALL ---- */
+.install-term { max-width: 720px; }
+.install-term .term-body { font-size: 14px; }
+
+/* ---- FOOTER (shared; --nav-wrap controls width) ---- */
+footer { border-top: 1px solid var(--line); padding: 48px 0; }
+.foot-in { max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; align-items: center; }
+.foot-links { display: flex; gap: 22px; font-family: var(--mono); font-size: 13.5px; }
+.foot-links a { color: var(--muted); text-decoration: none; }
+.foot-links a:hover { color: var(--ink); }
+.foot-brand { font-family: var(--mono); color: var(--muted); font-size: 13.5px; }
+
+/* =========================================================
+   DOCS PAGE — sidebar + reference layout
+   ========================================================= */
+body.docs-page { --nav-wrap: 1200px; }
+
+.docs { max-width: 1200px; margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px 1fr; gap: 56px; align-items: start; }
+@media (max-width: 860px) { .docs { grid-template-columns: 1fr; gap: 0; } }
+
+.side { position: sticky; top: 60px; align-self: start; max-height: calc(100vh - 60px); overflow-y: auto; padding: 34px 0 60px; }
+@media (max-width: 860px) { .side { position: static; max-height: none; border-bottom: 1px solid var(--line); padding: 20px 0; } }
+.side-group { margin-bottom: 26px; }
+.side-group .gh { font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); opacity: .8; margin-bottom: 10px; padding-left: 12px; }
+.side a { display: block; font-size: 14px; color: var(--muted); text-decoration: none; padding: 5px 12px; border-left: 2px solid transparent; border-radius: 0 6px 6px 0; transition: color .12s, border-color .12s, background .12s; }
+.side a code { font-family: var(--mono); font-size: 13px; }
+.side a:hover { color: var(--ink); background: color-mix(in srgb, var(--frost) 5%, transparent); }
+.side a.active { color: var(--frost); border-left-color: var(--frost); background: color-mix(in srgb, var(--frost) 7%, transparent); }
+
+.content { min-width: 0; padding: 40px 0 100px; max-width: 760px; }
+.doc-sec { scroll-margin-top: 78px; padding-top: 26px; margin-top: 26px; }
+.doc-sec:first-child { margin-top: 0; padding-top: 8px; }
+.grp-head { border-top: 1px solid var(--line); padding-top: 40px; margin-top: 52px; }
+.grp-head:first-of-type { border-top: 0; margin-top: 0; padding-top: 0; }
+.kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 12px; }
+.content h1 { font-family: var(--mono); font-size: clamp(30px, 5vw, 40px); letter-spacing: -.035em; line-height: 1.05; }
+.content h2 { font-family: var(--mono); font-size: clamp(21px, 3vw, 26px); letter-spacing: -.02em; }
+.content > p, .doc-sec > p, .prose p { color: var(--muted); font-size: 16px; margin-top: 14px; }
+.prose p + p { margin-top: 12px; }
+.lead-p { font-size: 18px !important; color: var(--muted); margin-top: 18px; }
+.content b, .prose b { color: var(--ink); font-weight: 600; }
+.content em { color: var(--ink); font-style: italic; }
+p code, li code, .prose code { font-size: 13.5px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 1px 6px; color: var(--ink); }
+
+.cmd { margin-top: 8px; }
+.cmd .name { font-family: var(--mono); font-size: 24px; font-weight: 700; letter-spacing: -.02em; display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.cmd .name .c { color: var(--frost); }
+.cmd .name.warm .c { color: var(--ember); }
+.cmd .name .badge { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; align-self: center; }
+.cmd .sig { font-family: var(--mono); font-size: 14px; color: var(--muted); margin-top: 8px; }
+.cmd .desc { margin-top: 12px; color: var(--muted); font-size: 15.5px; }
+.cmd .desc b { color: var(--ink); }
+
+.flags { margin-top: 18px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+.flag-row { display: grid; grid-template-columns: 190px 1fr; gap: 16px; padding: 11px 16px; border-top: 1px solid var(--line); font-size: 14px; }
+.flag-row:first-child { border-top: 0; }
+.flag-row .fk { font-family: var(--mono); font-size: 12.5px; color: var(--frost); }
+.flag-row .fv { color: var(--muted); }
+.flag-row .fv b { color: var(--ink); }
+@media (max-width: 560px) { .flag-row { grid-template-columns: 1fr; gap: 4px; } }
+
+.callout { margin-top: 20px; border: 1px solid var(--line); border-left: 3px solid var(--frost); background: var(--surface-2); border-radius: 8px; padding: 14px 18px; font-size: 14.5px; color: var(--muted); }
+.callout.warm { border-left-color: var(--ember); }
+.callout b { color: var(--ink); }
+.callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--frost); display: block; margin-bottom: 6px; }
+.callout.warm .ct { color: var(--ember); }
+
+.types { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; margin-top: 20px; }
+@media (max-width: 680px) { .types { grid-template-columns: 1fr; } }
+.tcard { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 18px; }
+.tcard .tt { font-family: var(--mono); font-size: 13px; font-weight: 700; }
+.tcard.file .tt { color: var(--ember); } .tcard.flow .tt { color: var(--frost); } .tcard.lesson .tt { color: var(--ink); }
+.tcard p { font-size: 13.5px; color: var(--muted); margin-top: 7px; }
+
+ul.tight { margin: 14px 0 0; padding-left: 20px; color: var(--muted); font-size: 15px; }
+ul.tight li { margin-top: 8px; }
+ul.tight li b { color: var(--ink); }
+
+.subhead { font-family: var(--mono); margin-top: 30px; font-size: 15px; letter-spacing: .02em; }
+
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } html { scroll-behavior: auto !important; } }
+:focus-visible { outline: 2px solid var(--frost); outline-offset: 2px; border-radius: 4px; }


### PR DESCRIPTION
## Summary
- New `site/` — a home page (`index.html`) pitching the two-layer model (navigation index + agent-written notebook) and a sidebar docs reference (`docs.html`) for `find`/`gs`/`kb`, sharing one `styles.css`. Docs scope to the stable core and link out to README/ARCHITECTURE.md/PHILOSOPHY.md/TROUBLESHOOTING.md for exhaustive flags and internals, so the site doesn't have to track every detail.
- `site/llms.txt` — an agent-readable manifest generated from the README.
- `.github/workflows/pages.yml` — deploys `site/` to GitHub Pages via Actions on every push to `main` that touches it.
- README: added Website/Docs/npm links under the title.
- CLAUDE.md: noted that `site/docs.html` (and `index.html` if it affects the pitch) should be updated when a change is user-visible.
- Fixed install commands to the scoped package name `@cstart/coldstart` (the `coldstart` CLI binary itself is unchanged).

## Test plan
- [x] Enable **Settings → Pages → Source: GitHub Actions** (one-time, required before the workflow can publish)
- [x] Merge to `main` and confirm the `Deploy site to Pages` workflow run succeeds
- [ ] Visit `https://akashgoenka.github.io/coldstart/` and `https://akashgoenka.github.io/coldstart/docs.html` — check nav, in-page anchors, and cross-page links resolve
- [ ] Spot-check dark mode and a narrow viewport (mobile nav collapse, docs sidebar becoming static)

🤖 Generated with [Claude Code](https://claude.com/claude-code)