### PR TITLE
site: add Google Analytics (GA4) tracking

### DIFF
--- a/site/docs.html
+++ b/site/docs.html
@@ -23,6 +23,15 @@
 <meta name="twitter:description" content="Command reference for find, gs, the kb notebook family, team sharing, and index freshness." />
 <meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/logo.svg" />
 <link rel="stylesheet" href="docs.css" />
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page">
 

--- a/site/index.html
+++ b/site/index.html
@@ -46,6 +46,15 @@
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
 }
 </script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body>
 


### PR DESCRIPTION
Adds the GA4 gtag snippet (`G-D1Q44HNQ8H`) before `</head>` on both site pages so page visits are counted on both the landing page and the docs.

- `site/index.html`
- `site/docs.html`

Deploys via the Pages workflow on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)