### PR TITLE
fix(kb): recall surfaces a note when the prompt names its file path

### DIFF
--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -173,6 +173,17 @@ const rarityMax = (n: number): number => Math.ceil(n / HOOK_RARITY_DIVISOR);
  *  strongTerms is logged on every injection decision for re-calibration. */
 const HOOK_CONVERGE_MIN = 4;
 
+/** Path-name override: when the raw prompt literally contains a note's anchor
+ *  path (case/separator-insensitive), the user named that file — surface its
+ *  note regardless of term rarity. parseTerms drops `/`-glued paths (the `/`
+ *  fails its alnum token filter) and sub-3-char extensions, so a bare path like
+ *  "arches/urls.py" yields ZERO terms; without this, naming a file is a no-op.
+ *  The anchor-path squash must be ≥ this many chars to fire, so trivially short
+ *  paths can't graze arbitrary prose. Boost dominates term scores so the named
+ *  file leads its freshness tier. */
+const PATH_MATCH_MIN_SQUASH = 6;
+const PATH_MATCH_BOOST = 100;
+
 const tokenCount = (s: string): number => (s ? s.split(/\s+/).filter(Boolean).length : 0);
 
 /** Substring occurrence count in normalized text; a squash-only match counts 1. */
@@ -253,7 +264,20 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
   const max = opts.maxResults ?? 3;
   const { notes, warnings } = loadAll(root);
   const terms = parseTerms(query).filter((t) => !STOPWORDS.has(t.toLowerCase()));
-  if (!notes.length || !terms.length) {
+  // Path-name override (recall only): the raw prompt literally naming a note's
+  // anchor path surfaces that note even when parseTerms yields nothing — a
+  // `/`-glued path fails the alnum token filter and a 2-char extension drops,
+  // so "what does arches/urls.py do" would otherwise leave no terms to match.
+  const querySquash = squash(query);
+  const pathNamedIds = new Set<string>();
+  if (opts.strongOnly) {
+    for (const note of notes) {
+      if (note.anchors.some((a) => { const ps = squash(a.path); return ps.length >= PATH_MATCH_MIN_SQUASH && querySquash.includes(ps); })) {
+        pathNamedIds.add(note.id);
+      }
+    }
+  }
+  if (!notes.length || (!terms.length && !pathNamedIds.size)) {
     if (notes.length && !opts.noMissLog) logMetric(root, 'miss-log', { query, source: opts.source ?? 'tool', reason: 'no-terms' });
     return { hits: [], terms, warnings };
   }
@@ -337,6 +361,16 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
         const idfB = Math.log(1 + (notes.length - df[k] + 0.5) / (df[k] + 0.5));
         boost += (idfB * (wtf * (BM25_K1 + 1))) / (wtf + BM25_K1 * (1 - BM25_B + (BM25_B * lens[i]) / avgLen));
       }
+    }
+    // Path-name override: the prompt named this note's file → treat as a strong,
+    // discriminating hit and boost it to the top of its tier, bypassing the
+    // term-rarity eligibility gate (and the suppression gate, via rare=true).
+    if (opts.strongOnly && pathNamedIds.has(note.id)) {
+      if (!covered) covered = 1;
+      strong = true;
+      rare = true;
+      strongTerms = Math.max(strongTerms, 1);
+      boost += PATH_MATCH_BOOST;
     }
     if (!covered) continue;
     if (opts.strongOnly && !strong) continue; // body-word coverage ≠ a hit on an arbitrary sentence

--- a/tests/kb-retrieval-live.test.ts
+++ b/tests/kb-retrieval-live.test.ts
@@ -121,6 +121,39 @@ describe('hook injection floor', () => {
     expect(page).not.toContain('## ');
     expect(page).toContain('- **');
   });
+
+  it('path-name override: naming a note\'s anchor path injects it even when tokenization drops the path', async () => {
+    // Calibrated regime, so the rarity gate is fully active — the override must
+    // work independently of it.
+    seedCorpus(35);
+    touch('src/routing/urls.py');
+    appendRecord(root, {
+      id: 'urls-file', type: 'file', op: 'put', character: 'single',
+      title: 'src/routing/urls.py', summary: 'The main URL router.',
+      anchors: [{ path: 'src/routing/urls.py' }],
+    } as never);
+
+    // parseTerms drops the `/`-glued path and the 2-char extension, so the
+    // path contributes no usable terms; the override surfaces it anyway.
+    const named = await kbSearch(root, 'what does src/routing/urls.py actually do', {
+      strongOnly: true, noMissLog: true, source: 'hook',
+    });
+    expect(named.hits.length).toBeGreaterThan(0);
+    expect(named.hits[0].note.id).toBe('urls-file');
+
+    // A bare path yields ZERO parseTerms terms — still resolves via the override.
+    const bare = await kbSearch(root, 'src/routing/urls.py', {
+      strongOnly: true, noMissLog: true, source: 'hook',
+    });
+    expect(bare.hits.length).toBeGreaterThan(0);
+    expect(bare.hits[0].note.id).toBe('urls-file');
+
+    // A prompt naming no path stays silent — no accidental squash graze.
+    const nopath = await kbSearch(root, 'please clean up and refactor everything here', {
+      strongOnly: true, noMissLog: true, source: 'hook',
+    });
+    expect(nopath.hits).toHaveLength(0);
+  });
 });
 
 describe('inactive projection — notes whose anchored files are absent on this branch', () => {


### PR DESCRIPTION
## Problem

The recall hook (`kb search --hook`, the `UserPromptSubmit` injector) never surfaced a file note when the user **named the file directly** — e.g. *"what does arches/urls.py do"* stayed silent even though a fresh, perfect note existed. Found while debugging the Codex notebook integration on a real repo.

Two independent causes:
1. **Tokenization discards paths.** `parseTerms` splits on `.` and whitespace **but not `/`**, so `arches/urls.py` becomes `arches/urls` (fails the `^[A-Za-z_][A-Za-z0-9_-]*$` filter — a `/` isn't allowed → dropped) + `py` (< 3 chars → dropped). A bare path yields **zero** terms.
2. **Rarity gate.** Even space-separated, the path's words (`arches`, `urls`) are common in a themed notebook and fail the hook-mode minority filter.

## Fix

A **path-name override**, scoped to recall (`strongOnly`) only: if the squash-normalized prompt contains a note's anchor path, that note is admitted as a strong, discriminating hit that bypasses the rarity/eligibility and suppression gates and boosts to the top of its freshness tier. A minimum squash length keeps trivially short paths from grazing arbitrary prose.

`find` and tool-mode `kb search` are **untouched**.

## Falsification (offline, on a real 7-note notebook)

| Prompt | Result |
|---|---|
| `arches/urls.py` (zero parseTerms terms) | **INJECT** ✓ |
| `do you know what the purpose of *arches/urls.py is?*` | **INJECT** ✓ |
| `what does arches/urls.py do` | **INJECT** ✓ |
| `purpose of arches/settings.py` | **INJECT** ✓ |
| `list the files` / `clean up the code` / `refactor this function` | **SILENT** ✓ |

## Notes

- I also prototyped scale-guarding the rarity gate below 30 notes, but **A/B falsification showed it changed nothing** on the failing notebook (the suppression gate is already off below 30 by design) — dropped as unjustified.
- Regression test added in `tests/kb-retrieval-live.test.ts`; full suite green (543).

🤖 Generated with [Claude Code](https://claude.com/claude-code)