### PR TITLE
feat(notebook): gate capture on task durability

### DIFF
--- a/hooks/codex-kb-elicit.mjs
+++ b/hooks/codex-kb-elicit.mjs
@@ -147,9 +147,18 @@ function filesBlock(root, files) {
 // configuration: gates off via --force, capture-only) ---------------------------
 function buildCapturePrompt(root, block, sid) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
-process. We need to preserve the knowledge so that another agent in future can make use of your \
-findings. We are storing this in a notebook format and this notebook has to be backed by the \
-codebase you are working on.
+process — knowledge another agent in future could make use of.
+
+But before writing any notes, we need to decide whether the task you completed deserves a note. \
+If you were investigating on an older branch or doing a PR review, we may not need to save notes \
+because that code is not in the present — it's in the past or it's in the future. The notes that \
+we write are backed by the code in the present. This was an example to explain to you. As an \
+agent who worked on the current task, you know its exact intent and are best suited to decide \
+whether this task deserves a note. And if nothing about the current code is worth recording, \
+then no note is the right answer.
+
+Once you decide the task does deserve a note, we store it in a notebook format, and this \
+notebook has to be backed by the codebase you are working on.
 
 We need to save only the working knowledge of the codebase in a specific format so that it can \
 be searched and served to future cold agents. We don't need to store any general interaction you \
@@ -160,8 +169,9 @@ below format —
 
 THE NOTEBOOK HAS THREE CONTAINERS. Put each piece of knowledge in its one home:
 
-1. FILE notes — write one for EVERY file you actually read and understood this session. No \
-judgment call about whether it seems obvious. First decide the file's CHARACTER:
+1. FILE notes (if you decided to write a note for the entire task) — write one for EVERY file \
+you actually read and understood this session. No judgment call about whether it seems obvious. \
+First decide the file's CHARACTER:
    - hub    = the file has no single purpose (models.py, helpers, utils). Knowledge lives per \
 SYMBOL, as facets: one facet for each symbol you worked with this session. Only symbols you \
 have firsthand knowledge of — never enumerate the rest.

--- a/hooks/cursor-kb-elicit.mjs
+++ b/hooks/cursor-kb-elicit.mjs
@@ -154,9 +154,18 @@ function filesBlock(root, files) {
 // --- The capture prompt (kept identical to the Codex/Claude capture prompt) ----
 function buildCapturePrompt(root, block, sid) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
-process. We need to preserve the knowledge so that another agent in future can make use of your \
-findings. We are storing this in a notebook format and this notebook has to be backed by the \
-codebase you are working on.
+process — knowledge another agent in future could make use of.
+
+But before writing any notes, we need to decide whether the task you completed deserves a note. \
+If you were investigating on an older branch or doing a PR review, we may not need to save notes \
+because that code is not in the present — it's in the past or it's in the future. The notes that \
+we write are backed by the code in the present. This was an example to explain to you. As an \
+agent who worked on the current task, you know its exact intent and are best suited to decide \
+whether this task deserves a note. And if nothing about the current code is worth recording, \
+then no note is the right answer.
+
+Once you decide the task does deserve a note, we store it in a notebook format, and this \
+notebook has to be backed by the codebase you are working on.
 
 We need to save only the working knowledge of the codebase in a specific format so that it can \
 be searched and served to future cold agents. We don't need to store any general interaction you \
@@ -167,8 +176,9 @@ below format —
 
 THE NOTEBOOK HAS THREE CONTAINERS. Put each piece of knowledge in its one home:
 
-1. FILE notes — write one for EVERY file you actually read and understood this session. No \
-judgment call about whether it seems obvious. First decide the file's CHARACTER:
+1. FILE notes (if you decided to write a note for the entire task) — write one for EVERY file \
+you actually read and understood this session. No judgment call about whether it seems obvious. \
+First decide the file's CHARACTER:
    - hub    = the file has no single purpose (models.py, helpers, utils). Knowledge lives per \
 SYMBOL, as facets: one facet for each symbol you worked with this session. Only symbols you \
 have firsthand knowledge of — never enumerate the rest.

--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -149,9 +149,18 @@ function filesBlock(root, files) {
 // configuration: gates off via --force, capture-only) ---------------------------
 function buildCapturePrompt(root, block, sid) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
-process. We need to preserve the knowledge so that another agent in future can make use of your \
-findings. We are storing this in a notebook format and this notebook has to be backed by the \
-codebase you are working on.
+process — knowledge another agent in future could make use of.
+
+But before writing any notes, we need to decide whether the task you completed deserves a note. \
+If you were investigating on an older branch or doing a PR review, we may not need to save notes \
+because that code is not in the present — it's in the past or it's in the future. The notes that \
+we write are backed by the code in the present. This was an example to explain to you. As an \
+agent who worked on the current task, you know its exact intent and are best suited to decide \
+whether this task deserves a note. And if nothing about the current code is worth recording, \
+then no note is the right answer.
+
+Once you decide the task does deserve a note, we store it in a notebook format, and this \
+notebook has to be backed by the codebase you are working on.
 
 We need to save only the working knowledge of the codebase in a specific format so that it can \
 be searched and served to future cold agents. We don't need to store any general interaction you \
@@ -162,8 +171,9 @@ below format —
 
 THE NOTEBOOK HAS THREE CONTAINERS. Put each piece of knowledge in its one home:
 
-1. FILE notes — write one for EVERY file you actually read and understood this session. No \
-judgment call about whether it seems obvious. First decide the file's CHARACTER:
+1. FILE notes (if you decided to write a note for the entire task) — write one for EVERY file \
+you actually read and understood this session. No judgment call about whether it seems obvious. \
+First decide the file's CHARACTER:
    - hub    = the file has no single purpose (models.py, helpers, utils). Knowledge lives per \
 SYMBOL, as facets: one facet for each symbol you worked with this session. Only symbols you \
 have firsthand knowledge of — never enumerate the rest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cstart/coldstart",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What

Reworks the Stop/SubagentStop capture prompt across all three host hooks (Claude, Codex, Cursor) to add a **durability gate**: before writing anything, the agent decides whether the task deserves a note at all.

Work that is **backward-looking** (investigating an old branch/commit) or **forward-looking** (reviewing an unmerged PR) isn't the codebase as it stands, so it earns no note. The agent's knowledge of the task's intent is the decider, and an empty result is explicitly valid.

Also scopes the *"write one for EVERY file you read"* rule under that decision (`(if you decided to write a note for the entire task)`) so it no longer contradicts the gate.

## Why

The prior prompt presumed every task produced knowledge worth preserving, so agents wrote notes for transient work (PR reviews, historical investigations) that describe code not present on the current branch.

## Validation

Run on **arches-coldstart** (which points its live Stop hook at this repo): a real PR-review task correctly wrote **no note** for the unmerged PR (`origin/pr12826`) while leaving the existing `datatypes.py` notes untouched. The gate's reasoning was explicit: *"reviewing an unmerged PR, not investigating the current state of the checked-out codebase."*

Note: a prompt's effect on capture yield isn't unit-testable; this is a single-scenario behavioral check, not a full benchmark.

## Version

Patch bump `2.0.1 → 2.0.2`; also syncs `package-lock.json` (was stale at `2.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)