### PR TITLE
fix(notebook): subagent capture restates its deliverable last

### DIFF
--- a/hooks/codex-kb-elicit.mjs
+++ b/hooks/codex-kb-elicit.mjs
@@ -145,7 +145,7 @@ function filesBlock(root, files) {
 
 // --- The capture prompt (v4, 2026-07-07 — user-authored opening; validation-run
 // configuration: gates off via --force, capture-only) ---------------------------
-function buildCapturePrompt(root, block, sid) {
+function buildCapturePrompt(root, block, sid, isSubagent) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
 process — knowledge another agent in future could make use of.
 
@@ -247,7 +247,9 @@ Spec shapes (only include fields you actually have):
                   "body":"what you looked for + that it is not there",
                   "scope":{"terms":["search","terms"]}}          (the search that proved it)
 
-When your notes are written, stop.`;
+${isSubagent
+  ? `Once you have handled the notebook — whether you wrote notes or decided none were needed — remember you were spawned as a subagent. The coordinator that spawned you receives ONLY your final message, so your last message must repeat, in full, the result you produced for it — your findings, not the notebook decision.`
+  : `When your notes are written, stop.`}`;
 }
 
 // --- stdin + guards -------------------------------------------------------------
@@ -328,7 +330,7 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
       process.exit(0);
     }
 
-    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid);
+    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid, input.hook_event_name === "SubagentStop");
     logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, hook: input.hook_event_name });
     log(`ELICIT session=${sid} agent=${aid} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
     process.stdout.write(JSON.stringify({ decision: "block", reason: prompt }));

--- a/hooks/cursor-kb-elicit.mjs
+++ b/hooks/cursor-kb-elicit.mjs
@@ -152,7 +152,7 @@ function filesBlock(root, files) {
 }
 
 // --- The capture prompt (kept identical to the Codex/Claude capture prompt) ----
-function buildCapturePrompt(root, block, sid) {
+function buildCapturePrompt(root, block, sid, isSubagent) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
 process — knowledge another agent in future could make use of.
 
@@ -255,7 +255,9 @@ Spec shapes (only include fields you actually have):
                   "body":"what you looked for + that it is not there",
                   "scope":{"terms":["search","terms"]}}          (the search that proved it)
 
-When your notes are written, stop.`;
+${isSubagent
+  ? `Once you have handled the notebook — whether you wrote notes or decided none were needed — remember you were spawned as a subagent. The coordinator that spawned you receives ONLY your final message, so your last message must repeat, in full, the result you produced for it — your findings, not the notebook decision.`
+  : `When your notes are written, stop.`}`;
 }
 
 // --- stdin + guards -------------------------------------------------------------
@@ -334,7 +336,7 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
       process.exit(0);
     }
 
-    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid);
+    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid, event === "subagentStop");
     logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, hook: event });
     log(`ELICIT session=${sid} agent=${aid} touched=${files.length} promptBytes=${prompt.length} event=${event || "?"}`);
     process.stdout.write(JSON.stringify({ followup_message: prompt }));

--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -147,7 +147,7 @@ function filesBlock(root, files) {
 
 // --- The capture prompt (v4, 2026-07-07 — user-authored opening; validation-run
 // configuration: gates off via --force, capture-only) ---------------------------
-function buildCapturePrompt(root, block, sid) {
+function buildCapturePrompt(root, block, sid, isSubagent) {
   return `You have completed a task now and have gathered knowledge as a part of that task or \
 process — knowledge another agent in future could make use of.
 
@@ -249,7 +249,9 @@ Spec shapes (only include fields you actually have):
                   "body":"what you looked for + that it is not there",
                   "scope":{"terms":["search","terms"]}}          (the search that proved it)
 
-When your notes are written, stop.`;
+${isSubagent
+  ? `Once you have handled the notebook — whether you wrote notes or decided none were needed — remember you were spawned as a subagent. The coordinator that spawned you receives ONLY your final message, so your last message must repeat, in full, the result you produced for it — your findings, not the notebook decision.`
+  : `When your notes are written, stop.`}`;
 }
 
 // --- stdin + guards -------------------------------------------------------------
@@ -333,7 +335,7 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
       process.exit(0);
     }
 
-    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid);
+    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid, input.hook_event_name === "SubagentStop");
     logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, hook: input.hook_event_name });
     log(`ELICIT session=${sid} agent=${aid} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
     process.stdout.write(JSON.stringify({ decision: "block", reason: prompt }));


### PR DESCRIPTION
## Problem

On `SubagentStop`, the capture hook returns `decision: "block"`, which forces the subagent to take one more turn — the notebook decision. A subagent's return value to its coordinator is its **last** message, so that capture turn overwrites the deliverable: a finder subagent returned *"No note to write"* instead of its findings, and the coordinator had to re-ask (verified in session `786073cb`, rec49 findings → rec52 decision returned → rec53 coordinator re-ask).

This is a property of capturing on `SubagentStop` at all, not of the prompt wording — but it only bites subagents, whose last message *is* their payload to the parent.

## Fix

Add a `SubagentStop`-only tail to the capture prompt (all three host hooks): after the notebook step, the subagent must repeat its result in full as its final message. The main-agent `Stop` prompt is untouched. Threaded via the `isSubagent` flag the hook already derives from `hook_event_name`.

Worst case (agent ignores it) = today's behavior, so it's a strict improvement.

## Validation (arches-coldstart, live hook)

Two finder subagents reviewing PR #12826, no checkout:
1. **Fix works** — each subagent's final message is its restated findings list (`FINAL FINDINGS:` / `FINDINGS FOR COORDINATOR:`), findings inline, not a dangling "findings above" reference.
2. **No re-ask** — both subagent transcripts end at the findings; no coordinator "I need your actual findings" injection (contrast: prior run required one).
3. **No capture dilution** — both still made the notebook decision (gate correctly declined the PR-review note) *before* restating.

No version bump — rides under the still-unreleased 2.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)