### PR TITLE
Site redesign: dark terminal-native home, snowflake logo, docs reskin, SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-<h1>❄️&nbsp; coldstart</h1>
+<img src="https://raw.githubusercontent.com/AkashGoenka/coldstart/main/site/logo.svg" alt="coldstart" width="76" height="76" />
+
+<h1>coldstart</h1>
 
 <p>
   <b>Codebase navigation and a codebase notebook for AI agents.</b><br/>

--- a/site/docs.css
+++ b/site/docs.css
@@ -1,0 +1,225 @@
+/* coldstart docs — dark design system, tokens matched to the home (styles.css)
+   frost = navigation/index, ember = notebook/memory */
+
+:root {
+  --bg: #070a11;
+  --surface: #0f1826;
+  --surface-2: #0b111c;
+  --ink: #e7eef8;
+  --muted: #8b9ab2;
+  --frost: #4fbfe0;
+  --frost-bright: #6fd3ef;
+  --ember: #ef9448;
+  --ember-bright: #ffb267;
+  --line: #1a2536;
+  --line-warm: #2a2218;
+  --term-bg: #05080e;
+  --term-ink: #c3d0e2;
+  --ok: #57cc92;
+  --ok-bg: #10241a;
+  --warn: #ef9448;
+  --warn-bg: #2a1e0c;
+  --mono: "SF Mono", ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --wrap: 1080px;
+  --nav-wrap: 1080px;
+  --radius: 12px;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; background: var(--bg); color: var(--ink);
+  font-family: var(--sans); line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "kern" 1;
+}
+.wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 24px; }
+a { color: inherit; }
+h1, h2, h3, h4 { text-wrap: balance; margin: 0; }
+p { margin: 0; }
+code { font-family: var(--mono); }
+
+.thread {
+  height: 2px; border: 0; margin: 0;
+  background: linear-gradient(90deg, var(--frost) 0%, var(--frost) 30%, var(--ember) 100%);
+  opacity: .7;
+}
+
+/* ---- NAV (shared; --nav-wrap lets docs.html run a wider bar) ---- */
+nav {
+  position: sticky; top: 0; z-index: 30;
+  background: color-mix(in srgb, var(--bg) 80%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; }
+.brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.02em; display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
+.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, var(--ember-bright), var(--frost)); box-shadow: 0 0 10px color-mix(in srgb, var(--frost) 50%, transparent); }
+.brand .mark { flex: none; }
+.mark { fill: none; }
+.fl { stroke-width: 2.1; stroke-linecap: round; }
+.s2 .fl { stroke: url(#warm); }
+.core { stroke: none; }
+.brand .tag { font-size: 12px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
+.nav-spacer { flex: 1; }
+.nav-links { display: flex; gap: 22px; font-size: 14px; font-family: var(--mono); }
+.nav-links a { color: var(--muted); text-decoration: none; transition: color .15s; }
+.nav-links a:hover { color: var(--ink); }
+.nav-cta { font-family: var(--mono); font-size: 13px; text-decoration: none; padding: 7px 14px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink); transition: border-color .15s, background .15s; }
+.nav-cta:hover { border-color: var(--frost); background: color-mix(in srgb, var(--frost) 10%, transparent); }
+@media (max-width: 860px) { .nav-links { display: none; } }
+
+/* ---- TERMINAL (docs command blocks) ---- */
+.term {
+  margin-top: 52px; background: var(--term-bg); border: 1px solid var(--line);
+  border-radius: var(--radius); overflow: hidden;
+}
+.term-bar { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,.06); }
+.term-bar .tl { width: 11px; height: 11px; border-radius: 50%; }
+.term-bar .tl:nth-child(1) { background: #ff5f57; }
+.term-bar .tl:nth-child(2) { background: #febc2e; }
+.term-bar .tl:nth-child(3) { background: #28c840; }
+.term-bar .title { margin-left: 10px; font-family: var(--mono); font-size: 12px; color: #5d6b83; }
+.term-body { padding: 20px 22px 26px; font-family: var(--mono); font-size: 13.5px; line-height: 1.75; color: var(--term-ink); overflow-x: auto; }
+.term-body .ln { white-space: pre; }
+.c-prompt { color: #4fd18b; }
+.c-cmd { color: #eef3fb; }
+.c-flag { color: #ffb267; }
+.c-dim { color: #5d6b83; }
+.c-frost { color: #6fd3ef; }
+.c-ember { color: #ffb267; }
+.c-file { color: #c3d0e2; }
+.c-hit { color: #4fd18b; }
+.term-body .gap { display: block; height: 10px; }
+
+/* docs.html uses smaller inline terminals — scope a compact variant */
+.doc-sec .term { margin-top: 18px; box-shadow: none; }
+.doc-sec .term-bar { padding: 10px 14px; }
+.doc-sec .term-bar .tl { width: 10px; height: 10px; }
+.doc-sec .term-bar .title { margin-left: 8px; font-size: 11.5px; }
+.doc-sec .term-body { padding: 16px 18px; font-size: 13px; line-height: 1.7; }
+.doc-sec .term-body .gap { height: 9px; }
+
+/* ---- LANGS ---- */
+.langs { display: flex; flex-wrap: wrap; gap: 9px; }
+.chip { font-family: var(--mono); font-size: 12.5px; padding: 5px 11px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); background: var(--surface-2); }
+.chip.hot { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
+.doc-sec .langs { margin-top: 20px; gap: 8px; }
+
+/* ---- pills (freshness) ---- */
+.pill { font-family: var(--mono); font-size: 11px; padding: 3px 9px 3px 8px; border-radius: 999px; display: inline-flex; align-items: center; gap: 6px; font-weight: 600; vertical-align: middle; }
+.pill .d { width: 7px; height: 7px; border-radius: 50%; }
+.pill.fresh { background: rgba(87,204,146,.14); color: var(--ok); }
+.pill.fresh .d { background: var(--ok); }
+.pill.changed { background: rgba(239,148,72,.14); color: var(--ember); }
+.pill.changed .d { background: var(--ember); }
+
+/* ---- FLOW / ARCHITECTURE DIAGRAM ---- */
+.diagram { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 30px; overflow-x: auto; }
+.diagram svg { display: block; width: 100%; height: auto; min-width: 540px; }
+.d-box { fill: var(--surface-2); stroke: var(--line); }
+.d-frost { fill: none; stroke: var(--frost); }
+.d-ember { fill: none; stroke: var(--ember); }
+.d-label { fill: var(--ink); font-family: var(--mono); font-size: 15px; font-weight: 700; }
+.d-sub { fill: var(--muted); font-family: var(--sans); font-size: 12.5px; }
+.d-cmd { fill: var(--frost); font-family: var(--mono); font-size: 13px; }
+.d-arrow { stroke: var(--muted); stroke-width: 1.6; fill: none; }
+.d-arrowhead { fill: var(--muted); }
+.d-note { fill: var(--ember); font-family: var(--mono); font-size: 12px; }
+.doc-sec .diagram { padding: 24px; margin-top: 20px; }
+.doc-sec .diagram svg { min-width: 540px; }
+.doc-sec .d-label { font-size: 14px; }
+.doc-sec .d-sub, .doc-sec .d-cmd { font-size: 12px; }
+
+/* ---- FRESHNESS / feature cards ---- */
+.fgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+@media (max-width: 820px) { .fgrid { grid-template-columns: 1fr; } }
+.fcard { border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; background: var(--surface); }
+.fcard .fnum { font-family: var(--mono); font-size: 12px; color: var(--frost); letter-spacing: .1em; }
+.fcard h4 { font-family: var(--mono); font-size: 16px; margin: 10px 0 8px; letter-spacing: -.01em; }
+.fcard p { font-size: 14.5px; color: var(--muted); }
+.doc-sec .fgrid { gap: 16px; margin-top: 20px; }
+.doc-sec .fcard { padding: 20px; }
+.doc-sec .fcard .fnum { font-size: 11.5px; }
+.doc-sec .fcard h4 { font-size: 15px; margin: 9px 0 7px; }
+.doc-sec .fcard p { font-size: 14px; }
+
+/* ---- FOOTER (shared; --nav-wrap controls width) ---- */
+footer { border-top: 1px solid var(--line); padding: 48px 0; }
+.foot-in { max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; align-items: center; }
+.foot-links { display: flex; gap: 22px; font-family: var(--mono); font-size: 13.5px; }
+.foot-links a { color: var(--muted); text-decoration: none; }
+.foot-links a:hover { color: var(--ink); }
+.foot-brand { font-family: var(--mono); color: var(--muted); font-size: 13.5px; }
+
+/* =========================================================
+   DOCS PAGE — sidebar + reference layout
+   ========================================================= */
+body.docs-page { --nav-wrap: 1200px; }
+
+.docs { max-width: 1200px; margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px 1fr; gap: 56px; align-items: start; }
+@media (max-width: 860px) { .docs { grid-template-columns: 1fr; gap: 0; } }
+
+.side { position: sticky; top: 60px; align-self: start; max-height: calc(100vh - 60px); overflow-y: auto; padding: 34px 0 60px; }
+@media (max-width: 860px) { .side { position: static; max-height: none; border-bottom: 1px solid var(--line); padding: 20px 0; } }
+.side-group { margin-bottom: 26px; }
+.side-group .gh { font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); opacity: .8; margin-bottom: 10px; padding-left: 12px; }
+.side a { display: block; font-size: 14px; color: var(--muted); text-decoration: none; padding: 5px 12px; border-left: 2px solid transparent; border-radius: 0 6px 6px 0; transition: color .12s, border-color .12s, background .12s; }
+.side a code { font-family: var(--mono); font-size: 13px; }
+.side a:hover { color: var(--ink); background: color-mix(in srgb, var(--frost) 8%, transparent); }
+.side a.active { color: var(--frost); border-left-color: var(--frost); background: color-mix(in srgb, var(--frost) 10%, transparent); }
+
+.content { min-width: 0; padding: 40px 0 100px; max-width: 760px; }
+.doc-sec { scroll-margin-top: 78px; padding-top: 26px; margin-top: 26px; }
+.doc-sec:first-child { margin-top: 0; padding-top: 8px; }
+.grp-head { border-top: 1px solid var(--line); padding-top: 40px; margin-top: 52px; }
+.grp-head:first-of-type { border-top: 0; margin-top: 0; padding-top: 0; }
+.kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 12px; }
+.content h1 { font-family: var(--mono); font-size: clamp(30px, 5vw, 40px); letter-spacing: -.035em; line-height: 1.05; }
+.content h2 { font-family: var(--mono); font-size: clamp(21px, 3vw, 26px); letter-spacing: -.02em; }
+.content > p, .doc-sec > p, .prose p { color: var(--muted); font-size: 16px; margin-top: 14px; }
+.prose p + p { margin-top: 12px; }
+.lead-p { font-size: 18px !important; color: var(--muted); margin-top: 18px; }
+.content b, .prose b { color: var(--ink); font-weight: 600; }
+.content em { color: var(--ink); font-style: italic; }
+p code, li code, .prose code { font-size: 13.5px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 1px 6px; color: var(--ink); }
+
+.cmd { margin-top: 8px; }
+.cmd .name { font-family: var(--mono); font-size: 24px; font-weight: 700; letter-spacing: -.02em; display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.cmd .name .c { color: var(--frost); }
+.cmd .name.warm .c { color: var(--ember); }
+.cmd .name .badge { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; align-self: center; }
+.cmd .sig { font-family: var(--mono); font-size: 14px; color: var(--muted); margin-top: 8px; }
+.cmd .desc { margin-top: 12px; color: var(--muted); font-size: 15.5px; }
+.cmd .desc b { color: var(--ink); }
+
+.flags { margin-top: 18px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+.flag-row { display: grid; grid-template-columns: 190px 1fr; gap: 16px; padding: 11px 16px; border-top: 1px solid var(--line); font-size: 14px; }
+.flag-row:first-child { border-top: 0; }
+.flag-row .fk { font-family: var(--mono); font-size: 12.5px; color: var(--frost); }
+.flag-row .fv { color: var(--muted); }
+.flag-row .fv b { color: var(--ink); }
+@media (max-width: 560px) { .flag-row { grid-template-columns: 1fr; gap: 4px; } }
+
+.callout { margin-top: 20px; border: 1px solid var(--line); border-left: 3px solid var(--frost); background: var(--surface-2); border-radius: 8px; padding: 14px 18px; font-size: 14.5px; color: var(--muted); }
+.callout.warm { border-left-color: var(--ember); }
+.callout b { color: var(--ink); }
+.callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--frost); display: block; margin-bottom: 6px; }
+.callout.warm .ct { color: var(--ember); }
+
+.types { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; margin-top: 20px; }
+@media (max-width: 680px) { .types { grid-template-columns: 1fr; } }
+.tcard { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 18px; }
+.tcard .tt { font-family: var(--mono); font-size: 13px; font-weight: 700; }
+.tcard.file .tt { color: var(--ember); } .tcard.flow .tt { color: var(--frost); } .tcard.lesson .tt { color: var(--ink); }
+.tcard p { font-size: 13.5px; color: var(--muted); margin-top: 7px; }
+
+ul.tight { margin: 14px 0 0; padding-left: 20px; color: var(--muted); font-size: 15px; }
+ul.tight li { margin-top: 8px; }
+ul.tight li b { color: var(--ink); }
+
+.subhead { font-family: var(--mono); margin-top: 30px; font-size: 15px; letter-spacing: .02em; }
+
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } html { scroll-behavior: auto !important; } }
+:focus-visible { outline: 2px solid var(--frost); outline-offset: 2px; border-radius: 4px; }

--- a/site/docs.html
+++ b/site/docs.html
@@ -4,14 +4,38 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>coldstart docs — commands, notebook, architecture</title>
-<meta name="description" content="coldstart command reference: find, gs, the kb notebook family, sharing a notebook with a team, and how the index stays fresh." />
-<link rel="stylesheet" href="styles.css" />
+<meta name="description" content="coldstart command reference: find, gs, the kb notebook family, sharing a notebook with a team, and how the index stays fresh. The stable core surface for the coldstart CLI and MCP server." />
+<meta name="keywords" content="coldstart docs, find, gs, kb notebook, agent memory, code navigation, MCP tools, index freshness" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#070a11" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/docs.html" />
+<link rel="icon" type="image/svg+xml" href="logo.svg" />
+<link rel="apple-touch-icon" href="logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="coldstart docs — commands, notebook, architecture" />
+<meta property="og:description" content="Command reference for find, gs, the kb notebook family, team sharing, and how the index stays fresh." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/docs.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/logo.svg" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="coldstart docs — commands, notebook, architecture" />
+<meta name="twitter:description" content="Command reference for find, gs, the kb notebook family, team sharing, and index freshness." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/logo.svg" />
+<link rel="stylesheet" href="docs.css" />
 </head>
 <body class="docs-page">
 
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+
 <nav>
   <div class="nav-in">
-    <a class="brand" href="index.html"><span class="dot"></span>coldstart <span class="tag">docs</span></a>
+    <a class="brand" href="index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">docs</span></a>
     <span class="nav-spacer"></span>
     <div class="nav-links">
       <a href="index.html">Home</a>
@@ -365,7 +389,7 @@
 <hr class="thread" />
 <footer>
   <div class="foot-in">
-    <span class="foot-brand"><a class="brand" href="index.html" style="font-size:15px"><span class="dot"></span>coldstart</a> — docs · MIT</span>
+    <span class="foot-brand"><a class="brand" href="index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> — docs · MIT</span>
     <div class="foot-links">
       <a href="index.html">Home</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>

--- a/site/index.html
+++ b/site/index.html
@@ -3,136 +3,138 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>coldstart — codebase memory &amp; navigation for AI agents</title>
-<meta name="description" content="coldstart is a fast static index that tells agents which files matter, plus a notebook the agent writes and maintains itself. No embeddings, no separate API key." />
+<title>coldstart — codebase memory &amp; navigation for AI coding agents</title>
+<meta name="description" content="coldstart gives a coding agent a notebook it writes itself, plus a fast static index to find the right file without wasted reads. No embeddings, no API key — it runs on the model you already pay for." />
+<meta name="keywords" content="AI coding agent, codebase navigation, code search, agent memory, notebook, Claude Code, Codex, Cursor, MCP, no embeddings, ripgrep, tree-sitter" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#070a11" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/" />
+<link rel="icon" type="image/svg+xml" href="logo.svg" />
+<link rel="apple-touch-icon" href="logo.svg" />
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="coldstart — codebase memory & navigation for AI coding agents" />
+<meta property="og:description" content="A notebook the agent writes itself, plus a fast index to find the right file without wasted reads. No embeddings, no API key — it runs on the model you already pay for." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/logo.svg" />
+<meta property="og:image:alt" content="coldstart logo — a snowflake with a warm ember core" />
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="coldstart — codebase memory & navigation for AI coding agents" />
+<meta name="twitter:description" content="A notebook the agent writes itself, plus a fast index to find the right file without wasted reads. No embeddings, no API key." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/logo.svg" />
+
 <link rel="stylesheet" href="styles.css" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "coldstart",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Node.js 18+",
+  "description": "Codebase navigation and a self-maintaining notebook for AI coding agents. A fast static index over paths, symbols, exports, and the import/call graph, plus durable agent-written notes kept honest by the index. No embeddings, no API key.",
+  "url": "https://akashgoenka.github.io/coldstart/",
+  "downloadUrl": "https://www.npmjs.com/package/@cstart/coldstart",
+  "codeRepository": "https://github.com/AkashGoenka/coldstart",
+  "license": "https://opensource.org/licenses/MIT",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
 </head>
 <body>
 
+<div class="progress" id="prog"></div>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="glow" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#ef9448" stop-opacity=".5"/><stop offset="70%" stop-color="#ef9448" stop-opacity=".1"/><stop offset="100%" stop-color="#ef9448" stop-opacity="0"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+
 <nav>
   <div class="nav-in">
-    <span class="brand"><span class="dot"></span>coldstart</span>
-    <span class="nav-spacer"></span>
+    <span class="brand"><svg class="mark s2" width="28" height="28" viewBox="0 0 32 32" aria-hidden="true"><circle class="core" cx="16" cy="16" r="8" fill="url(#glow)"/><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</span>
+    <span class="nav-sp"></span>
     <div class="nav-links">
-      <a href="#notebook">Notebook</a>
-      <a href="#flow">The&nbsp;flow</a>
-      <a href="#semantics">Philosophy</a>
       <a href="docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     </div>
     <a class="nav-cta" href="#install">Install</a>
   </div>
 </nav>
-<hr class="thread" />
 
+<!-- ===================== HERO ===================== -->
 <header class="hero">
-  <div class="wrap">
-    <div class="eyebrow">Codebase memory &amp; navigation for AI agents</div>
-    <h1 class="hero-title">Your agent lands <span class="cold">cold</span> in every repo.</h1>
-    <p class="hero-sub">coldstart is the layer that warms it up — a <strong>fast static index</strong> that answers <em>which files matter</em> in milliseconds, and a <strong>notebook the agent writes and maintains itself</strong> — a knowledge base that grows as the repo gets worked, so each agent starts with more context and wastes less effort re-deriving what's already known. No embeddings. No model to run. No service to babysit.</p>
-    <div class="cta-row">
-      <a class="btn btn-primary" href="#install">Get started →</a>
-      <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">View on GitHub →</a>
-      <span class="hero-note">MIT · Node 18+ · no separate API key</span>
+  <div class="wrap hero-grid">
+    <div>
+      <div class="eyebrow">Memory + navigation for coding agents</div>
+      <h1 class="title">Your agent relearns your codebase from <span class="cold">scratch</span> — every <span class="warm">session</span>.</h1>
+      <p class="hero-sub">coldstart gives a coding agent a <b>notebook it writes itself</b>, so what one session figures out, the next already knows — plus a fast index to <b>find the right file without three wrong reads</b>. No embeddings, no API key: it runs on the model you already pay for.</p>
+      <div class="cta">
+        <a class="btn btn-primary" href="#install">Install →</a>
+        <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">View on GitHub</a>
+        <span class="hero-note">MIT · Node 18+ · runs offline</span>
+      </div>
     </div>
-
-    <div class="term" role="img" aria-label="Terminal showing a coldstart find command and its ranked, evidence-backed results">
-      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">agent — coldstart</span></div>
+    <div class="term type" role="img" aria-label="Terminal: coldstart find returns ranked, evidence-backed files with a past agent's note, then gs shows one file's symbols and callers">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">agent — coldstart</span></div>
       <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart find</span> <span class="c-cmd">auth session cookie</span></span>
+<span class="l" style="animation-delay:.05s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart find</span> auth session cookie</span>
 <span class="gap"></span>
-<span class="ln"><span class="c-frost">src/auth/service.ts</span>  <span class="c-dim">·······</span> <span class="c-hit">3/3</span> <span class="c-dim">defines</span> auth, session, cookie</span>
-<span class="ln">  <span class="c-ember">Summary</span> <span class="c-dim">[fresh]</span> Signs and verifies session cookies; entry for login/logout.</span>
-<span class="ln"><span class="c-frost">src/middleware/session.ts</span>  <span class="c-dim">·</span> <span class="c-hit">2/3</span> <span class="c-dim">imports</span> session, cookie</span>
-<span class="ln"><span class="c-frost">src/routes/login.ts</span>  <span class="c-dim">·······</span> <span class="c-hit">2/3</span> <span class="c-dim">defines</span> auth · <span class="c-dim">imports</span> session</span>
+<span class="l" style="animation-delay:.5s"><span class="p-frost">src/auth/service.ts</span>  <span class="p-hit">3/3</span> <span class="p-dim">defines</span> auth, session, cookie</span>
+<span class="l" style="animation-delay:.7s">  <span class="p-ember">note</span> <span class="p-dim">[fresh]</span> signs &amp; verifies session cookies · login/logout entry</span>
+<span class="l" style="animation-delay:.9s"><span class="p-frost">src/middleware/session.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">imports</span> session, cookie</span>
+<span class="l" style="animation-delay:1.1s"><span class="p-frost">src/routes/login.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">defines</span> auth · <span class="p-dim">imports</span> session</span>
 <span class="gap"></span>
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart gs</span> <span class="c-cmd">src/auth/service.ts</span></span>
-<span class="ln"><span class="c-dim">symbols</span>  signCookie <span class="c-dim">L12</span> · verify <span class="c-dim">L34</span> · rotate <span class="c-dim">L61</span></span>
-<span class="ln"><span class="c-dim">callers</span>  verify ← <span class="c-file">middleware/session.ts</span>, <span class="c-file">routes/login.ts</span></span>
-<span class="ln"><span class="c-dim">imported by</span>  4 files <span class="c-dim">·</span> <span class="c-frost">→ Read only the method body you need</span></span>
+<span class="l" style="animation-delay:1.5s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart gs</span> src/auth/service.ts</span>
+<span class="l" style="animation-delay:1.7s"><span class="p-dim">symbols</span>  signCookie <span class="p-dim">L12</span> · verify <span class="p-dim">L34</span> · rotate <span class="p-dim">L61</span></span>
+<span class="l" style="animation-delay:1.9s"><span class="p-dim">callers</span>  verify ← <span class="p-file">middleware/session.ts</span>, <span class="p-file">routes/login.ts</span></span>
+<span class="l" style="animation-delay:2.1s"><span class="p-dim">imported by</span>  4 files <span class="p-frost">→ read only the body you need</span><span class="cursor"></span></span>
       </div>
     </div>
   </div>
 </header>
 
-<section class="band">
+<!-- ===================== NOTEBOOK (the lead value) ===================== -->
+<section id="notebook" class="nb">
   <div class="wrap">
-    <div class="prob-grid">
-      <div>
-        <div class="sec-eyebrow">The cold-start tax</div>
-        <div class="prob-stat">Find, not read.</div>
-      </div>
-      <div class="prob-list">
-        <div class="prob-item"><span class="x">✕</span><p><strong>Agents already read code well.</strong> That was never the bottleneck.</p></div>
-        <div class="prob-item"><span class="x">✕</span><p>They burn tokens <strong>finding</strong> the right file — speculative greps, three wrong reads before the right one.</p></div>
-        <div class="prob-item"><span class="x">✕</span><p>And they <strong>re-derive</strong> what a past session already figured out, every single time.</p></div>
-        <div class="prob-item"><span class="x">✕</span><p>coldstart does exactly those two things — <strong>cutting the tokens agents spend orienting</strong>, and getting out of the way.</p></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="layers">
-  <div class="wrap">
-    <div class="sec-head">
-      <div class="sec-eyebrow">Two layers, one tool</div>
-      <h2>Exact structure, plus honest memory.</h2>
-      <p class="sec-lead">The cold layer keeps facts <em>exact</em>. The warm layer keeps judgment <em>honest</em>. The agent supplies both — you maintain neither.</p>
-    </div>
-    <div class="layers">
-      <div class="layer cold">
-        <div class="tag">❄ Navigation · the index</div>
-        <h3>Find the file. Fast.</h3>
-        <p>A static index over paths, symbols, exports, and the import/call graph. Deterministic, offline, free — no API key, no GPU, no inference.</p>
-        <div class="op"><div class="opname"><span class="cold">find</span> &lt;terms&gt;</div><p>Ranks files by how many of your query terms each covers — and shows <em>why</em> it ranked: which terms it defines vs. imports.</p></div>
-        <div class="op"><div class="opname"><span class="cold">gs</span> &lt;file&gt;</div><p>One file's shape: symbols with line ranges, who imports it, who calls each symbol. Not a grep — the answer to "who uses this?"</p></div>
-      </div>
-      <div class="layer warm">
-        <div class="tag">✦ Notebook · the memory</div>
-        <h3>Remember what was learned.</h3>
-        <p>Durable notes about how <em>this</em> repo actually works — written by the agent after real tasks, recalled when a later task matches. You never touch it.</p>
-        <div class="op"><div class="opname"><span class="warm">Anchored</span> to real files</div><p>Every note cites concrete paths and symbols. The index re-checks each anchor's hash as code changes.</p></div>
-        <div class="op"><div class="opname"><span class="warm">Kept honest</span>, never stale</div><p>A note whose evidence drifted renders <code>[evidence changed]</code> — degraded to a labeled hypothesis, not served as a confident lie.</p></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ============ NOTEBOOK CENTERPIECE ============ -->
-<section id="notebook" class="nb-band">
-  <div class="wrap">
-    <div class="sec-head nb-head">
-      <div class="sec-eyebrow">The notebook · written and maintained by the agent</div>
-      <h2>A memory your agent keeps — <span class="warm">so you don't have to.</span></h2>
-      <p class="sec-lead">Most "knowledge bases" rot because a human has to feed them. coldstart's notebook is written by the agent that just did the work, kept honest by the index automatically, and recalled the moment it's relevant. There is no human in the maintenance loop — and that's the point.</p>
+    <div class="rise">
+      <div class="eyebrow warm">The notebook · written and kept by the agent</div>
+      <h2>The second time a question comes up,<br>the answer is <span class="warm">already written down.</span></h2>
+      <p class="lead">Most knowledge bases rot because a human has to feed them. This one is written by the agent that just did the work, kept honest by the index, and recalled when a later task matches. You never touch it — and that's what keeps it from going stale.</p>
     </div>
 
     <div class="beats">
-
-      <!-- BEAT 1 — the agent writes -->
-      <div class="beat">
-        <div class="beat-text">
-          <div class="beat-step"><span class="n">1</span>The agent writes it</div>
-          <h3>Authored after a real task.</h3>
-          <p>The reasoner that just solved something writes down what it learned — a file's purpose, a cross-file flow, a trap — with concrete citations, while the full context is still in hand. A write gate dedupes by concept, and concurrent agents never silently merge or lose a note.</p>
-          <div class="notyou"><s>You write the docs.</s> &nbsp;<b>The agent does.</b></div>
+      <!-- beat 1 -->
+      <div class="beat rise">
+        <div class="bt">
+          <div class="bstep"><span class="n">1</span>Written after a real task</div>
+          <h3>By the agent that just figured it out.</h3>
+          <p>The reasoner that solved something writes down what it learned — a file's purpose, a cross-file flow, a trap — with concrete citations, while the full context is still in hand. A write gate dedupes by concept, and concurrent agents never silently merge or lose a note.</p>
         </div>
-        <div class="beat-visual">
-          <div class="notecard">
-            <div class="nc-top">
-              <div class="nc-kicker">
-                <span class="type-pill">File note</span>
-                <span class="pill fresh"><span class="d"></span>fresh</span>
-              </div>
-              <div class="nc-title">src/models.py · Tile</div>
+        <div class="bv">
+          <div class="card">
+            <div class="card-top">
+              <div class="kick"><span class="pill-t">File note</span><span class="pill fresh"><span class="d"></span>fresh</span></div>
+              <div class="card-title">src/models.py · Tile</div>
             </div>
-            <div class="nc-body">
-              <p>Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps <span class="link">bbox</span> from the geometry before insert, so callers must never set bbox by hand.</p>
-              <p>Part of the <span class="link">[[tile-save-lifecycle]]</span> flow.</p>
-              <div class="nc-anchors">
-                <div class="panel-label">Anchors — the files this note rests on</div>
-                <div class="anchors">
-                  <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
-                  <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+            <div class="card-body">
+              <p>Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps <span class="mono-link">bbox</span> from the geometry before insert, so callers must never set bbox by hand.</p>
+              <p>Part of the <span class="mono-link">[[tile-save-lifecycle]]</span> flow.</p>
+              <div class="anchors">
+                <div class="lbl">Anchors — the files this note rests on</div>
+                <div class="arow">
+                  <span class="anc fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                  <span class="anc fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
                 </div>
               </div>
             </div>
@@ -140,31 +142,27 @@
         </div>
       </div>
 
-      <!-- BEAT 2 — the index keeps it honest (visual on left) -->
-      <div class="beat rev">
-        <div class="beat-text">
-          <div class="beat-step"><span class="n">2</span>The index keeps it honest</div>
-          <h3>Freshness is mechanical, not hoped-for.</h3>
-          <p>Every anchor is stamped with a content hash. The background keeper re-checks it as the code moves — no one has to remember to. When the evidence drifts, the note flips to <code>[evidence changed]</code> automatically: degraded to a labeled hypothesis, never served as a confident lie.</p>
-          <div class="notyou"><s>You prune stale docs.</s> &nbsp;<b>The hash does.</b></div>
+      <!-- beat 2 -->
+      <div class="beat rev rise">
+        <div class="bt">
+          <div class="bstep"><span class="n">2</span>Kept honest by a content hash</div>
+          <h3>Freshness is checked, not hoped for.</h3>
+          <p>Every anchor is stamped with a content hash. The background keeper re-checks it as the code moves — no one has to remember to. When the evidence drifts, the note flips to <code>[evidence changed]</code> automatically and is served as a labeled hypothesis to re-verify, never as fact.</p>
         </div>
-        <div class="beat-visual">
-          <div class="notecard">
-            <div class="nc-top">
-              <div class="nc-kicker">
-                <span class="type-pill">File note</span>
-                <span class="pill changed"><span class="d"></span>evidence changed</span>
-              </div>
-              <div class="nc-title">src/models.py · Tile</div>
+        <div class="bv">
+          <div class="card">
+            <div class="card-top">
+              <div class="kick"><span class="pill-t">File note</span><span class="pill chg"><span class="d"></span>evidence changed</span></div>
+              <div class="card-title">src/models.py · Tile</div>
             </div>
-            <div class="nc-body">
+            <div class="card-body">
               <p>Persists a map tile and its geometry. <b>save()</b> is the single write path…</p>
-              <div class="nc-changed-note">⚠ evidence changed: src/models.py — re-verify before relying on this note.</div>
-              <div class="nc-anchors">
-                <div class="panel-label">Anchors</div>
-                <div class="anchors">
-                  <span class="anchor changed"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
-                  <span class="anchor changed"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+              <div class="warnbar">⚠ evidence changed: src/models.py — re-verify before relying on this note.</div>
+              <div class="anchors">
+                <div class="lbl">Anchors</div>
+                <div class="arow">
+                  <span class="anc chg"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                  <span class="anc chg"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
                 </div>
               </div>
             </div>
@@ -172,54 +170,40 @@
         </div>
       </div>
 
-      <!-- BEAT 3 — the next agent recalls (visual = the kb view browser) -->
-      <div class="beat">
-        <div class="beat-text">
-          <div class="beat-step"><span class="n">3</span>The next agent recalls it</div>
-          <h3>Surfaced when it's relevant — not searched for.</h3>
-          <p>A matching prompt pulls the note in automatically, and a fresh <code>Summary</code> rides along on every <code>find</code>. The second time any question comes up, the answer is one <code>Read</code> away instead of a re-derivation.</p>
+      <!-- beat 3 -->
+      <div class="beat rise">
+        <div class="bt">
+          <div class="bstep"><span class="n">3</span>Recalled when it's relevant</div>
+          <h3>It comes to the next agent — unprompted.</h3>
+          <p>A matching prompt pulls the note in automatically, and a fresh <code>summary</code> rides along on every <code>find</code>. So the next agent starts a step ahead instead of re-deriving from scratch.</p>
           <p>And when a human wants to see what the agents have been keeping, <code>coldstart kb view</code> opens the whole notebook as one HTML file — no server.</p>
-          <div class="notyou"><s>You go looking.</s> &nbsp;<b>It comes to you.</b></div>
         </div>
-        <div class="beat-visual">
-          <div class="viewer" role="img" aria-label="Mock of the coldstart kb view notebook browser: a file tree on the left with per-file freshness dots, and a note pane on the right">
-            <div class="vw-chrome">
-              <span class="tl"></span><span class="tl"></span><span class="tl"></span>
-              <span class="vw-url">file:///arches/.coldstart/notebook/index.html</span>
-            </div>
-            <div class="vw-app">
-              <div class="vw-topbar">
-                <div>
-                  <div class="vw-kicker">coldstart notebook</div>
-                  <div class="vw-repo">arches</div>
-                </div>
-                <div class="vw-tabs" style="margin-left:20px">
-                  <span class="vw-tab on">Files</span>
-                  <span class="vw-tab">Flows</span>
-                </div>
-                <span class="vw-count">111 notes · 108 fresh</span>
+        <div class="bv">
+          <div class="viewer" role="img" aria-label="Mock of coldstart kb view: a file tree with per-file freshness dots on the left and a note pane on the right">
+            <div class="vchrome"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="vurl">file:///arches/.coldstart/notebook/index.html</span></div>
+            <div class="vapp">
+              <div class="vtop">
+                <div><div class="vk">coldstart notebook</div><div class="vrepo">arches</div></div>
+                <span class="vcount">111 notes · 108 fresh</span>
               </div>
-              <div class="vw-tree">
-                <div class="vw-row dir"><span class="tw">▾</span>src</div>
-                <div class="vw-row file on vw-ind"><span class="tw">•</span>models.py<span class="dd fresh"></span></div>
-                <div class="vw-row file vw-ind"><span class="tw">•</span>search.py<span class="dd fresh"></span></div>
-                <div class="vw-row dir vw-ind"><span class="tw">▾</span>views</div>
-                <div class="vw-row file vw-ind2"><span class="tw">•</span>tile.py<span class="dd changed"></span></div>
-                <div class="vw-row file vw-ind2"><span class="tw">•</span>map.py<span class="dd fresh"></span></div>
-                <div class="vw-row dir"><span class="tw">▸</span>api</div>
+              <div class="vtree">
+                <div class="vr dir"><span class="tw">▾</span>src</div>
+                <div class="vr on i1"><span class="tw">•</span>models.py<span class="dd fresh"></span></div>
+                <div class="vr i1"><span class="tw">•</span>search.py<span class="dd fresh"></span></div>
+                <div class="vr dir i1"><span class="tw">▾</span>views</div>
+                <div class="vr i2"><span class="tw">•</span>tile.py<span class="dd chg"></span></div>
+                <div class="vr i2"><span class="tw">•</span>map.py<span class="dd fresh"></span></div>
+                <div class="vr dir"><span class="tw">▸</span>api</div>
               </div>
-              <div class="vw-pane">
-                <div class="nc-kicker">
-                  <span class="type-pill">File note</span>
-                  <span class="pill fresh"><span class="d"></span>fresh</span>
-                </div>
-                <div class="nc-title">src/models.py · Tile</div>
-                <p style="margin-top:10px">Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps bbox from the geometry before insert.</p>
-                <div class="nc-anchors">
-                  <div class="panel-label">Anchors</div>
-                  <div class="anchors">
-                    <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
-                    <span class="anchor fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
+              <div class="vpane">
+                <div class="kick"><span class="pill-t">File note</span><span class="pill fresh"><span class="d"></span>fresh</span></div>
+                <div class="card-title" style="margin-top:10px">src/models.py · Tile</div>
+                <p>Persists a map tile and its geometry. <b>save()</b> is the single write path — it stamps bbox from the geometry before insert.</p>
+                <div class="anchors">
+                  <div class="lbl">Anchors</div>
+                  <div class="arow">
+                    <span class="anc fresh"><span class="d"></span>src/models.py <span class="sym">· Tile</span></span>
+                    <span class="anc fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
                   </div>
                 </div>
               </div>
@@ -227,102 +211,95 @@
           </div>
         </div>
       </div>
-
     </div>
 
-    <div class="keynote nb-share">
-      <span class="kk">Shared, it compounds faster</span>
-      <p><b>Commit the notebook to your repo and the whole team feeds one corpus.</b> The append-only logs union-merge across branches and machines — no conflicts — so every teammate's agent both reads from and adds to the same notebook. Private by default; opt in with <code>coldstart init --commit-notebook</code>. More sessions in, bigger notebook out.</p>
+    <div class="keynote rise">
+      <span class="kk">Shared, it compounds</span>
+      <p><b>Commit the notebook to your repo and the whole team feeds one corpus.</b> The append-only logs union-merge across branches and machines — no conflicts — so every teammate's agent both reads from and adds to the same notebook. Private by default; opt in with <code>coldstart init --commit-notebook</code>.</p>
     </div>
 
-    <div class="nb-foot">
-      <p class="lead">A knowledge base that compounds as the repo gets worked — more context for the next agent, less effort spent re-deriving what's already known.</p>
-      <p class="sub">Every note stays anchored to the code, so the <b>codebase remains the single source of truth</b> — the notebook only remembers what was learned about it, and the index keeps the two in sync.</p>
-    </div>
-
-    <div style="text-align:center;margin-top:30px">
-      <a class="btn btn-ghost" href="docs.html#notebook">Read more about the notebook →</a>
+    <div class="nb-foot rise">
+      <p class="big">A knowledge base that grows as the repo gets worked — more context for the next agent, less effort re-deriving what's already known.</p>
+      <p class="sm">Every note stays anchored to the code, so the <b>codebase remains the single source of truth</b> — the notebook only remembers what was learned about it, and the index keeps the two in sync.</p>
     </div>
   </div>
 </section>
 
-<section id="flow">
+<!-- ===================== NAVIGATION (the index — the other half + the foundation) ===================== -->
+<section id="flow" class="navsec">
   <div class="wrap">
-    <div class="sec-head">
-      <div class="sec-eyebrow">The intended flow</div>
-      <h2>find → gs → Read.</h2>
-      <p class="sec-lead">Orient with two cheap calls before you spend a single token reading. Notebook summaries ride along on <code style="font-family:var(--mono)">find</code>, so the orientation step often answers itself.</p>
+    <div class="rise">
+      <div class="eyebrow">The index · exact, offline, instant</div>
+      <h2>Memory compounds over time.<br>Navigation pays off on the first lookup.</h2>
+      <p class="lead">The same index that keeps the notebook honest also gets the agent to the right file — no embeddings, just paths, symbols, exports, and the import/call graph, patched in the background as you type. An agent dropped into an unfamiliar repo spends its first tokens <em>finding</em>, not thinking; coldstart replaces that with two cheap lookups, so the file it finally opens is the right one.</p>
     </div>
-    <div class="diagram">
-      <svg viewBox="0 0 900 260" role="img" aria-label="Flow diagram: find ranks candidate files, gs reveals one file's structure and callers, then Read opens only the needed method body">
-        <defs>
-          <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path class="d-arrowhead" d="M0,0 L9,4.5 L0,9 z"/></marker>
-        </defs>
-        <rect class="d-box d-frost" x="24" y="70" width="230" height="120" rx="10" stroke-width="2"/>
-        <text class="d-cmd" x="44" y="102">coldstart find</text>
-        <text class="d-label" x="44" y="132">Which files?</text>
-        <text class="d-sub" x="44" y="156">Ranked candidates,</text>
-        <text class="d-sub" x="44" y="174">each with its evidence.</text>
-        <text class="d-note" x="44" y="52">＋ notebook Summary [fresh]</text>
-        <path class="d-arrow" d="M262,130 L322,130" marker-end="url(#ah)"/>
-        <rect class="d-box d-frost" x="332" y="70" width="230" height="120" rx="10" stroke-width="2"/>
-        <text class="d-cmd" x="352" y="102">coldstart gs</text>
-        <text class="d-label" x="352" y="132">What is it?</text>
-        <text class="d-sub" x="352" y="156">Symbols, importers,</text>
-        <text class="d-sub" x="352" y="174">per-symbol callers.</text>
-        <path class="d-arrow" d="M570,130 L630,130" marker-end="url(#ah)"/>
-        <rect class="d-box d-ember" x="640" y="70" width="236" height="120" rx="10" stroke-width="2"/>
-        <text class="d-cmd" x="660" y="102" style="fill:var(--ember)">Read</text>
-        <text class="d-label" x="660" y="132">Just the body.</text>
-        <text class="d-sub" x="660" y="156">Open only the one</text>
-        <text class="d-sub" x="660" y="174">method you need.</text>
-      </svg>
+    <div class="ops rise">
+      <div class="op">
+        <div class="on">find <span class="sig">&lt;terms&gt;</span></div>
+        <h3>Which files are about this?</h3>
+        <p>Ranks files by how many of your terms each covers — and shows <em>why</em> it ranked: which terms it defines, which it imports. A repo-wide reference pass runs on ripgrep, so it keeps pace with raw grep.</p>
+      </div>
+      <div class="op">
+        <div class="on">gs <span class="sig">&lt;file&gt;</span></div>
+        <h3>What is this file, and who uses it?</h3>
+        <p>One file's symbols with line ranges, who imports it, and who calls each symbol — in a single call. Not a grep: the actual answer to <em>who uses this?</em></p>
+      </div>
     </div>
+    <div class="flow rise">
+      <div class="step cold"><div class="k">Which files?</div><div class="cmd">coldstart find</div><div class="cap">Ranked candidates, each with the evidence for why it ranked.</div></div>
+      <div class="arrow">→</div>
+      <div class="step cold"><div class="k">What is it? Who uses it?</div><div class="cmd">coldstart gs</div><div class="cap">One file's symbols, importers, and per-symbol callers.</div></div>
+      <div class="arrow">→</div>
+      <div class="step warm"><div class="k">Now read</div><div class="cmd">Read</div><div class="cap">Open the one method body that matters — not the whole file.</div></div>
+    </div>
+    <p class="tax-note rise">Two cheap calls before a single token is spent reading. <b>Notebook summaries ride along on find</b>, so the orientation step often answers itself.</p>
   </div>
 </section>
 
-<section id="semantics" class="band">
+<!-- ===================== PHILOSOPHY / why it works ===================== -->
+<section id="philosophy" class="phil">
   <div class="wrap">
-    <div class="sec-head">
-      <div class="sec-eyebrow">Bring your own semantics</div>
+    <div class="rise">
+      <div class="eyebrow">Bring your own semantics</div>
       <h2>No embeddings. On purpose.</h2>
-      <p class="sec-lead">Every consumer is already a frontier model — the best semantic reasoner in the loop. Pre-computing meaning at index time only duplicates that, worse and stale. So coldstart keeps what's cheap to keep <em>exact</em>, and leaves meaning to the reasoner holding the task.</p>
+      <p class="lead">Every consumer is already a frontier model — the best semantic reasoner in the loop. Pre-computing meaning at index time just duplicates that, worse and stale. So coldstart keeps what's cheap to keep <em style="font-style:italic;color:var(--text)">exact</em>, and leaves meaning to the reasoner holding the task.</p>
     </div>
-    <div class="compare">
-      <div class="cmp them">
+    <div class="cmp rise">
+      <div class="col them">
         <h4>Embedding-based code search</h4>
         <ul>
           <li><span class="mk">✕</span><span>Freezes <b>one interpretation</b> of a file at index time, blind to the task.</span></li>
-          <li><span class="mk">✕</span><span>A stale vector <b>fails silently</b> — a confident wrong answer you can't spot.</span></li>
-          <li><span class="mk">✕</span><span>Returns a <b>cosine score</b> the agent has to trust blindly or re-verify.</span></li>
+          <li><span class="mk">✕</span><span>A stale vector <b>fails silently</b> — a wrong answer that looks confident.</span></li>
+          <li><span class="mk">✕</span><span>Returns a <b>cosine score</b> the agent has to trust or re-verify.</span></li>
           <li><span class="mk">✕</span><span>Needs an API key, a GPU, inference on every query.</span></li>
         </ul>
       </div>
-      <div class="cmp us">
+      <div class="col us">
         <h4>coldstart</h4>
         <ul>
           <li><span class="mk">✓</span><span>The agent judges relevance <b>in context</b>, against the actual goal.</span></li>
           <li><span class="mk">✓</span><span>A background keeper patches facts in <b>milliseconds</b> — the index never lies about the tree.</span></li>
           <li><span class="mk">✓</span><span>Returns <b>checkable evidence</b> — this term is defined here, imported there.</span></li>
-          <li><span class="mk">✓</span><span>Runs on <b>the agent you already pay for</b> — deterministic, offline, no key, no GPU.</span></li>
+          <li><span class="mk">✓</span><span>Runs on <b>the agent you already pay for</b> — deterministic, offline, no key.</span></li>
         </ul>
       </div>
     </div>
-    <div class="keynote">
+    <div class="keynote cool rise">
       <span class="kk">No second bill</span>
-      <p><b>coldstart runs on the agent you already pay for.</b> The semantic layer <em>is</em> your Claude Code, Codex, or Cursor subscription — coldstart adds no inference of its own, so there's <b>no separate API key, no metered embeddings, nothing new to provision.</b> Most code-search tools bill you twice: once for the agent, again for their own model. This one doesn't.</p>
+      <p><b>coldstart adds no inference of its own.</b> The semantic layer is your Claude Code, Codex, or Cursor subscription — so there's no separate API key, no metered embeddings, nothing new to provision. Most code-search tools bill you twice: once for the agent, again for their own model. This one doesn't.</p>
     </div>
   </div>
 </section>
 
+<!-- ===================== LANGUAGES ===================== -->
 <section id="languages">
   <div class="wrap">
-    <div class="sec-head">
-      <div class="sec-eyebrow">Supported languages</div>
+    <div class="rise">
+      <div class="eyebrow">Supported languages</div>
       <h2>Parses 20+ languages. The notebook works on all of them.</h2>
-      <p class="sec-lead">Tree-sitter for the parsed set; content-hash freshness for the notebook means notes on a Swift repo are as trustworthy as notes on a TypeScript one.</p>
+      <p class="lead">Tree-sitter for the parsed set; content-hash freshness for the notebook, which means notes on a Swift repo are as trustworthy as notes on a TypeScript one.</p>
     </div>
-    <div class="langs">
+    <div class="langs rise">
       <span class="chip hot">TypeScript</span><span class="chip hot">JavaScript</span><span class="chip hot">JSX / TSX</span>
       <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
       <span class="chip hot">Python</span><span class="chip hot">Ruby (Rails)</span><span class="chip hot">Go</span><span class="chip hot">Rust</span>
@@ -332,25 +309,26 @@
   </div>
 </section>
 
-<section id="install">
+<!-- ===================== INSTALL ===================== -->
+<section id="install" class="install">
   <div class="wrap">
-    <div class="sec-head">
-      <div class="sec-eyebrow">Get started</div>
+    <div class="rise">
+      <div class="eyebrow">Get started</div>
       <h2>Two commands to warm the repo.</h2>
-      <p class="sec-lead">Works best with <strong>Claude Code</strong>, <strong>Codex</strong>, and <strong>Cursor</strong> — all get the fast CLI path <em>and</em> the notebook capture/recall hooks auto-wired by <code style="font-family:var(--mono)">init</code>.</p>
+      <p class="lead">Works best with <b>Claude Code</b>, <b>Codex</b>, and <b>Cursor</b> — all get the fast CLI path <em style="font-style:italic;color:var(--text)">and</em> the notebook capture/recall hooks, wired automatically by <code style="font-family:var(--mono)">init</code>.</p>
     </div>
-    <div class="term install-term">
-      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">your-project</span></div>
+    <div class="term install-term rise">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">your-project</span></div>
       <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">npm install -g @cstart/coldstart</span> <span class="c-flag">--legacy-peer-deps</span></span>
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">cd</span> your-project</span>
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">npm install -g @cstart/coldstart</span> <span class="p-flag">--legacy-peer-deps</span></span>
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">cd</span> your-project</span>
 <span class="gap"></span>
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span>   <span class="c-dim"># coldstart.md + client wiring + notebook + capture/recall hooks</span></span>
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">coldstart init</span>   <span class="p-dim"># coldstart.md + client wiring + notebook + hooks</span></span>
 <span class="gap"></span>
-<span class="ln"><span class="c-hit">✓</span> <span class="c-dim">index warming in the background — your first lookup is instant.</span></span>
+<span class="l"><span class="p-hit">✓</span> <span class="p-dim">index warming in the background — your first lookup is instant.</span></span>
       </div>
     </div>
-    <div class="cta-row">
+    <div class="cta rise">
       <a class="btn btn-primary" href="docs.html">Read the docs →</a>
       <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a class="btn btn-ghost" href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
@@ -358,19 +336,37 @@
   </div>
 </section>
 
-<hr class="thread" />
 <footer>
   <div class="foot-in">
-    <span class="foot-brand"><span class="brand" style="font-size:15px"><span class="dot"></span>coldstart</span> — codebase memory &amp; navigation for AI agents · MIT</span>
+    <span class="foot-brand"><span class="brand" style="font-size:14px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</span> &nbsp; navigation + memory for coding agents · MIT</span>
     <div class="foot-links">
-      <a href="docs.html">Docs</a>
-      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
-      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
-      <a href="#notebook">Notebook</a>
-      <a href="#semantics">Philosophy</a>
+      <a href="docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a><a href="#notebook">Notebook</a><a href="#philosophy">Philosophy</a>
     </div>
   </div>
 </footer>
 
+<script>
+(function(){
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var prog = document.getElementById('prog');
+  function onScroll(){
+    var h = document.documentElement;
+    var max = h.scrollHeight - h.clientHeight;
+    var pct = max > 0 ? (h.scrollTop || document.body.scrollTop) / max : 0;
+    if (prog) prog.style.width = (pct * 100).toFixed(2) + '%';
+  }
+  window.addEventListener('scroll', onScroll, {passive:true});
+  onScroll();
+  var rises = Array.prototype.slice.call(document.querySelectorAll('.rise'));
+  if (reduce || !('IntersectionObserver' in window)){
+    rises.forEach(function(el){ el.classList.add('in'); });
+    return;
+  }
+  var obs = new IntersectionObserver(function(entries){
+    entries.forEach(function(e){ if (e.isIntersecting){ e.target.classList.add('in'); obs.unobserve(e.target); } });
+  }, {rootMargin:'0px 0px -12% 0px', threshold:.08});
+  rises.forEach(function(el){ obs.observe(el); });
+})();
+</script>
 </body>
 </html>

--- a/site/logo.svg
+++ b/site/logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="coldstart">
+  <defs>
+    <radialGradient id="core" cx="38%" cy="32%" r="75%">
+      <stop offset="0" stop-color="#ffc884"/>
+      <stop offset="1" stop-color="#ef9448"/>
+    </radialGradient>
+    <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13">
+      <stop offset="0" stop-color="#ffb267"/>
+      <stop offset=".52" stop-color="#ef9448"/>
+      <stop offset="1" stop-color="#4fbfe0"/>
+    </radialGradient>
+    <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none"/>
+    <g id="flake">
+      <use href="#arm"/>
+      <use href="#arm" transform="rotate(60 16 16)"/>
+      <use href="#arm" transform="rotate(120 16 16)"/>
+      <use href="#arm" transform="rotate(180 16 16)"/>
+      <use href="#arm" transform="rotate(240 16 16)"/>
+      <use href="#arm" transform="rotate(300 16 16)"/>
+    </g>
+  </defs>
+  <g fill="none" stroke="url(#warm)" stroke-width="2.1" stroke-linecap="round">
+    <use href="#flake"/>
+    <circle cx="16" cy="16" r="6"/>
+  </g>
+  <circle cx="16" cy="16" r="3" fill="url(#core)"/>
+</svg>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://akashgoenka.github.io/coldstart/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/docs.html</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,401 +1,278 @@
-/* coldstart site — shared design system (frost = navigation/index, ember = notebook/memory) */
-
-:root {
-  --bg: #eaeef4;
-  --surface: #ffffff;
-  --surface-2: #f3f6fa;
-  --ink: #0d1520;
-  --muted: #55617a;
-  --frost: #16708f;
-  --frost-bright: #1f93b8;
-  --ember: #c26714;
-  --ember-bright: #d9781f;
-  --line: #d3dae6;
-  --term-bg: #0a0e15;
-  --term-ink: #cbd6e6;
-  --ok: #2f8f57;
-  --ok-bg: #e4f2ea;
-  --warn: #a85a06;
-  --warn-bg: #fbeede;
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --wrap: 1080px;
-  --nav-wrap: 1080px;
-  --radius: 12px;
+/* ============================================================
+   coldstart — home · notebook-first, destination nav (nextjs-style IA)
+   temperature = concept: frost = the cold exact index, ember = the warm memory.
+   ============================================================ */
+:root{
+  --void:#070a11;
+  --ink-1:#0b111c;
+  --ink-2:#0f1826;
+  --raised:#121d2d;
+  --warm-ground:#12100e;
+  --text:#e7eef8;
+  --muted:#8b9ab2;
+  --faint:#5d6b83;
+  --frost:#4fbfe0;
+  --frost-dim:#2f89a8;
+  --ember:#ef9448;
+  --ember-dim:#b96a28;
+  --ok:#57cc92;
+  --line:#1a2536;
+  --line-warm:#2a2218;
+  --mono:"SF Mono",ui-monospace,"JetBrains Mono","Fira Code",Menlo,Consolas,monospace;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --wrap:1120px;
 }
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #080b11; --surface: #0f151f; --surface-2: #0c1119; --ink: #dfe7f2;
-    --muted: #8b98b0; --frost: #5fc8e8; --frost-bright: #7ad6f0; --ember: #f6a340;
-    --ember-bright: #ffb35a; --line: #1c2634; --term-bg: #05080d; --term-ink: #cbd6e6;
-    --ok: #5fca8c; --ok-bg: #10241a; --warn: #f6a340; --warn-bg: #2a1e0c;
-  }
+*{box-sizing:border-box;}
+body{
+  margin:0;background:var(--void);color:var(--text);
+  font-family:var(--sans);line-height:1.6;-webkit-font-smoothing:antialiased;
+  font-feature-settings:"kern" 1;overflow-x:hidden;
 }
-:root[data-theme="dark"] {
-  --bg: #080b11; --surface: #0f151f; --surface-2: #0c1119; --ink: #dfe7f2;
-  --muted: #8b98b0; --frost: #5fc8e8; --frost-bright: #7ad6f0; --ember: #f6a340;
-  --ember-bright: #ffb35a; --line: #1c2634; --term-bg: #05080d; --term-ink: #cbd6e6;
-  --ok: #5fca8c; --ok-bg: #10241a; --warn: #f6a340; --warn-bg: #2a1e0c;
+a{color:inherit;text-decoration:none;}
+h1,h2,h3,h4{margin:0;text-wrap:balance;}
+p{margin:0;}
+code{font-family:var(--mono);}
+.wrap{max-width:var(--wrap);margin:0 auto;padding:0 28px;}
+
+/* scroll progress: a hairline that warms frost→ember as you descend */
+.progress{position:fixed;top:0;left:0;height:2px;width:0;z-index:60;
+  background:linear-gradient(90deg,var(--frost),var(--ember));
+  box-shadow:0 0 12px rgba(239,148,72,.4);transition:width .08s linear;}
+
+/* ---------- NAV ---------- */
+nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
+  background:color-mix(in srgb,var(--void) 78%,transparent);
+  border-bottom:1px solid var(--line);}
+.nav-in{max-width:var(--wrap);margin:0 auto;padding:0 28px;height:62px;
+  display:flex;align-items:center;gap:22px;}
+.brand{font-family:var(--mono);font-weight:700;font-size:17px;letter-spacing:-.02em;
+  display:flex;align-items:center;gap:10px;color:var(--text);}
+.brand .dot{width:11px;height:11px;border-radius:50%;
+  background:radial-gradient(circle at 34% 30%,var(--ember),var(--frost));
+  box-shadow:0 0 12px color-mix(in srgb,var(--frost) 60%,transparent);}
+.brand .mark{flex:none;}
+.mark{fill:none;}
+.fl{stroke-width:2.1;stroke-linecap:round;}
+.s2 .fl{stroke:url(#warm);}
+.core{stroke:none;}
+.nav-sp{flex:1;}
+.nav-links{display:flex;gap:24px;font-family:var(--mono);font-size:13.5px;}
+.nav-links a{color:var(--muted);transition:color .15s;}
+.nav-links a:hover{color:var(--text);}
+.nav-cta{font-family:var(--mono);font-size:13px;padding:8px 16px;border-radius:8px;
+  border:1px solid var(--line);color:var(--text);transition:.15s;}
+.nav-cta:hover{border-color:var(--frost);background:color-mix(in srgb,var(--frost) 12%,transparent);}
+@media(max-width:820px){.nav-links{display:none;}}
+
+/* ---------- shared section scaffold ---------- */
+section{padding:104px 0;position:relative;}
+.eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--frost);margin-bottom:22px;}
+.eyebrow.warm{color:var(--ember);}
+h2{font-family:var(--mono);font-weight:700;font-size:clamp(27px,4vw,40px);
+  letter-spacing:-.035em;line-height:1.08;}
+.lead{margin-top:20px;font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:60ch;}
+.lead b,.lead strong{color:var(--text);font-weight:600;}
+
+/* reveal on scroll */
+.rise{opacity:0;transform:translateY(22px);transition:opacity .7s ease,transform .7s ease;}
+.rise.in{opacity:1;transform:none;}
+
+/* ---------- HERO ---------- */
+.hero{padding:88px 0 96px;position:relative;overflow:hidden;}
+.hero::before{content:"";position:absolute;inset:0;z-index:-1;
+  background:
+    radial-gradient(80% 60% at 78% -10%,color-mix(in srgb,var(--frost) 15%,transparent),transparent 60%),
+    radial-gradient(60% 50% at 0% 8%,color-mix(in srgb,var(--frost) 8%,transparent),transparent 55%);}
+.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;gap:56px;align-items:center;}
+@media(max-width:940px){.hero-grid{grid-template-columns:1fr;gap:40px;}}
+h1.title{font-family:var(--mono);font-weight:700;
+  font-size:clamp(32px,5.2vw,54px);line-height:1.05;letter-spacing:-.04em;max-width:16ch;}
+h1.title .cold{color:var(--frost);}
+h1.title .warm{color:var(--ember);}
+.hero-sub{margin-top:26px;font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:52ch;}
+.hero-sub b{color:var(--text);font-weight:600;}
+.cta{margin-top:34px;display:flex;gap:14px;align-items:center;flex-wrap:wrap;}
+.btn{font-family:var(--mono);font-size:14px;padding:12px 22px;border-radius:9px;
+  display:inline-flex;align-items:center;gap:9px;transition:transform .12s,box-shadow .25s,border-color .15s,background .2s;}
+.btn-primary{background:var(--frost);color:#04121a;font-weight:600;}
+.btn-primary:hover{transform:translateY(-1px);box-shadow:0 12px 30px -8px color-mix(in srgb,var(--frost) 55%,transparent);}
+.btn-ghost{color:var(--text);border:1px solid var(--line);}
+.btn-ghost:hover{border-color:var(--frost);}
+.hero-note{font-family:var(--mono);font-size:12px;color:var(--faint);}
+
+/* ---------- TERMINAL ---------- */
+.term{background:#05080e;border:1px solid var(--line);border-radius:13px;overflow:hidden;
+  box-shadow:0 40px 90px -40px rgba(0,0,0,.9),0 0 0 1px rgba(255,255,255,.02) inset;}
+.term-bar{display:flex;align-items:center;gap:8px;padding:12px 15px;
+  border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.015);}
+.tl{width:11px;height:11px;border-radius:50%;}
+.tl:nth-child(1){background:#ff5f57;}.tl:nth-child(2){background:#febc2e;}.tl:nth-child(3){background:#28c840;}
+.term-title{margin-left:10px;font-family:var(--mono);font-size:11.5px;color:#5d6b83;}
+.term-body{padding:20px 22px 24px;font-family:var(--mono);font-size:13px;line-height:1.85;
+  color:#c3d0e2;overflow-x:auto;}
+.term-body .l{white-space:pre;display:block;}
+.p-prompt{color:#4fd18b;}.p-cmd{color:#eef3fb;}.p-flag{color:var(--ember);}
+.p-dim{color:#5d6b83;}.p-frost{color:#6fd3ef;}.p-ember{color:#ffb267;}
+.p-hit{color:#4fd18b;}.p-file{color:#c3d0e2;}
+.term-body .gap{display:block;height:9px;}
+/* typing reveal */
+.type .l{opacity:0;animation:lineIn .28s ease forwards;}
+@keyframes lineIn{to{opacity:1;}}
+.cursor{display:inline-block;width:8px;height:15px;vertical-align:-2px;margin-left:2px;
+  background:var(--frost);animation:blink 1.05s steps(1) infinite;}
+@keyframes blink{50%{opacity:0;}}
+
+/* ---------- NAVIGATION SECTION (the index) ---------- */
+.navsec{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.ops{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:44px;}
+@media(max-width:800px){.ops{grid-template-columns:1fr;}}
+.op{border:1px solid var(--line);border-radius:13px;background:var(--void);padding:30px;position:relative;overflow:hidden;}
+.op::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;background:var(--frost);opacity:.7;}
+.op .on{font-family:var(--mono);font-weight:700;font-size:20px;color:var(--frost);}
+.op .on .sig{color:var(--faint);font-weight:400;font-size:14px;}
+.op h3{font-family:var(--mono);font-size:16px;margin:14px 0 8px;letter-spacing:-.01em;color:var(--text);}
+.op p{color:var(--muted);font-size:14.5px;}
+.op p em{color:var(--text);font-style:normal;border-bottom:1px solid var(--frost-dim);}
+.flow{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;align-items:stretch;margin-top:22px;}
+@media(max-width:800px){.flow{grid-template-columns:1fr;gap:14px;}.flow .arrow{display:none;}}
+.step{border:1px solid var(--line);border-radius:12px;background:var(--void);padding:22px;}
+.step .k{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint);}
+.step .cmd{font-family:var(--mono);font-weight:700;font-size:17px;margin-top:10px;letter-spacing:-.02em;}
+.step.cold .cmd{color:var(--frost);}.step.warm .cmd{color:var(--ember);}
+.step .cap{color:var(--muted);font-size:13.5px;margin-top:9px;}
+.arrow{display:grid;place-items:center;font-family:var(--mono);color:var(--faint);font-size:20px;padding:0 18px;}
+.tax-note{margin-top:24px;font-family:var(--mono);font-size:13px;color:var(--muted);}
+.tax-note b{color:var(--frost);font-weight:600;}
+
+/* ---------- NOTEBOOK (the lead value, warm) ---------- */
+.nb{background:
+    radial-gradient(90% 70% at 82% -5%,color-mix(in srgb,var(--ember) 13%,transparent),transparent 58%),
+    radial-gradient(70% 60% at 0% 100%,color-mix(in srgb,var(--ember) 8%,transparent),transparent 55%),
+    var(--warm-ground);
+  border-top:1px solid var(--line-warm);border-bottom:1px solid var(--line-warm);}
+.nb h2 .warm{color:var(--ember);}
+.beats{display:flex;flex-direction:column;gap:78px;margin-top:60px;}
+.beat{display:grid;grid-template-columns:.92fr 1.08fr;gap:54px;align-items:center;}
+.beat.rev .bv{order:-1;}
+@media(max-width:860px){.beat{grid-template-columns:1fr;gap:28px;}.beat.rev .bv{order:0;}}
+.bstep{font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ember);display:flex;align-items:center;gap:12px;}
+.bstep .n{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;font-size:12px;flex:none;
+  border:1px solid color-mix(in srgb,var(--ember) 50%,var(--line-warm));color:var(--ember);}
+.beat h3{font-family:var(--mono);font-size:clamp(20px,2.6vw,25px);letter-spacing:-.025em;margin:18px 0 12px;}
+.bt p{color:var(--muted);font-size:15px;}
+.bt p+p{margin-top:11px;}
+.bt code{font-family:var(--mono);font-size:12.5px;background:rgba(239,148,72,.1);
+  border:1px solid var(--line-warm);border-radius:6px;padding:1px 7px;color:var(--ember);}
+.lbl{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);}
+
+/* note card */
+.card{border:1px solid var(--line-warm);border-radius:13px;background:#0e0c09;overflow:hidden;
+  box-shadow:0 30px 70px -40px rgba(0,0,0,.9);}
+.card-top{padding:17px 20px 15px;border-bottom:1px solid var(--line-warm);}
+.kick{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
+.pill-t{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;
+  padding:3px 9px;border-radius:999px;border:1px solid color-mix(in srgb,var(--ember) 45%,var(--line-warm));color:var(--ember);}
+.pill{font-family:var(--mono);font-size:10.5px;padding:3px 9px 3px 8px;border-radius:999px;
+  display:inline-flex;align-items:center;gap:6px;font-weight:600;}
+.pill .d{width:7px;height:7px;border-radius:50%;}
+.pill.fresh{background:rgba(87,204,146,.14);color:var(--ok);}.pill.fresh .d{background:var(--ok);}
+.pill.chg{background:rgba(239,148,72,.14);color:var(--ember);}.pill.chg .d{background:var(--ember);}
+.card-title{font-family:var(--mono);font-size:16px;font-weight:700;letter-spacing:-.02em;margin-top:12px;color:var(--text);}
+.card-body{padding:16px 20px 20px;}
+.card-body p{font-size:13.5px;color:#cdd8e8;}
+.card-body p+p{margin-top:9px;}
+.mono-link{color:var(--frost);font-family:var(--mono);font-size:13px;}
+.warnbar{margin-top:11px;font-family:var(--mono);font-size:11.5px;color:var(--ember);
+  background:rgba(239,148,72,.1);border-radius:8px;padding:9px 11px;}
+.anchors{margin-top:15px;border-top:1px solid var(--line-warm);padding-top:13px;}
+.anchors .lbl{margin-bottom:9px;}
+.arow{display:flex;flex-wrap:wrap;gap:8px;}
+.anc{font-family:var(--mono);font-size:11.5px;padding:4px 9px;border:1px solid var(--line-warm);
+  border-radius:7px;background:rgba(255,255,255,.02);color:#cdd8e8;display:inline-flex;align-items:center;gap:7px;}
+.anc .d{width:6px;height:6px;border-radius:50%;}
+.anc.fresh .d{background:var(--ok);}.anc.chg .d{background:var(--ember);}
+.anc .sym{color:var(--faint);}
+
+/* kb view mock */
+.viewer{border:1px solid var(--line-warm);border-radius:13px;background:#0e0c09;overflow:hidden;
+  box-shadow:0 30px 70px -40px rgba(0,0,0,.9);}
+.vchrome{display:flex;align-items:center;gap:8px;padding:10px 14px;background:rgba(255,255,255,.02);border-bottom:1px solid var(--line-warm);}
+.vchrome .tl{width:10px;height:10px;}
+.vurl{margin-left:8px;font-family:var(--mono);font-size:11px;color:var(--faint);
+  background:rgba(0,0,0,.4);border:1px solid var(--line-warm);border-radius:6px;padding:3px 10px;flex:1;}
+.vapp{display:grid;grid-template-columns:200px 1fr;min-height:300px;}
+@media(max-width:520px){.vapp{grid-template-columns:1fr;}.vtree{display:none;}}
+.vtop{grid-column:1/-1;display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid var(--line-warm);}
+.vrepo{font-family:var(--mono);font-weight:700;font-size:14px;}
+.vk{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);}
+.vcount{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);}
+.vtree{border-right:1px solid var(--line-warm);padding:10px 8px;font-family:var(--mono);font-size:12px;background:rgba(0,0,0,.25);}
+.vr{display:flex;align-items:center;gap:7px;padding:4px 8px;border-radius:6px;color:#cdd8e8;white-space:nowrap;}
+.vr .tw{color:var(--faint);width:10px;display:inline-block;}
+.vr.dir{color:var(--faint);}
+.vr.on{background:rgba(79,191,224,.1);}
+.vr .dd{width:6px;height:6px;border-radius:50%;margin-left:auto;}
+.vr .dd.fresh{background:var(--ok);}.vr .dd.chg{background:var(--ember);}
+.i1{padding-left:16px;}.i2{padding-left:30px;}
+.vpane{padding:18px 20px;}
+.vpane p{font-size:13px;color:#cdd8e8;margin-top:10px;}
+
+/* keynote */
+.keynote{margin-top:64px;border:1px solid color-mix(in srgb,var(--ember) 40%,var(--line-warm));
+  background:color-mix(in srgb,var(--ember) 7%,var(--warm-ground));border-radius:13px;
+  padding:24px 28px;display:flex;gap:24px;align-items:baseline;}
+.keynote .kk{font-family:var(--mono);font-size:11.5px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ember);white-space:nowrap;flex:none;}
+.keynote p{font-size:15px;color:var(--text);line-height:1.65;}
+.keynote b{font-weight:600;}
+.keynote code{font-family:var(--mono);font-size:13px;background:rgba(0,0,0,.35);border:1px solid var(--line-warm);border-radius:6px;padding:2px 7px;color:var(--ember);}
+@media(max-width:640px){.keynote{flex-direction:column;gap:10px;}}
+.nb-foot{margin-top:40px;max-width:64ch;margin-inline:auto;text-align:center;}
+.nb-foot .big{font-family:var(--mono);font-size:clamp(17px,2.2vw,21px);letter-spacing:-.02em;line-height:1.4;color:var(--text);}
+.nb-foot .sm{margin-top:13px;font-size:14.5px;color:var(--muted);}
+.nb-foot b{color:var(--ember);font-weight:600;}
+
+/* ---------- PHILOSOPHY / why it works ---------- */
+.phil{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.cmp{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-top:44px;}
+@media(max-width:760px){.cmp{grid-template-columns:1fr;}}
+.col{border:1px solid var(--line);border-radius:13px;background:var(--void);padding:26px;}
+.col.them{opacity:.72;}
+.col h4{font-family:var(--mono);font-size:14px;margin:0 0 16px;letter-spacing:.02em;}
+.col.them h4{color:var(--muted);}.col.us h4{color:var(--frost);}
+.col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:13px;}
+.col li{display:flex;gap:11px;font-size:14px;color:var(--muted);}
+.col li b{color:var(--text);font-weight:600;}
+.mk{font-family:var(--mono);flex:none;}
+.them .mk{color:#c46a60;}.us .mk{color:var(--ok);}
+.keynote.cool{border-color:color-mix(in srgb,var(--frost) 40%,var(--line));
+  background:color-mix(in srgb,var(--frost) 6%,var(--ink-1));}
+.keynote.cool .kk{color:var(--frost);}
+.keynote.cool code{color:var(--frost);}
+
+/* ---------- LANGUAGES ---------- */
+.langs{display:flex;flex-wrap:wrap;gap:9px;margin-top:40px;}
+.chip{font-family:var(--mono);font-size:12.5px;padding:5px 12px;border:1px solid var(--line);
+  border-radius:999px;color:var(--muted);background:var(--ink-1);}
+.chip.hot{color:var(--frost);border-color:color-mix(in srgb,var(--frost) 40%,var(--line));}
+
+/* ---------- INSTALL ---------- */
+.install-term{max-width:760px;margin-top:44px;}
+.install .cta{justify-content:flex-start;margin-top:30px;}
+
+/* ---------- FOOTER ---------- */
+footer{border-top:1px solid var(--line);padding:50px 0;}
+.foot-in{max-width:var(--wrap);margin:0 auto;padding:0 28px;display:flex;justify-content:space-between;
+  gap:24px;flex-wrap:wrap;align-items:center;}
+.foot-brand{font-family:var(--mono);color:var(--faint);font-size:13px;}
+.foot-links{display:flex;gap:22px;font-family:var(--mono);font-size:13px;}
+.foot-links a{color:var(--muted);}.foot-links a:hover{color:var(--text);}
+
+@media(prefers-reduced-motion:reduce){
+  *{animation:none!important;transition:none!important;}
+  .type .l{opacity:1!important;}.rise{opacity:1!important;transform:none!important;}
+  .cursor{display:none;}
 }
-:root[data-theme="light"] {
-  --bg: #eaeef4; --surface: #ffffff; --surface-2: #f3f6fa; --ink: #0d1520;
-  --muted: #55617a; --frost: #16708f; --frost-bright: #1f93b8; --ember: #c26714;
-  --ember-bright: #d9781f; --line: #d3dae6; --term-bg: #0a0e15; --term-ink: #cbd6e6;
-  --ok: #2f8f57; --ok-bg: #e4f2ea; --warn: #a85a06; --warn-bg: #fbeede;
-}
-
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-  margin: 0; background: var(--bg); color: var(--ink);
-  font-family: var(--sans); line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  font-feature-settings: "kern" 1;
-}
-.wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 24px; }
-a { color: inherit; }
-h1, h2, h3, h4 { text-wrap: balance; margin: 0; }
-p { margin: 0; }
-code { font-family: var(--mono); }
-
-.thread {
-  height: 2px; border: 0; margin: 0;
-  background: linear-gradient(90deg, var(--frost) 0%, var(--frost) 30%, var(--ember) 100%);
-  opacity: .55;
-}
-
-/* ---- NAV (shared; --nav-wrap lets docs.html run a wider bar) ---- */
-nav {
-  position: sticky; top: 0; z-index: 30;
-  background: color-mix(in srgb, var(--bg) 82%, transparent);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--line);
-}
-.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; }
-.brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.02em; display: flex; align-items: center; gap: 9px; text-decoration: none; color: var(--ink); }
-.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, var(--ember-bright), var(--frost)); box-shadow: 0 0 10px color-mix(in srgb, var(--frost) 50%, transparent); }
-.brand .tag { font-size: 12px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
-.nav-spacer { flex: 1; }
-.nav-links { display: flex; gap: 22px; font-size: 14px; font-family: var(--mono); }
-.nav-links a { color: var(--muted); text-decoration: none; transition: color .15s; }
-.nav-links a:hover { color: var(--ink); }
-.nav-cta { font-family: var(--mono); font-size: 13px; text-decoration: none; padding: 7px 14px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink); transition: border-color .15s, background .15s; }
-.nav-cta:hover { border-color: var(--frost); background: color-mix(in srgb, var(--frost) 8%, transparent); }
-@media (max-width: 860px) { .nav-links { display: none; } }
-
-/* ---- HERO ---- */
-.hero { padding: 76px 0 30px; }
-.eyebrow { font-family: var(--mono); font-size: 12.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 20px; display: flex; align-items: center; gap: 10px; }
-.eyebrow::before { content: ""; width: 26px; height: 1px; background: var(--frost); display: inline-block; }
-h1.hero-title {
-  font-family: var(--mono); font-weight: 700;
-  font-size: clamp(34px, 6vw, 58px); line-height: 1.04; letter-spacing: -.035em;
-  max-width: 15ch;
-}
-h1.hero-title .warm { color: var(--ember); }
-h1.hero-title .cold { color: var(--frost); }
-.hero-sub { margin-top: 24px; font-size: clamp(17px, 2.1vw, 20px); color: var(--muted); max-width: 56ch; }
-.hero-sub strong { color: var(--ink); font-weight: 600; }
-.cta-row { margin-top: 34px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
-.btn { font-family: var(--mono); font-size: 14.5px; text-decoration: none; padding: 12px 20px; border-radius: 9px; display: inline-flex; align-items: center; gap: 9px; transition: transform .12s, box-shadow .2s, background .2s; }
-.btn-primary { background: var(--ink); color: var(--bg); }
-.btn-primary:hover { transform: translateY(-1px); box-shadow: 0 8px 24px color-mix(in srgb, var(--frost) 30%, transparent); }
-.btn-ghost { color: var(--ink); border: 1px solid var(--line); }
-.btn-ghost:hover { border-color: var(--frost); }
-.hero-note { font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
-
-/* ---- TERMINAL (shared by home hero + docs command blocks) ---- */
-.term {
-  margin-top: 52px; background: var(--term-bg); border: 1px solid var(--line);
-  border-radius: var(--radius); overflow: hidden;
-}
-.hero .term, .install-term { box-shadow: 0 30px 70px -30px rgba(3,10,22,.6); }
-.term-bar { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,.06); }
-.term-bar .tl { width: 11px; height: 11px; border-radius: 50%; }
-.term-bar .tl:nth-child(1) { background: #ff5f57; }
-.term-bar .tl:nth-child(2) { background: #febc2e; }
-.term-bar .tl:nth-child(3) { background: #28c840; }
-.term-bar .title { margin-left: 10px; font-family: var(--mono); font-size: 12px; color: #6b7a90; }
-.term-body { padding: 20px 22px 26px; font-family: var(--mono); font-size: 13.5px; line-height: 1.75; color: var(--term-ink); overflow-x: auto; }
-.term-body .ln { white-space: pre; }
-.c-prompt { color: #4fd18b; }
-.c-cmd { color: #eaeef4; }
-.c-flag { color: #f6a340; }
-.c-dim { color: #6b7a90; }
-.c-frost { color: #7ad6f0; }
-.c-ember { color: #ffb35a; }
-.c-file { color: #cbd6e6; }
-.c-hit { color: #4fd18b; }
-.term-body .gap { display: block; height: 10px; }
-
-/* docs.html uses smaller inline terminals — scope a compact variant */
-.doc-sec .term { margin-top: 18px; box-shadow: none; }
-.doc-sec .term-bar { padding: 10px 14px; }
-.doc-sec .term-bar .tl { width: 10px; height: 10px; }
-.doc-sec .term-bar .title { margin-left: 8px; font-size: 11.5px; }
-.doc-sec .term-body { padding: 16px 18px; font-size: 13px; line-height: 1.7; }
-.doc-sec .term-body .gap { height: 9px; }
-
-/* ---- SECTION SCAFFOLD (home) ---- */
-section { padding: 84px 0; }
-.sec-head { max-width: 62ch; margin-bottom: 44px; }
-.sec-eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .16em; text-transform: uppercase; color: var(--muted); margin-bottom: 14px; }
-h2 { font-family: var(--mono); font-size: clamp(26px, 4vw, 38px); letter-spacing: -.03em; line-height: 1.1; }
-.sec-lead { margin-top: 18px; font-size: 18px; color: var(--muted); max-width: 60ch; }
-
-/* ---- PROBLEM STRIP ---- */
-.band { background: var(--surface-2); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.prob-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: center; }
-@media (max-width: 760px) { .prob-grid { grid-template-columns: 1fr; gap: 28px; } }
-.prob-stat { font-family: var(--mono); font-size: clamp(40px, 8vw, 72px); font-weight: 700; letter-spacing: -.04em; line-height: 1; background: linear-gradient(120deg, var(--frost), var(--ember)); -webkit-background-clip: text; background-clip: text; color: transparent; }
-.prob-list { display: flex; flex-direction: column; gap: 18px; }
-.prob-item { display: flex; gap: 14px; }
-.prob-item .x { font-family: var(--mono); color: var(--ember); flex: none; }
-.prob-item p { color: var(--muted); }
-.prob-item strong { color: var(--ink); }
-
-/* ---- TWO LAYERS ---- */
-.layers { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
-@media (max-width: 820px) { .layers { grid-template-columns: 1fr; } }
-.layer { border: 1px solid var(--line); border-radius: var(--radius); padding: 32px; background: var(--surface); position: relative; overflow: hidden; }
-.layer::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 3px; }
-.layer.cold::before { background: var(--frost); }
-.layer.warm::before { background: var(--ember); }
-.layer .tag { font-family: var(--mono); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; }
-.layer.cold .tag { color: var(--frost); }
-.layer.warm .tag { color: var(--ember); }
-.layer h3 { font-family: var(--mono); font-size: 22px; margin: 14px 0 12px; letter-spacing: -.02em; }
-.layer > p { color: var(--muted); margin-bottom: 20px; }
-.layer code { font-family: var(--mono); font-size: 13px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
-.op { border-top: 1px solid var(--line); padding-top: 16px; margin-top: 16px; }
-.op .opname { font-family: var(--mono); font-weight: 700; }
-.op .opname .cold { color: var(--frost); }
-.op .opname .warm { color: var(--ember); }
-.op p { font-size: 14.5px; color: var(--muted); margin-top: 4px; }
-
-/* ---- NOTEBOOK CENTERPIECE ---- */
-.nb-band { background:
-    radial-gradient(120% 100% at 85% 0%, color-mix(in srgb, var(--ember) 9%, transparent), transparent 60%),
-    var(--surface-2);
-  border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.nb-head .sec-eyebrow { color: var(--ember); }
-.nb-head h2 .warm { color: var(--ember); }
-
-.beats { display: flex; flex-direction: column; gap: 72px; }
-.beat { display: grid; grid-template-columns: 0.9fr 1.1fr; gap: 52px; align-items: center; }
-.beat.rev .beat-visual { order: -1; }
-@media (max-width: 820px) { .beat { grid-template-columns: 1fr; gap: 26px; } .beat.rev .beat-visual { order: 0; } }
-.beat-step { font-family: var(--mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: var(--ember); display: flex; align-items: center; gap: 12px; }
-.beat-step .n { width: 26px; height: 26px; border-radius: 50%; border: 1px solid color-mix(in srgb, var(--ember) 45%, var(--line)); display: grid; place-items: center; font-size: 12px; flex: none; }
-.beat h3 { font-family: var(--mono); font-size: clamp(22px, 3vw, 27px); letter-spacing: -.025em; margin: 20px 0 14px; }
-.beat-text > p { color: var(--muted); font-size: 15.5px; }
-.beat-text > p + p { margin-top: 12px; }
-.beat-text code { font-family: var(--mono); font-size: 13px; background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
-.beat .notyou { margin-top: 20px; font-family: var(--mono); font-size: 13px; color: var(--muted); }
-.beat .notyou s { color: color-mix(in srgb, var(--muted) 62%, transparent); }
-.beat .notyou b { color: var(--ember); font-weight: 600; }
-.nb-foot { margin-top: 64px; max-width: 62ch; margin-left: auto; margin-right: auto; text-align: center; }
-.nb-foot .lead { font-family: var(--mono); font-size: clamp(17px, 2.2vw, 21px); letter-spacing: -.02em; color: var(--ink); line-height: 1.4; }
-.nb-foot .sub { margin-top: 14px; font-size: 15px; color: var(--muted); }
-.nb-foot b { color: var(--ember); font-weight: 600; }
-
-.panel-label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-bottom: 12px; }
-
-/* note card (mirrors the kb note shape) */
-.notecard { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow: hidden; box-shadow: 0 18px 44px -30px rgba(3,10,22,.4); }
-.nc-top { padding: 18px 20px 16px; border-bottom: 1px solid var(--line); }
-.nc-kicker { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.type-pill { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; border: 1px solid color-mix(in srgb, var(--ember) 40%, var(--line)); color: var(--ember); }
-.type-pill.flow { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
-.pill { font-family: var(--mono); font-size: 11px; padding: 3px 9px 3px 8px; border-radius: 999px; display: inline-flex; align-items: center; gap: 6px; font-weight: 600; vertical-align: middle; }
-.pill .d { width: 7px; height: 7px; border-radius: 50%; }
-.pill.fresh { background: var(--ok-bg); color: var(--ok); }
-.pill.fresh .d { background: var(--ok); }
-.pill.changed { background: var(--warn-bg); color: var(--warn); }
-.pill.changed .d { background: var(--warn); }
-.nc-title { font-family: var(--mono); font-size: 17px; font-weight: 700; letter-spacing: -.02em; margin-top: 12px; }
-.nc-body { padding: 16px 20px 20px; }
-.nc-body p { font-size: 14px; color: var(--ink); }
-.nc-body p + p { margin-top: 10px; }
-.nc-body .link { color: var(--frost); font-family: var(--mono); font-size: 13.5px; }
-.nc-changed-note { margin-top: 12px; font-family: var(--mono); font-size: 12px; color: var(--warn); background: var(--warn-bg); border-radius: 8px; padding: 9px 11px; }
-.nc-anchors { margin-top: 16px; border-top: 1px solid var(--line); padding-top: 14px; }
-.nc-anchors .panel-label { margin-bottom: 10px; }
-.anchors { display: flex; flex-wrap: wrap; gap: 8px; }
-.anchor { font-family: var(--mono); font-size: 12px; padding: 4px 9px; border: 1px solid var(--line); border-radius: 7px; background: var(--surface-2); color: var(--ink); display: inline-flex; align-items: center; gap: 7px; }
-.anchor .d { width: 6px; height: 6px; border-radius: 50%; }
-.anchor.fresh .d { background: var(--ok); }
-.anchor.changed .d { background: var(--warn); }
-.anchor .sym { color: var(--muted); }
-
-/* viewer mock (kb view browser) */
-.viewer { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow: hidden; box-shadow: 0 18px 44px -30px rgba(3,10,22,.4); }
-.vw-chrome { display: flex; align-items: center; gap: 8px; padding: 10px 14px; background: var(--surface-2); border-bottom: 1px solid var(--line); }
-.vw-chrome .tl { width: 10px; height: 10px; border-radius: 50%; }
-.vw-chrome .tl:nth-child(1){ background:#ff5f57;} .vw-chrome .tl:nth-child(2){ background:#febc2e;} .vw-chrome .tl:nth-child(3){ background:#28c840;}
-.vw-url { margin-left: 10px; font-family: var(--mono); font-size: 11.5px; color: var(--muted); background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 3px 10px; flex: 1; }
-.vw-app { display: grid; grid-template-columns: 210px 1fr; min-height: 340px; }
-@media (max-width: 480px) { .vw-app { grid-template-columns: 1fr; } .vw-tree { display: none; } }
-.vw-topbar { grid-column: 1 / -1; display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
-.vw-kicker { font-family: var(--mono); font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); }
-.vw-repo { font-family: var(--mono); font-weight: 700; font-size: 14px; }
-.vw-count { margin-left: auto; font-family: var(--mono); font-size: 11.5px; color: var(--muted); }
-.vw-tabs { display: flex; gap: 6px; }
-.vw-tab { font-family: var(--mono); font-size: 11px; padding: 3px 10px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted); }
-.vw-tab.on { color: var(--frost); border-color: color-mix(in srgb,var(--frost) 45%,var(--line)); background: color-mix(in srgb,var(--frost) 8%,transparent); }
-.vw-tree { border-right: 1px solid var(--line); padding: 10px 8px; font-family: var(--mono); font-size: 12.5px; background: var(--surface-2); }
-.vw-row { display: flex; align-items: center; gap: 7px; padding: 4px 8px; border-radius: 6px; color: var(--ink); white-space: nowrap; }
-.vw-row .tw { color: var(--muted); width: 10px; display: inline-block; }
-.vw-row.dir { color: var(--muted); }
-.vw-row.file.on { background: color-mix(in srgb,var(--frost) 10%,transparent); color: var(--ink); }
-.vw-row .dd { width: 6px; height: 6px; border-radius: 50%; margin-left: auto; }
-.vw-row .dd.fresh { background: var(--ok); } .vw-row .dd.changed { background: var(--warn); }
-.vw-ind { padding-left: 16px; } .vw-ind2 { padding-left: 30px; }
-.vw-pane { padding: 18px 20px; }
-.vw-pane .nc-kicker { margin-bottom: 10px; }
-.vw-pane .nc-title { margin: 0 0 10px; }
-.vw-pane p { font-size: 13.5px; color: var(--ink); }
-
-/* ---- FLOW / ARCHITECTURE DIAGRAM ---- */
-.diagram { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 30px; overflow-x: auto; }
-.diagram svg { display: block; width: 100%; height: auto; min-width: 540px; }
-.d-box { fill: var(--surface-2); stroke: var(--line); }
-.d-frost { fill: none; stroke: var(--frost); }
-.d-ember { fill: none; stroke: var(--ember); }
-.d-label { fill: var(--ink); font-family: var(--mono); font-size: 15px; font-weight: 700; }
-.d-sub { fill: var(--muted); font-family: var(--sans); font-size: 12.5px; }
-.d-cmd { fill: var(--frost); font-family: var(--mono); font-size: 13px; }
-.d-arrow { stroke: var(--muted); stroke-width: 1.6; fill: none; }
-.d-arrowhead { fill: var(--muted); }
-.d-note { fill: var(--ember); font-family: var(--mono); font-size: 12px; }
-.doc-sec .diagram { padding: 24px; margin-top: 20px; }
-.doc-sec .diagram svg { min-width: 540px; }
-.doc-sec .d-label { font-size: 14px; }
-.doc-sec .d-sub, .doc-sec .d-cmd { font-size: 12px; }
-
-/* ---- COMPARISON ---- */
-.compare { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
-@media (max-width: 760px) { .compare { grid-template-columns: 1fr; } }
-.cmp { border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; background: var(--surface); }
-.cmp.them { opacity: .82; }
-.cmp h4 { font-family: var(--mono); font-size: 15px; margin: 0 0 16px; letter-spacing: .02em; }
-.cmp.them h4 { color: var(--muted); }
-.cmp.us h4 { color: var(--frost); }
-.cmp ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px; }
-.cmp li { display: flex; gap: 11px; font-size: 14.5px; color: var(--muted); }
-.cmp li b { color: var(--ink); font-weight: 600; }
-.cmp .mk { font-family: var(--mono); flex: none; }
-.cmp.them .mk { color: #b0574f; }
-.cmp.us .mk { color: #3f9d6b; }
-
-/* ---- KEYNOTE callouts (home) ---- */
-.keynote { margin-top: 30px; border: 1px solid color-mix(in srgb, var(--frost) 42%, var(--line)); background: color-mix(in srgb, var(--frost) 6%, var(--surface)); border-radius: var(--radius); padding: 22px 26px; display: flex; gap: 22px; align-items: baseline; }
-.keynote .kk { font-family: var(--mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: var(--frost); white-space: nowrap; flex: none; }
-.keynote p { font-size: 15px; color: var(--ink); line-height: 1.65; }
-.keynote b { font-weight: 600; }
-@media (max-width: 640px) { .keynote { flex-direction: column; gap: 10px; } }
-.keynote code { font-family: var(--mono); font-size: 13px; background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; color: var(--ink); }
-.keynote.nb-share { border-color: color-mix(in srgb, var(--ember) 42%, var(--line)); background: color-mix(in srgb, var(--ember) 6%, var(--surface)); }
-.keynote.nb-share .kk { color: var(--ember); }
-
-/* ---- FRESHNESS / feature cards ---- */
-.fgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
-@media (max-width: 820px) { .fgrid { grid-template-columns: 1fr; } }
-.fcard { border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; background: var(--surface); }
-.fcard .fnum { font-family: var(--mono); font-size: 12px; color: var(--frost); letter-spacing: .1em; }
-.fcard h4 { font-family: var(--mono); font-size: 16px; margin: 10px 0 8px; letter-spacing: -.01em; }
-.fcard p { font-size: 14.5px; color: var(--muted); }
-.doc-sec .fgrid { gap: 16px; margin-top: 20px; }
-.doc-sec .fcard { padding: 20px; }
-.doc-sec .fcard .fnum { font-size: 11.5px; }
-.doc-sec .fcard h4 { font-size: 15px; margin: 9px 0 7px; }
-.doc-sec .fcard p { font-size: 14px; }
-
-/* ---- LANGS ---- */
-.langs { display: flex; flex-wrap: wrap; gap: 9px; }
-.chip { font-family: var(--mono); font-size: 12.5px; padding: 5px 11px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); background: var(--surface); }
-.chip.hot { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
-.doc-sec .langs { margin-top: 20px; gap: 8px; }
-
-/* ---- INSTALL ---- */
-.install-term { max-width: 720px; }
-.install-term .term-body { font-size: 14px; }
-
-/* ---- FOOTER (shared; --nav-wrap controls width) ---- */
-footer { border-top: 1px solid var(--line); padding: 48px 0; }
-.foot-in { max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; align-items: center; }
-.foot-links { display: flex; gap: 22px; font-family: var(--mono); font-size: 13.5px; }
-.foot-links a { color: var(--muted); text-decoration: none; }
-.foot-links a:hover { color: var(--ink); }
-.foot-brand { font-family: var(--mono); color: var(--muted); font-size: 13.5px; }
-
-/* =========================================================
-   DOCS PAGE — sidebar + reference layout
-   ========================================================= */
-body.docs-page { --nav-wrap: 1200px; }
-
-.docs { max-width: 1200px; margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px 1fr; gap: 56px; align-items: start; }
-@media (max-width: 860px) { .docs { grid-template-columns: 1fr; gap: 0; } }
-
-.side { position: sticky; top: 60px; align-self: start; max-height: calc(100vh - 60px); overflow-y: auto; padding: 34px 0 60px; }
-@media (max-width: 860px) { .side { position: static; max-height: none; border-bottom: 1px solid var(--line); padding: 20px 0; } }
-.side-group { margin-bottom: 26px; }
-.side-group .gh { font-family: var(--mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); opacity: .8; margin-bottom: 10px; padding-left: 12px; }
-.side a { display: block; font-size: 14px; color: var(--muted); text-decoration: none; padding: 5px 12px; border-left: 2px solid transparent; border-radius: 0 6px 6px 0; transition: color .12s, border-color .12s, background .12s; }
-.side a code { font-family: var(--mono); font-size: 13px; }
-.side a:hover { color: var(--ink); background: color-mix(in srgb, var(--frost) 5%, transparent); }
-.side a.active { color: var(--frost); border-left-color: var(--frost); background: color-mix(in srgb, var(--frost) 7%, transparent); }
-
-.content { min-width: 0; padding: 40px 0 100px; max-width: 760px; }
-.doc-sec { scroll-margin-top: 78px; padding-top: 26px; margin-top: 26px; }
-.doc-sec:first-child { margin-top: 0; padding-top: 8px; }
-.grp-head { border-top: 1px solid var(--line); padding-top: 40px; margin-top: 52px; }
-.grp-head:first-of-type { border-top: 0; margin-top: 0; padding-top: 0; }
-.kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 12px; }
-.content h1 { font-family: var(--mono); font-size: clamp(30px, 5vw, 40px); letter-spacing: -.035em; line-height: 1.05; }
-.content h2 { font-family: var(--mono); font-size: clamp(21px, 3vw, 26px); letter-spacing: -.02em; }
-.content > p, .doc-sec > p, .prose p { color: var(--muted); font-size: 16px; margin-top: 14px; }
-.prose p + p { margin-top: 12px; }
-.lead-p { font-size: 18px !important; color: var(--muted); margin-top: 18px; }
-.content b, .prose b { color: var(--ink); font-weight: 600; }
-.content em { color: var(--ink); font-style: italic; }
-p code, li code, .prose code { font-size: 13.5px; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 1px 6px; color: var(--ink); }
-
-.cmd { margin-top: 8px; }
-.cmd .name { font-family: var(--mono); font-size: 24px; font-weight: 700; letter-spacing: -.02em; display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
-.cmd .name .c { color: var(--frost); }
-.cmd .name.warm .c { color: var(--ember); }
-.cmd .name .badge { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; align-self: center; }
-.cmd .sig { font-family: var(--mono); font-size: 14px; color: var(--muted); margin-top: 8px; }
-.cmd .desc { margin-top: 12px; color: var(--muted); font-size: 15.5px; }
-.cmd .desc b { color: var(--ink); }
-
-.flags { margin-top: 18px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
-.flag-row { display: grid; grid-template-columns: 190px 1fr; gap: 16px; padding: 11px 16px; border-top: 1px solid var(--line); font-size: 14px; }
-.flag-row:first-child { border-top: 0; }
-.flag-row .fk { font-family: var(--mono); font-size: 12.5px; color: var(--frost); }
-.flag-row .fv { color: var(--muted); }
-.flag-row .fv b { color: var(--ink); }
-@media (max-width: 560px) { .flag-row { grid-template-columns: 1fr; gap: 4px; } }
-
-.callout { margin-top: 20px; border: 1px solid var(--line); border-left: 3px solid var(--frost); background: var(--surface-2); border-radius: 8px; padding: 14px 18px; font-size: 14.5px; color: var(--muted); }
-.callout.warm { border-left-color: var(--ember); }
-.callout b { color: var(--ink); }
-.callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--frost); display: block; margin-bottom: 6px; }
-.callout.warm .ct { color: var(--ember); }
-
-.types { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; margin-top: 20px; }
-@media (max-width: 680px) { .types { grid-template-columns: 1fr; } }
-.tcard { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); padding: 18px; }
-.tcard .tt { font-family: var(--mono); font-size: 13px; font-weight: 700; }
-.tcard.file .tt { color: var(--ember); } .tcard.flow .tt { color: var(--frost); } .tcard.lesson .tt { color: var(--ink); }
-.tcard p { font-size: 13.5px; color: var(--muted); margin-top: 7px; }
-
-ul.tight { margin: 14px 0 0; padding-left: 20px; color: var(--muted); font-size: 15px; }
-ul.tight li { margin-top: 8px; }
-ul.tight li b { color: var(--ink); }
-
-.subhead { font-family: var(--mono); margin-top: 30px; font-size: 15px; letter-spacing: .02em; }
-
-@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } html { scroll-behavior: auto !important; } }
-:focus-visible { outline: 2px solid var(--frost); outline-offset: 2px; border-radius: 4px; }
+:focus-visible{outline:2px solid var(--frost);outline-offset:2px;border-radius:4px;}


### PR DESCRIPTION
Ports the approved v2 redesign from scratchpad into the real site, reskins the docs to match, adds the new logo everywhere, and bakes in SEO.

## What changed
- **Home (`site/index.html` + `styles.css`)** — dark, terminal-native redesign. nextjs-style destination nav (Docs · GitHub · npm), live `find`/`gs` hero terminal, notebook as the lead value, "No embeddings. On purpose." philosophy, scroll-progress hairline. Copy fixes baked in (killed the self-contradicting "find, not read"; plain eyebrows).
- **New logo (`site/logo.svg`)** — the S5 snowflake: frost→ember gradient arms + a ring around an ember core. Wired as the favicon on both pages, the nav/footer brand mark, and the README header (replaces the ❄️ emoji).
- **Docs reskin (`site/docs.css`)** — docs now render in the same dark system. Content is unchanged; `index.html` and `docs.html` each own their stylesheet now (they no longer share one).
- **SEO** — canonical URLs, Open Graph + Twitter cards, JSON-LD `SoftwareApplication`, `theme-color`, `robots.txt`, `sitemap.xml`.

## Deploy
No workflow change needed — `.github/workflows/pages.yml` already publishes the whole `site/` dir on push to `main`, so the new assets (logo, docs.css, robots, sitemap) ship automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)