### PR TITLE
fix(init): import detector fooled by prose mention of @coldstart.md

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -310,7 +310,11 @@ export function wireClaudeImport(cwd: string): 'created' | 'added' | 'present' {
     return 'created';
   }
   const existing = fs.readFileSync(filePath, 'utf8');
-  if (existing.includes(IMPORT_LINE)) return 'present';
+  // LINE check, not substring: a CLAUDE.md can mention `@coldstart.md` in
+  // backticked prose (this repo's own does), and Claude Code does not resolve
+  // imports inside code spans — only a standalone line wires the guidance.
+  // Symmetric with unwire's line-based strip.
+  if (existing.split('\n').some((l) => l.trim() === IMPORT_LINE)) return 'present';
   const sep = existing.endsWith('\n') ? '' : '\n';
   fs.appendFileSync(filePath, `${sep}\n${IMPORT_LINE}\n`);
   return 'added';

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -130,6 +130,17 @@ describe('init wiring (coldstart.md import model)', () => {
     const body = fs.readFileSync(path.join(tempDir, 'CLAUDE.md'), 'utf8');
     expect(body.match(/@coldstart\.md/g)!.length).toBe(1);
   });
+
+  it('wireClaudeImport is NOT fooled by a prose mention of @coldstart.md (2.2.0 dogfood bug)', () => {
+    // Claude Code does not resolve imports inside code spans — a backticked
+    // mention is documentation, not wiring. Found live: coldstart's own
+    // CLAUDE.md describes the import and init skipped adding the real line.
+    fs.writeFileSync(path.join(tempDir, 'CLAUDE.md'),
+      '# Rules\n\nSetup writes `@coldstart.md` into CLAUDE.md automatically.\n');
+    expect(wireClaudeImport(tempDir)).toBe('added');
+    const lines = fs.readFileSync(path.join(tempDir, 'CLAUDE.md'), 'utf8').split('\n');
+    expect(lines.some((l) => l.trim() === '@coldstart.md')).toBe(true);
+  });
 });
 
 describe('wireClaudeHooks (settings.json hook wiring)', () => {


### PR DESCRIPTION
First dogfood catch from installing 2.2.0 on coldstart's own repo: `wireClaudeImport` used a substring check, this repo's CLAUDE.md mentions `@coldstart.md` in backticked prose, so init reported "already imports" and never added the real import line — leaving the guidance unwired (Claude Code doesn't resolve imports inside code spans). Fixed with a standalone-line check, symmetric with unwire's line-based strip. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)