### PR TITLE
kb hooks: incremental long-session capture + gate the search checkpoint on writes

### DIFF
--- a/hooks/codex-kb-elicit.mjs
+++ b/hooks/codex-kb-elicit.mjs
@@ -295,17 +295,20 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
     if (input.stop_hook_active === true) { log("SKIP stop_hook_active"); process.exit(0); }
 
     // Codex session_id identifies a thread; turn_id identifies one user turn.
-    // Capture once per turn so a resumed thread can contribute new knowledge.
+    // Capture across the whole thread, incrementally — a resumed thread keeps
+    // contributing new knowledge.
     const sid = String(input.session_id || "").replace(/[^A-Za-z0-9_-]/g, "");
     if (!sid) { log("SKIP no-session-id"); process.exit(0); }
-    const tid = String(input.turn_id || sid).replace(/[^A-Za-z0-9_-]/g, "") || sid;
 
-    // Guard 2: one elicitation per (session, agent) — subagents share the
-    // parent session_id, so the marker is scoped by agent too.
+    // Guard 2: capture across the session, but only files not yet offered. The
+    // old per-turn marker re-offered EVERY touched file on every turn; instead we
+    // remember which files were already offered and elicit only the new ones (the
+    // delta is computed below). Subagents share the parent session_id, so the
+    // record is scoped by agent too.
     const aid = String(input.agent_id || "main").replace(/[^A-Za-z0-9_-]/g, "") || "main";
-    const marker = join(tmpdir(), `coldstart-codex-kb-${tid}-${aid}.done`);
-    if (existsSync(marker)) { log(`SKIP already-elicited session=${sid} agent=${aid}`); process.exit(0); }
-    try { writeFileSync(marker, String(Date.now())); } catch { /* best effort */ }
+    const marker = join(tmpdir(), `coldstart-codex-kb-${sid}-${aid}.json`);
+    let offered = new Set();
+    try { offered = new Set(JSON.parse(readFileSync(marker, "utf8")).files || []); } catch { /* first Stop of this session */ }
 
     // Codex supplies the child's own rollout as agent_transcript_path on
     // SubagentStop. Its transcript_path is the parent's rollout at that event.
@@ -321,18 +324,25 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
     // Ephemeral Codex runs deliberately expose no transcript path. Fail open:
     // navigation/recall still work, but capture has no trustworthy evidence.
     const files = transcriptPath ? touchedFiles(transcriptPath, root) : [];
+    // Delta: only files not already offered on an earlier Stop this session.
+    const newFiles = files.filter((f) => !offered.has(f));
 
-    // FAST-EXIT only when the agent touched NO repo file at all (pure
-    // orchestration / Q&A). Anything touched → the agent judges what's worth
-    // capturing; the hook never guesses from read modality.
-    if (!files.length) {
-      log(`FAST-EXIT zero touched files session=${sid} agent=${aid} event=${input.hook_event_name || "?"}`);
+    // FAST-EXIT when there is nothing NEW to capture — either no repo file was
+    // touched at all (pure orchestration / Q&A) or every touched file was already
+    // offered on a previous Stop. No record is written on this path, so an early
+    // no-op Stop can never burn the session's capture.
+    if (!newFiles.length) {
+      log(`FAST-EXIT no-new-files session=${sid} agent=${aid} touched=${files.length} event=${input.hook_event_name || "?"}`);
       process.exit(0);
     }
 
-    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid, input.hook_event_name === "SubagentStop");
-    logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, hook: input.hook_event_name });
-    log(`ELICIT session=${sid} agent=${aid} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
+    // Record everything now offered BEFORE returning the block, so the post-write
+    // re-Stop and every later Stop skip these files.
+    try { writeFileSync(marker, JSON.stringify({ files: [...offered, ...newFiles], ts: Date.now() })); } catch { /* best effort */ }
+
+    const prompt = buildCapturePrompt(root, filesBlock(root, newFiles), sid, input.hook_event_name === "SubagentStop");
+    logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, new: newFiles.length, hook: input.hook_event_name });
+    log(`ELICIT session=${sid} agent=${aid} new=${newFiles.length} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
     process.stdout.write(JSON.stringify({ decision: "block", reason: prompt }));
   } catch (e) {
     log(`handler ${e?.stack || e}`); // fail-open: no stdout → stop allowed

--- a/hooks/codex-nudge-handler.mjs
+++ b/hooks/codex-nudge-handler.mjs
@@ -37,6 +37,7 @@
 
 import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { canonicalFindKey } from "./canonical-find-key.mjs";
@@ -66,6 +67,48 @@ const GS_FALLBACK_RE = /NOT a declared symbol here|no declared symbol matches/;
 const SEARCH_RE =
   /(^|[;&|]|\s)(grep|egrep|fgrep|rg)\b|git\s+grep|git\s+log|(^|[;&|]|\s)find\s|(^|[;&|]|\s)ls\b|(^|[;&|]|\s)cat\b/;
 const GS_FILE_RE = /(?:coldstart|index\.js)\s+gs\s+(\S+)/;
+
+// The checkpoint (detector 4) only makes sense when the agent may be SPINNING IN
+// SEARCH — never mid-implementation. A write is the signal that it is producing,
+// not spinning. Fast per-call detection: structured write tools + write-shaped
+// shell (sed -i, redirections, cp/mv/rm, git apply/checkout…). This is the
+// fallback; git ground-truth (below) is authoritative when the repo is a git repo.
+const WRITE_TOOLS = new Set([
+  "Edit", "Write", "MultiEdit", "NotebookEdit", // Claude
+  "apply_patch", "edit_file", "write_file", "create_file", // Codex / Cursor / MCP writers
+]);
+const WRITE_CMD_RE =
+  /(^|[\s;&|(])(sed\s+-i|tee|dd|truncate|patch|apply_patch|cp|mv|rm|mkdir|touch|install)\b|>>?(?!\s*\/dev\/null)|git\s+(apply|checkout|restore|stash|reset|revert|commit|mv|rm)\b/;
+
+// Genuine, tool-agnostic write detection: hash the working-tree state so ANY
+// modification (Edit, sed -i, >>, an MCP writer, a new or deleted file) changes
+// it, while pure reads leave it untouched. Empty string when git is unavailable
+// (no repo / no commits / no git) — callers fall back to the fast signal above.
+// porcelain catches added/removed/untracked files; shortstat catches further
+// edits to an already-dirty file. Verified across write modalities 2026-07-10.
+function gitFingerprint(root) {
+  try {
+    const opts = { cwd: root, encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] };
+    const status = execFileSync("git", ["status", "--porcelain=v1"], opts);
+    const stat = execFileSync("git", ["diff", "HEAD", "--shortstat"], opts);
+    return createHash("sha1").update(status + " " + stat).digest("hex").slice(0, 16);
+  } catch {
+    return "";
+  }
+}
+
+// Current HEAD (short sha), or "" when unavailable. The fingerprint above reads
+// the working-tree DIFF against HEAD, so a HEAD move (branch switch / commit /
+// rebase) can shift it without the agent writing anything — we compare HEAD
+// across checkpoints and distrust the fingerprint whenever it moved.
+function gitHead(root) {
+  try {
+    const opts = { cwd: root, encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] };
+    return execFileSync("git", ["rev-parse", "HEAD"], opts).trim().slice(0, 12);
+  } catch {
+    return "";
+  }
+}
 
 // Evidence store regexes — paths printed in ANY output, and files named as ARGS.
 const PATH_RE = /[\w./-]+\.(?:py|js|jsx|ts|tsx|htm|html|vue|json|scss|css|rb|java)/g;
@@ -161,6 +204,9 @@ export default function handle(input) {
     held_files: [],
     redundant_fired: 0,
     seen_find_queries: [],
+    wrote_since_ckpt: false, // (4) any write since the last checkpoint window
+    git_fp: "", // (4) working-tree fingerprint at the last checkpoint
+    git_head: "", // (4) HEAD at the last checkpoint — a move invalidates the fp diff
   };
   try {
     Object.assign(st, JSON.parse(readFileSync(stateFile, "utf8")));
@@ -185,6 +231,8 @@ export default function handle(input) {
     tool === "Glob" ||
     (tool === "Bash" && !isFind && !isGs && !isKb && SEARCH_RE.test(cmd));
   const isNonfindShell = isSearch;
+  // Producing, not spinning — used only to gate the checkpoint (detector 4).
+  const isWrite = WRITE_TOOLS.has(tool) || (tool === "Bash" && WRITE_CMD_RE.test(cmd));
 
   const _ob = out !== null && out !== undefined ? out.trim().toLowerCase() : null;
   const outEmpty =
@@ -195,6 +243,7 @@ export default function handle(input) {
       _ob === "no files found");
 
   st.total += 1;
+  if (isWrite) st.wrote_since_ckpt = true;
   // seen_find gates the spiral detectors (3/3b): they stay silent for sessions that
   // never touch coldstart at all (deliberate — this hook must not nag non-users).
   // Any coldstart surface proves awareness: find (set below on the find branch),
@@ -329,19 +378,38 @@ export default function handle(input) {
     st.last_gs_fallback = out && GS_FALLBACK_RE.test(out) ? gsFile : "";
   }
 
-  // (4) checkpoint — periodic, lowest urgency
+  // (4) checkpoint — periodic, lowest urgency. Fires ONLY when the agent may be
+  // spinning in search: suppressed whenever a write happened in the window, so it
+  // never nags mid-implementation (where "stop searching and answer" is nonsense).
+  // git is authoritative when present (ground-truth over the whole window); the
+  // fast per-call signal covers the first window and non-git repos.
   if (st.total - st.last_checkpoint >= CHECKPOINT_EVERY) {
     st.last_checkpoint = st.total;
-    msgs.push([
-      5,
-      `Checkpoint (${st.total} tool calls). Stop and think before the next call — answer these in order:\n` +
-        "1. Restate the task in one sentence — what is the ONE thing it asks for?\n" +
-        "2. List the files you have already surfaced or read that bear on it.\n" +
-        "3. Can you answer (1) from (2)? If YES — write the answer now and stop searching; you almost " +
-        "certainly have enough.\n" +
-        "4. Only if NO — name the single specific fact still missing, and make the next call target ONLY " +
-        "that. Do not re-run a search whose results are already in your context.",
-    ]);
+    const headNow = gitHead(input.cwd);
+    const fpNow = gitFingerprint(input.cwd);
+    // Trust the git working-tree diff only with a prior baseline AND an unmoved
+    // HEAD — a branch switch / commit / rebase shifts the whole tree and would
+    // read as a spurious write. Otherwise (first window, no git, or HEAD moved)
+    // the fast per-call signal governs: it tracks the agent's own writes and is
+    // immune to branch movement.
+    const gitUsable = !!fpNow && !!st.git_fp && !!headNow && headNow === st.git_head;
+    const wrote = gitUsable ? fpNow !== st.git_fp : st.wrote_since_ckpt;
+    if (fpNow) st.git_fp = fpNow;
+    if (headNow) st.git_head = headNow;
+    st.wrote_since_ckpt = false;
+    if (!wrote) {
+      msgs.push([
+        5,
+        `Checkpoint (${st.total} tool calls). If you are searching or investigating, stop and think ` +
+          "before the next call (if you are mid-implementation, disregard this):\n" +
+          "1. Restate the task in one sentence — what is the ONE thing it asks for?\n" +
+          "2. List the files you have already surfaced or read that bear on it.\n" +
+          "3. Can you answer (1) from (2)? If YES — write the answer now and stop searching; you almost " +
+          "certainly have enough.\n" +
+          "4. Only if NO — name the single specific fact still missing, and make the next call target ONLY " +
+          "that. Do not re-run a search whose results are already in your context.",
+      ]);
+    }
   }
 
   // merge THIS call's evidence into the store (after novelty was computed above)

--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -300,12 +300,16 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
     const sid = String(input.session_id || "").replace(/[^A-Za-z0-9_-]/g, "");
     if (!sid) { log("SKIP no-session-id"); process.exit(0); }
 
-    // Guard 2: one elicitation per (session, agent) — subagents share the
-    // parent session_id, so the marker is scoped by agent too.
+    // Guard 2: capture across a long session, but only files not yet offered.
+    // A boolean once-per-(session,agent) marker silently dropped ALL knowledge
+    // after the first Stop; instead we remember which files were already offered
+    // for capture and elicit only the new ones (the delta is computed below,
+    // once the SubagentStop transcript is resolved). Subagents share the parent
+    // session_id, so the record is scoped by agent too.
     const aid = String(input.agent_id || "main").replace(/[^A-Za-z0-9_-]/g, "") || "main";
-    const marker = join(tmpdir(), `coldstart-kb-${sid}-${aid}.done`);
-    if (existsSync(marker)) { log(`SKIP already-elicited session=${sid} agent=${aid}`); process.exit(0); }
-    try { writeFileSync(marker, String(Date.now())); } catch { /* best effort */ }
+    const marker = join(tmpdir(), `coldstart-kb-${sid}-${aid}.json`);
+    let offered = new Set();
+    try { offered = new Set(JSON.parse(readFileSync(marker, "utf8")).files || []); } catch { /* first Stop of this session */ }
 
     // On SubagentStop, transcript_path is the PARENT's transcript (confirmed:
     // claude-code#11396) — scanning it would elicit the sub off the parent's
@@ -326,18 +330,27 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
       transcriptPath = own;
     }
     const files = transcriptPath ? touchedFiles(transcriptPath, root) : [];
+    // Delta: only files not already offered on an earlier Stop this session.
+    const newFiles = files.filter((f) => !offered.has(f));
 
-    // FAST-EXIT only when the agent touched NO repo file at all (pure
-    // orchestration / Q&A). Anything touched → the agent judges what's worth
-    // capturing; the hook never guesses from read modality.
-    if (!files.length) {
-      log(`FAST-EXIT zero touched files session=${sid} agent=${aid} event=${input.hook_event_name || "?"}`);
+    // FAST-EXIT when there is nothing NEW to capture — either no repo file was
+    // touched at all (pure orchestration / Q&A) or every touched file was already
+    // offered on a previous Stop. No record is written on this path, so an early
+    // no-op Stop can never burn the session's capture.
+    if (!newFiles.length) {
+      log(`FAST-EXIT no-new-files session=${sid} agent=${aid} touched=${files.length} event=${input.hook_event_name || "?"}`);
       process.exit(0);
     }
 
-    const prompt = buildCapturePrompt(root, filesBlock(root, files), sid, input.hook_event_name === "SubagentStop");
-    logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, hook: input.hook_event_name });
-    log(`ELICIT session=${sid} agent=${aid} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
+    // Record everything now offered BEFORE returning the block, so the post-write
+    // re-Stop and every later Stop skip these files. stop_hook_active (Guard 1)
+    // still short-circuits the immediate re-Stop; this record survives across the
+    // natural turns of a long session.
+    try { writeFileSync(marker, JSON.stringify({ files: [...offered, ...newFiles], ts: Date.now() })); } catch { /* best effort */ }
+
+    const prompt = buildCapturePrompt(root, filesBlock(root, newFiles), sid, input.hook_event_name === "SubagentStop");
+    logCaptureEvent(root, { event: "elicit", session: sid, agent: aid, touched: files.length, new: newFiles.length, hook: input.hook_event_name });
+    log(`ELICIT session=${sid} agent=${aid} new=${newFiles.length} touched=${files.length} promptBytes=${prompt.length} event=${input.hook_event_name || "?"}`);
     process.stdout.write(JSON.stringify({ decision: "block", reason: prompt }));
   } catch (e) {
     log(`handler ${e?.stack || e}`); // fail-open: no stdout → stop allowed

--- a/hooks/nudge-handler.mjs
+++ b/hooks/nudge-handler.mjs
@@ -37,6 +37,7 @@
 
 import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { canonicalFindKey } from "./canonical-find-key.mjs";
@@ -66,6 +67,48 @@ const GS_FALLBACK_RE = /NOT a declared symbol here|no declared symbol matches/;
 const SEARCH_RE =
   /(^|[;&|]|\s)(grep|egrep|fgrep|rg)\b|git\s+grep|git\s+log|(^|[;&|]|\s)find\s|(^|[;&|]|\s)ls\b|(^|[;&|]|\s)cat\b/;
 const GS_FILE_RE = /(?:coldstart|index\.js)\s+gs\s+(\S+)/;
+
+// The checkpoint (detector 4) only makes sense when the agent may be SPINNING IN
+// SEARCH — never mid-implementation. A write is the signal that it is producing,
+// not spinning. Fast per-call detection: structured write tools + write-shaped
+// shell (sed -i, redirections, cp/mv/rm, git apply/checkout…). This is the
+// fallback; git ground-truth (below) is authoritative when the repo is a git repo.
+const WRITE_TOOLS = new Set([
+  "Edit", "Write", "MultiEdit", "NotebookEdit", // Claude
+  "apply_patch", "edit_file", "write_file", "create_file", // Codex / Cursor / MCP writers
+]);
+const WRITE_CMD_RE =
+  /(^|[\s;&|(])(sed\s+-i|tee|dd|truncate|patch|apply_patch|cp|mv|rm|mkdir|touch|install)\b|>>?(?!\s*\/dev\/null)|git\s+(apply|checkout|restore|stash|reset|revert|commit|mv|rm)\b/;
+
+// Genuine, tool-agnostic write detection: hash the working-tree state so ANY
+// modification (Edit, sed -i, >>, an MCP writer, a new or deleted file) changes
+// it, while pure reads leave it untouched. Empty string when git is unavailable
+// (no repo / no commits / no git) — callers fall back to the fast signal above.
+// porcelain catches added/removed/untracked files; shortstat catches further
+// edits to an already-dirty file. Verified across write modalities 2026-07-10.
+function gitFingerprint(root) {
+  try {
+    const opts = { cwd: root, encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] };
+    const status = execFileSync("git", ["status", "--porcelain=v1"], opts);
+    const stat = execFileSync("git", ["diff", "HEAD", "--shortstat"], opts);
+    return createHash("sha1").update(status + " " + stat).digest("hex").slice(0, 16);
+  } catch {
+    return "";
+  }
+}
+
+// Current HEAD (short sha), or "" when unavailable. The fingerprint above reads
+// the working-tree DIFF against HEAD, so a HEAD move (branch switch / commit /
+// rebase) can shift it without the agent writing anything — we compare HEAD
+// across checkpoints and distrust the fingerprint whenever it moved.
+function gitHead(root) {
+  try {
+    const opts = { cwd: root, encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] };
+    return execFileSync("git", ["rev-parse", "HEAD"], opts).trim().slice(0, 12);
+  } catch {
+    return "";
+  }
+}
 
 // Evidence store regexes — paths printed in ANY output, and files named as ARGS.
 const PATH_RE = /[\w./-]+\.(?:py|js|jsx|ts|tsx|htm|html|vue|json|scss|css|rb|java)/g;
@@ -161,6 +204,9 @@ export default function handle(input) {
     held_files: [],
     redundant_fired: 0,
     seen_find_queries: [],
+    wrote_since_ckpt: false, // (4) any write since the last checkpoint window
+    git_fp: "", // (4) working-tree fingerprint at the last checkpoint
+    git_head: "", // (4) HEAD at the last checkpoint — a move invalidates the fp diff
   };
   try {
     Object.assign(st, JSON.parse(readFileSync(stateFile, "utf8")));
@@ -185,6 +231,8 @@ export default function handle(input) {
     tool === "Glob" ||
     (tool === "Bash" && !isFind && !isGs && !isKb && SEARCH_RE.test(cmd));
   const isNonfindShell = isSearch;
+  // Producing, not spinning — used only to gate the checkpoint (detector 4).
+  const isWrite = WRITE_TOOLS.has(tool) || (tool === "Bash" && WRITE_CMD_RE.test(cmd));
 
   const _ob = out !== null && out !== undefined ? out.trim().toLowerCase() : null;
   const outEmpty =
@@ -195,6 +243,7 @@ export default function handle(input) {
       _ob === "no files found");
 
   st.total += 1;
+  if (isWrite) st.wrote_since_ckpt = true;
   // seen_find gates the spiral detectors (3/3b): they stay silent for sessions that
   // never touch coldstart at all (deliberate — this hook must not nag non-users).
   // Any coldstart surface proves awareness: find (set below on the find branch),
@@ -329,19 +378,38 @@ export default function handle(input) {
     st.last_gs_fallback = out && GS_FALLBACK_RE.test(out) ? gsFile : "";
   }
 
-  // (4) checkpoint — periodic, lowest urgency
+  // (4) checkpoint — periodic, lowest urgency. Fires ONLY when the agent may be
+  // spinning in search: suppressed whenever a write happened in the window, so it
+  // never nags mid-implementation (where "stop searching and answer" is nonsense).
+  // git is authoritative when present (ground-truth over the whole window); the
+  // fast per-call signal covers the first window and non-git repos.
   if (st.total - st.last_checkpoint >= CHECKPOINT_EVERY) {
     st.last_checkpoint = st.total;
-    msgs.push([
-      5,
-      `Checkpoint (${st.total} tool calls). Stop and think before the next call — answer these in order:\n` +
-        "1. Restate the task in one sentence — what is the ONE thing it asks for?\n" +
-        "2. List the files you have already surfaced or read that bear on it.\n" +
-        "3. Can you answer (1) from (2)? If YES — write the answer now and stop searching; you almost " +
-        "certainly have enough.\n" +
-        "4. Only if NO — name the single specific fact still missing, and make the next call target ONLY " +
-        "that. Do not re-run a search whose results are already in your context.",
-    ]);
+    const headNow = gitHead(input.cwd);
+    const fpNow = gitFingerprint(input.cwd);
+    // Trust the git working-tree diff only with a prior baseline AND an unmoved
+    // HEAD — a branch switch / commit / rebase shifts the whole tree and would
+    // read as a spurious write. Otherwise (first window, no git, or HEAD moved)
+    // the fast per-call signal governs: it tracks the agent's own writes and is
+    // immune to branch movement.
+    const gitUsable = !!fpNow && !!st.git_fp && !!headNow && headNow === st.git_head;
+    const wrote = gitUsable ? fpNow !== st.git_fp : st.wrote_since_ckpt;
+    if (fpNow) st.git_fp = fpNow;
+    if (headNow) st.git_head = headNow;
+    st.wrote_since_ckpt = false;
+    if (!wrote) {
+      msgs.push([
+        5,
+        `Checkpoint (${st.total} tool calls). If you are searching or investigating, stop and think ` +
+          "before the next call (if you are mid-implementation, disregard this):\n" +
+          "1. Restate the task in one sentence — what is the ONE thing it asks for?\n" +
+          "2. List the files you have already surfaced or read that bear on it.\n" +
+          "3. Can you answer (1) from (2)? If YES — write the answer now and stop searching; you almost " +
+          "certainly have enough.\n" +
+          "4. Only if NO — name the single specific fact still missing, and make the next call target ONLY " +
+          "that. Do not re-run a search whose results are already in your context.",
+      ]);
+    }
   }
 
   // merge THIS call's evidence into the store (after novelty was computed above)

--- a/tests/kb-elicit-hook.test.ts
+++ b/tests/kb-elicit-hook.test.ts
@@ -96,3 +96,53 @@ describe('kb-elicit always-fire', () => {
     expect(out.trim()).toBe('');
   });
 });
+
+describe('kb-elicit long-session capture (delta, not once-per-session)', () => {
+  // Distinctive names — the capture prompt hard-codes example paths (src/a.py,
+  // src/x.py, models.py), so the touched files must not collide with those.
+  it('re-elicits NEW files on a later Stop, never re-offering one already captured', () => {
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/zebra_loader.py'), 'x = 1\n');
+    fs.writeFileSync(path.join(root, 'src/quokka_handler.py'), 'y = 2\n');
+
+    // Stop 1: only zebra_loader touched → elicits for it.
+    const out1 = JSON.parse(runHook([
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'src/zebra_loader.py') } }]),
+    ]));
+    expect(out1.decision).toBe('block');
+    expect(out1.reason).toContain('src/zebra_loader.py');
+
+    // Stop 2 (same session): both touched → elicits for the NEW file only.
+    const out2 = JSON.parse(runHook([
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'src/zebra_loader.py') } }]),
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'src/quokka_handler.py') } }]),
+    ]));
+    expect(out2.decision).toBe('block');
+    expect(out2.reason).toContain('src/quokka_handler.py');
+    expect(out2.reason).not.toContain('src/zebra_loader.py'); // already offered on Stop 1
+
+    // Stop 3 (same session): nothing new → stop is allowed (no re-nag).
+    const out3 = runHook([
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'src/zebra_loader.py') } }]),
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'src/quokka_handler.py') } }]),
+    ]);
+    expect(out3.trim()).toBe('');
+  });
+
+  it('a no-touch Stop does not burn the session — later real work still elicits', () => {
+    fs.writeFileSync(path.join(root, 'zephyr_widget.js'), 'const x = 1\n');
+
+    // Stop 1: nothing under-root touched → FAST-EXIT, and crucially no record written.
+    const out1 = runHook([
+      assistantLine([{ name: 'Bash', input: { command: 'git status && npm test' } }]),
+    ]);
+    expect(out1.trim()).toBe('');
+
+    // Stop 2: a real file is touched → still elicits (the slot was not consumed).
+    const out2 = JSON.parse(runHook([
+      assistantLine([{ name: 'Read', input: { file_path: path.join(root, 'zephyr_widget.js') } }]),
+    ]));
+    expect(out2.decision).toBe('block');
+    expect(out2.reason).toContain('zephyr_widget.js');
+  });
+});

--- a/tests/nudge-arming.test.ts
+++ b/tests/nudge-arming.test.ts
@@ -115,3 +115,81 @@ describe('kb-recall pre-seeds the nudge state on injection', () => {
     expect(st.seen_find).toBe(true);
   });
 });
+
+describe('checkpoint (detector 4) gates on genuine writes', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-ckpt-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  const call = (tool_name: string, tool_input: Record<string, unknown>) =>
+    handle({ session_id: sid, cwd: dir, tool_name, tool_input, tool_response: 'x' });
+
+  it('fires after 12 read/search calls with no write in the window', () => {
+    let res: ReturnType<typeof handle> = null;
+    for (let i = 0; i < 12; i++) res = call('Read', { file_path: `${dir}/f${i}.py` });
+    expect(res?.hookSpecificOutput?.additionalContext).toContain('Checkpoint');
+  });
+
+  it('is suppressed when a structured write (Edit) lands in the window', () => {
+    for (let i = 0; i < 11; i++) call('Read', { file_path: `${dir}/f${i}.py` });
+    const res = call('Edit', { file_path: `${dir}/f.py` });
+    expect(res).toBeNull();
+  });
+
+  it('is suppressed when a Bash write (sed -i) the structured signal misses lands in the window', () => {
+    for (let i = 0; i < 11; i++) call('Read', { file_path: `${dir}/f${i}.py` });
+    const res = handle({
+      session_id: sid, cwd: dir, tool_name: 'Bash',
+      tool_input: { command: `sed -i 's/a/b/' ${dir}/f.py` }, tool_response: '',
+    });
+    expect(res).toBeNull();
+  });
+
+  it('git ground-truth suppresses it for a write NO tool call revealed', () => {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@t.co'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    fs.writeFileSync(path.join(dir, 'tracked.py'), 'a\n');
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['commit', '-qm', 'init'], { cwd: dir });
+
+    // Window 1: 12 pure reads → checkpoint fires, clean baseline captured.
+    let res: ReturnType<typeof handle> = null;
+    for (let i = 0; i < 12; i++) res = call('Read', { file_path: `${dir}/r${i}.py` });
+    expect(res?.hookSpecificOutput?.additionalContext).toContain('Checkpoint');
+
+    // A write that arrives through NO tool call the hook can see (e.g. an editor
+    // save, an MCP writer) — only git knows the tree changed.
+    fs.appendFileSync(path.join(dir, 'tracked.py'), 'b\n');
+
+    // Window 2: 12 more pure reads → git sees the change → checkpoint suppressed.
+    for (let i = 0; i < 12; i++) res = call('Read', { file_path: `${dir}/s${i}.py` });
+    expect(res).toBeNull();
+  });
+
+  it('a HEAD move (commit / branch switch) does NOT spuriously suppress it', () => {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 't@t.co'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+    fs.writeFileSync(path.join(dir, 'f.py'), 'a\n');
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['commit', '-qm', 'init'], { cwd: dir });
+
+    // Window 1: 12 pure reads on a clean tree → checkpoint fires, baseline captured.
+    let res: ReturnType<typeof handle> = null;
+    for (let i = 0; i < 12; i++) res = call('Read', { file_path: `${dir}/r${i}.py` });
+    expect(res?.hookSpecificOutput?.additionalContext).toContain('Checkpoint');
+
+    // HEAD moves + the tree changes through NO agent tool call (a commit made
+    // out of band, then a fresh dirty edit) — exactly the branch-switch/manual
+    // case that would otherwise read as a spurious write.
+    fs.appendFileSync(path.join(dir, 'f.py'), 'b\n');
+    execFileSync('git', ['commit', '-qm', 'oob', '-a'], { cwd: dir });
+    fs.appendFileSync(path.join(dir, 'f.py'), 'c\n');
+
+    // Window 2: 12 pure reads, agent wrote nothing. HEAD moved since the baseline
+    // → the git diff is distrusted → the (empty) fast write signal governs → fires.
+    for (let i = 0; i < 12; i++) res = call('Read', { file_path: `${dir}/s${i}.py` });
+    expect(res?.hookSpecificOutput?.additionalContext).toContain('Checkpoint');
+  });
+});


### PR DESCRIPTION
Two independent hook fixes, kept together since both are notebook/nudge hook behavior.

---

## 1. `kb-elicit`: capture the whole session incrementally, not just the first Stop

In a long-running session, note capture stopped firing after the first Stop:

```
[2026-07-10T11:19:23.170Z] elicit: SKIP already-elicited
```

The guard used a **boolean once-per-`(session, agent)` marker**, written on the first Stop and never cleared — every later Stop found it and exited, so knowledge learned afterward was dropped. A **secondary bug**: the marker was written *before* the touched-files check, so an early Stop that touched nothing (pure Q&A) still burned the single capture slot.

**Fix — a per-file delta instead of a boolean.** Each Stop loads the set of files already offered for capture and elicits only the files touched since:
- work done later in a long session is captured;
- a no-op Stop writes no record and never burns the slot;
- a file offered once is never re-offered (no re-nagging);
- the record is written before the block, so the post-write re-Stop and later Stops skip already-offered files.

**Scope:** Claude (`kb-elicit.mjs`) had the exact bug. Codex (`codex-kb-elicit.mjs`) was keyed per `turn_id` — it re-fired each turn but re-offered *every* touched file every turn (the redundant sibling); re-keyed to `session_id` + delta. Cursor is left as-is — it already captures per turn scoped to that turn's files (keyed per generation), so it has neither bug (confirmed in practice: the issue only ever showed up on Claude).

## 2. `nudge`: fire the checkpoint only when spinning in search, not mid-implementation

The checkpoint nudge (detector 4) fired every 12 tool calls on **any** task, with search-framed text ("stop searching; you almost certainly have enough"). On an implementation/bug task the agent is producing, not spinning, so it misfired — and since the spiral detectors are gated on `seen_find`, the checkpoint was often the *only* nudge firing there.

**Fix — gate on genuine write activity.** Suppress the checkpoint whenever a write happened in the window, because a write means the agent is producing rather than spinning. Two layers:
- **Fast, per call:** a list of structured write tools (`Edit`/`Write`/`NotebookEdit`/`apply_patch`/…) plus write-shaped shell (`sed -i`, redirections, `cp`/`mv`/`rm`, `git apply`/`checkout`…). Covers the first window and non-git repos.
- **Genuine, via git:** at each checkpoint, fingerprint the working tree (`git status --porcelain` + `git diff HEAD --shortstat`, hashed) and compare to the previous checkpoint. Catches **any** write the fast signal missed — an editor save, an MCP writer, a further edit to an already-dirty file.

**HEAD-gate (branch-switch guard).** The fingerprint reads the diff *against HEAD*, so a branch switch / commit / rebase shifts it without the agent writing anything. HEAD is stamped alongside the fingerprint; the git diff is trusted only when HEAD is unchanged since the last checkpoint — if HEAD moved, the fast per-call signal governs (it tracks the agent's own writes and is immune to branch movement). Note the failure is always on the safe side: a false-positive write only ever *suppresses* this low-priority nudge, never fires it.

Plus a one-line caveat in the text ("if you are mid-implementation, disregard this") as a backstop.

**Scope:** `nudge-handler.mjs` (Claude) and `codex-nudge-handler.mjs` (Codex); `cursor-nudge-handler.mjs` delegates to the Codex handler and inherits the fix.

---

## Testing

- Full suite green (540 passed).
- **Elicit:** new cases spawn the real hook across multiple Stops — a new file on a later Stop elicits while an already-offered one doesn't; a no-touch Stop doesn't consume the session.
- **Checkpoint:** fires after 12 write-free calls; suppressed by a structured write, by a Bash `sed -i` the structured signal misses, and by a working-tree change no tool call revealed (git ground-truth); and **not** suppressed by a HEAD move with no agent write (the branch-switch guard).
- The git fingerprint was verified empirically across write modalities (`echo >>`, `sed -i` to a dirty file, new/deleted files) before wiring it in; pure reads leave it unchanged.

## Validation notes

- Elicit: across a long session you should now see repeated `ELICIT … new=<n>` lines and `FAST-EXIT no-new-files` when a Stop adds nothing — instead of one capture then `SKIP already-elicited` for the rest of the session.
- Checkpoint: it should stay quiet during an implementation phase (writes flowing) and re-arm when the agent shifts to pure searching.