### PR TITLE
release: v2.2.0 — trigger-timed notebook capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.0.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cstart/coldstart",
-      "version": "2.0.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Version bump for 2.2.0. Ships everything merged in #77: v5 trigger-timed capture (evidence tiers, arm/fire state machine, non-blocking next-prompt delivery, HEAD-drift commit-boundary capture), `.coldstart/.coldstartignore`, Cursor/Codex v5 capture ports, MCP↔CLI kb_write parity, hub-note prompt fix, `coldstart consumers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)