### PR TITLE
site: highlight Java + copy button on install box

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -312,7 +312,7 @@
       <span class="chip hot">TypeScript</span><span class="chip hot">JavaScript</span><span class="chip hot">JSX / TSX</span>
       <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
       <span class="chip hot">Python</span><span class="chip hot">Ruby (Rails)</span><span class="chip hot">Go</span><span class="chip hot">Rust</span>
-      <span class="chip">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
+      <span class="chip hot">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
       <span class="chip">Groovy / Gradle</span><span class="chip">GraphQL</span><span class="chip">YAML</span><span class="chip">TOML</span><span class="chip">XML</span><span class="chip">.env</span>
     </div>
   </div>
@@ -327,7 +327,7 @@
       <p class="lead">Works best with <b>Claude Code</b>, <b>Codex</b>, and <b>Cursor</b> — all get the fast CLI path <em style="font-style:italic;color:var(--text)">and</em> the notebook capture/recall hooks, wired automatically by <code style="font-family:var(--mono)">init</code>.</p>
     </div>
     <div class="term install-term rise">
-      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">your-project</span></div>
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">your-project</span><button type="button" class="copy-btn" id="copy-install" data-copy="npm install -g @cstart/coldstart&#10;coldstart init" aria-label="Copy install commands">Copy</button></div>
       <div class="term-body">
 <span class="l"><span class="p-prompt">$</span> <span class="p-cmd">npm install -g @cstart/coldstart</span></span>
 <span class="l"><span class="p-prompt">$</span> <span class="p-cmd">cd</span> your-project</span>
@@ -375,6 +375,30 @@
     entries.forEach(function(e){ if (e.isIntersecting){ e.target.classList.add('in'); obs.unobserve(e.target); } });
   }, {rootMargin:'0px 0px -12% 0px', threshold:.08});
   rises.forEach(function(el){ obs.observe(el); });
+})();
+(function(){
+  var btn = document.getElementById('copy-install');
+  if (!btn) return;
+  btn.addEventListener('click', function(){
+    var text = btn.getAttribute('data-copy') || '';
+    function done(){
+      var prev = btn.textContent;
+      btn.textContent = 'Copied';
+      btn.classList.add('copied');
+      setTimeout(function(){ btn.textContent = prev; btn.classList.remove('copied'); }, 1600);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText){
+      navigator.clipboard.writeText(text).then(done).catch(fallback);
+    } else { fallback(); }
+    function fallback(){
+      var ta = document.createElement('textarea');
+      ta.value = text; ta.setAttribute('readonly','');
+      ta.style.position = 'absolute'; ta.style.left = '-9999px';
+      document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); done(); } catch(e){}
+      document.body.removeChild(ta);
+    }
+  });
 })();
 </script>
 </body>

--- a/site/styles.css
+++ b/site/styles.css
@@ -109,6 +109,11 @@ h1.title .warm{color:var(--ember);}
 .tl{width:11px;height:11px;border-radius:50%;}
 .tl:nth-child(1){background:#ff5f57;}.tl:nth-child(2){background:#febc2e;}.tl:nth-child(3){background:#28c840;}
 .term-title{margin-left:10px;font-family:var(--mono);font-size:11.5px;color:#5d6b83;}
+.copy-btn{margin-left:auto;font-family:var(--mono);font-size:11px;color:#8aa0bd;cursor:pointer;
+  background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:6px;
+  padding:4px 10px;transition:color .15s,background .15s,border-color .15s;}
+.copy-btn:hover{color:#eef3fb;background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.16);}
+.copy-btn.copied{color:#4fd18b;border-color:rgba(79,209,139,.4);background:rgba(79,209,139,.08);}
 .term-body{padding:20px 22px 24px;font-family:var(--mono);font-size:13px;line-height:1.85;
   color:#c3d0e2;overflow-x:auto;}
 .term-body .l{white-space:pre;display:block;}


### PR DESCRIPTION
Two small site tweaks (no npm release).

## Changes
- **Highlight Java** in the supported-languages section (`hot` chip, matching TypeScript/Python/Go/Ruby).
- **Copy button on the install box** — copies the two real commands, one per line so they run sequentially on paste:
  ```
  npm install -g @cstart/coldstart
  coldstart init
  ```
  Skips the `cd your-project` placeholder and the trailing comment. Uses `navigator.clipboard` with an `execCommand` fallback for non-secure contexts; shows a green "Copied" confirmation.

## README
No change. Its fenced ```bash block already copies each command on its own line via GitHub/npm's built-in code-block copy. No release needed.

## Deploy
The Pages workflow triggers on push to `main` under `site/**`, so merging this deploys automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)