### PR TITLE
refactor(indexer): load grammars via static imports so bun can embed them

### DIFF
--- a/src/indexer/extractors/cpp.ts
+++ b/src/indexer/extractors/cpp.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import cppModule from 'tree-sitter-cpp';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const cppGrammar = require('tree-sitter-cpp') as unknown;
+const cppGrammar = cppModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/csharp.ts
+++ b/src/indexer/extractors/csharp.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import csharpModule from 'tree-sitter-c-sharp';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { childrenOfType, firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const csharpGrammar = require('tree-sitter-c-sharp') as unknown;
+const csharpGrammar = csharpModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/go.ts
+++ b/src/indexer/extractors/go.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import goModule from 'tree-sitter-go';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const goGrammar = require('tree-sitter-go') as unknown;
+const goGrammar = goModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/groovy.ts
+++ b/src/indexer/extractors/groovy.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import groovyRawModule from 'tree-sitter-groovy';
 import type { SymbolNode } from '../../types.js';
 import { childrenOfType, firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const groovyModule = require('tree-sitter-groovy') as unknown;
+const groovyModule = groovyRawModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/java.ts
+++ b/src/indexer/extractors/java.ts
@@ -5,14 +5,12 @@
  *
  * Follows the same interface and patterns as ts-parser.ts.
  */
-import { createRequire } from 'node:module';
+import javaModule from 'tree-sitter-java';
 import type { SymbolNode, SymbolKind, CallSite } from '../../types.js';
 import { childrenOfType, firstChildOfType, firstChildOfTypes } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const javaGrammar = require('tree-sitter-java') as unknown;
+const javaGrammar = javaModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/kotlin.ts
+++ b/src/indexer/extractors/kotlin.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import kotlinModule from 'tree-sitter-kotlin';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const kotlinGrammar = require('tree-sitter-kotlin') as unknown;
+const kotlinGrammar = kotlinModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/parser-factory.ts
+++ b/src/indexer/extractors/parser-factory.ts
@@ -11,11 +11,10 @@
  * `makeParser(grammar)` once at module scope and gets back a `getParser()` that
  * builds the parser on first use and caches it for the process lifetime.
  */
-import { createRequire } from 'node:module';
+import ParserModule from 'tree-sitter';
 
-const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ParserCtor = require('tree-sitter') as { new(): any };
+const ParserCtor = ParserModule as { new(): any };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyParser = any;

--- a/src/indexer/extractors/php.ts
+++ b/src/indexer/extractors/php.ts
@@ -1,12 +1,10 @@
-import { createRequire } from 'node:module';
+import phpDefault from 'tree-sitter-php';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { childrenOfType, firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
 // tree-sitter-php exports a { php, php_only } object
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const phpModule = require('tree-sitter-php') as { php: unknown; php_only: unknown };
+const phpModule = phpDefault as { php: unknown; php_only: unknown };
 const phpGrammar = phpModule.php ?? phpModule.php_only;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/indexer/extractors/python.ts
+++ b/src/indexer/extractors/python.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import pythonModule from 'tree-sitter-python';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { childrenOfType, firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const pythonGrammar = require('tree-sitter-python') as unknown;
+const pythonGrammar = pythonModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/ruby.ts
+++ b/src/indexer/extractors/ruby.ts
@@ -5,14 +5,12 @@
  *
  * Follows the same interface and patterns as ts-parser.ts.
  */
-import { createRequire } from 'node:module';
+import rubyModule from 'tree-sitter-ruby';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { childrenOfType, firstChildOfType, firstChildOfTypes } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const rubyGrammar = require('tree-sitter-ruby') as unknown;
+const rubyGrammar = rubyModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/rust.ts
+++ b/src/indexer/extractors/rust.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import rustModule from 'tree-sitter-rust';
 import type { SymbolNode, CallSite } from '../../types.js';
 import { firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const rustGrammar = require('tree-sitter-rust') as unknown;
+const rustGrammar = rustModule as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/toml.ts
+++ b/src/indexer/extractors/toml.ts
@@ -1,10 +1,8 @@
-import { createRequire } from 'node:module';
+import tomlDefault from '@tree-sitter-grammars/tree-sitter-toml';
 import type { SymbolNode } from '../../types.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const tomlModule = require('@tree-sitter-grammars/tree-sitter-toml') as unknown;
+const tomlModule = tomlDefault as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/xml.ts
+++ b/src/indexer/extractors/xml.ts
@@ -1,11 +1,9 @@
-import { createRequire } from 'node:module';
+import xmlDefault from '@tree-sitter-grammars/tree-sitter-xml';
 import type { SymbolNode } from '../../types.js';
 import { childrenOfType, firstChildOfType } from './node-helpers.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const xmlModule = require('@tree-sitter-grammars/tree-sitter-xml') as unknown;
+const xmlModule = xmlDefault as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/extractors/yaml.ts
+++ b/src/indexer/extractors/yaml.ts
@@ -1,10 +1,8 @@
-import { createRequire } from 'node:module';
+import yamlDefault from '@tree-sitter-grammars/tree-sitter-yaml';
 import type { SymbolNode } from '../../types.js';
 import { makeParser } from './parser-factory.js';
 
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const yamlModule = require('@tree-sitter-grammars/tree-sitter-yaml') as unknown;
+const yamlModule = yamlDefault as unknown;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TSNode = any;

--- a/src/indexer/ts-parser.ts
+++ b/src/indexer/ts-parser.ts
@@ -5,15 +5,16 @@
  *
  * This supplements the regex parser in parser.ts for TS/JS files only.
  */
-import { createRequire } from 'node:module';
+import ParserModule from 'tree-sitter';
+import tsTypescriptModule from 'tree-sitter-typescript';
 import type { SymbolNode, SymbolKind, CallSite } from '../types.js';
 
-// Native addons need createRequire in an ESM context
-const require = createRequire(import.meta.url);
+// Static default imports (not createRequire) so `bun build --compile` can trace
+// into each grammar wrapper and embed its prebuilt .node. Under Node these are
+// object-identical to the previous require() calls (verified).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ParserCtor = require('tree-sitter') as { new(): any };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { typescript: tsGrammar, tsx: tsxGrammar } = require('tree-sitter-typescript') as {
+const ParserCtor = ParserModule as { new(): any };
+const { typescript: tsGrammar, tsx: tsxGrammar } = tsTypescriptModule as {
   typescript: unknown;
   tsx: unknown;
 };


### PR DESCRIPTION
## What

Swap all 15 tree-sitter grammar loads (13 language extractors + tree-sitter core in `ts-parser.ts` and `parser-factory.ts`) from `createRequire(import.meta.url)('tree-sitter-x')` to **static default imports** (`import g from 'tree-sitter-x'`).

`searcher.ts` intentionally keeps `createRequire` for `@vscode/ripgrep` — that's a separate executable, not a `.node`, and isn't embeddable.

## Why

This is **Phase 1** of the standalone-binary track (`bun build --compile` → GitHub Releases), which is the only distribution path that retires the `--legacy-peer-deps` flag and npm's un-overridable install box.

The tree-sitter grammar packages already ship first-class `bun build --compile` support — each wrapper has a bun branch that requires a statically-analyzable per-platform prebuild path so bun embeds the right `.node`. But **our** dynamic `createRequire(...)(pkg)` is opaque to bun's static bundler, so it never reaches that wrapper code and the native fails to resolve in the compiled binary (`Cannot find package from /$bunfs/root/`). A static `import` is traceable, so bun embeds the prebuild.

This PR is a **pure no-op under Node** and ships independently of any binary work.

## Why it's safe under Node (the regression concern)

- `import g from pkg` is **object-identical** to `createRequire(url)(pkg)` — verified `===` for every grammar, including the multi-export shapes (`php` → `{php, php_only}`, `typescript` → `{typescript, tsx}`).
- The grammar packages ship type declarations (`types: bindings/node`, core ships `tree-sitter.d.ts`), so `noImplicitAny` is satisfied — no TS7016.
- Named imports are deliberately **avoided** (these CJS packages assign exports dynamically, so Node's cjs-lexer can't see named exports); every site uses default-import-then-cast.

## Verification

- `tsc` clean (build + `--noEmit`)
- **533/533** tests pass (incl. real parsing via the rails/django/laravel/csharp fixtures)
- All 13 grammars + core **load and parse** through the built `dist`
- Real `find` run indexes 309 files; the changed `parser-factory` path runs live

🤖 Generated with [Claude Code](https://claude.com/claude-code)