### PR TITLE
site: mention adaptive capture on the pitch page (frost theme dropped)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -180,6 +180,7 @@
           <div class="bstep"><span class="n">1</span>Written after a real task</div>
           <h3>By the agent that just figured it out.</h3>
           <p>The reasoner that solved something writes down what it learned — a file's purpose, a cross-file flow, a trap — with concrete citations, while the full context is still in hand. A write gate dedupes by concept, and concurrent agents never silently merge or lose a note.</p>
+          <p>And capture fires <b>adaptively</b> — at the natural boundaries of the work, like a burst of activity settling or a commit landing — not after every answer. Most turns end in silence.</p>
         </div>
         <div class="bv">
           <div class="card">


### PR DESCRIPTION
The frost/thaw visual experiments were reviewed and dropped — the branch is reset to main's site plus ONE content line in the notebook section: capture fires **adaptively** at natural boundaries of the work (no trigger specifics). Complements the docs.html "When capture happens" section that shipped in #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)