### PR TITLE
fix(kb): survive /compact — reprocess shrunk transcript instead of dropping capture evidence

### DIFF
--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -121,6 +121,12 @@ process.on("unhandledRejection", (e) => { log(`unhandled ${e?.stack || e}`); pro
     // This stop's transcript slice (everything since the last processed line).
     const text = readFileSync(transcriptPath, "utf8");
     const lines = text.split("\n");
+    // A transcript SHORTER than our stored offset was replaced out from under us
+    // — Claude Code's /compact rewrites it far shorter (also log rotation). The
+    // offset now points past the end, so slice() would return an empty segment
+    // and silently drop this turn's (and every later turn's) evidence until the
+    // line count grows back. Reset to reprocess the new transcript from its start.
+    if (state.lineCount > lines.length) state.lineCount = 0;
     const segment = lines.slice(state.lineCount).join("\n");
     state.lineCount = lines.length;
 

--- a/tests/kb-elicit-hook.test.ts
+++ b/tests/kb-elicit-hook.test.ts
@@ -149,6 +149,24 @@ describe('kb-elicit v5 trigger', () => {
     expect(res.reason).toContain('src/one.py');
     expect(res.reason).toContain('then stop');
   });
+
+  it('a /compact-shrunk transcript is reprocessed, not silently skipped', () => {
+    const before = Array.from({ length: 10 }, (_, i) => `src/before${i}.py`);
+    seed([...before, 'src/after.py']);
+    const markerPath = path.join(os.tmpdir(), `coldstart-kb-${sid}-main.json`);
+    // stop 1: a long turn grows the transcript well past a handful of lines.
+    expect(stop(before.map((f) => turn([{ name: 'Read', input: { file_path: path.join(root, f) } }])).flat()).trim()).toBe('');
+    const bigLineCount = JSON.parse(fs.readFileSync(markerPath, 'utf8')).lineCount;
+    expect(bigLineCount).toBeGreaterThan(15);
+    // /compact replaces the transcript with a much SHORTER compacted version —
+    // its length is now well below the stored offset.
+    fs.writeFileSync(transcript, JSON.stringify({ type: 'summary', summary: 'compacted' }) + '\n');
+    // stop 2: a real edit lands in the post-compact transcript.
+    expect(stop(turn([{ name: 'Edit', input: { file_path: path.join(root, 'src/after.py') } }])).trim()).toBe('');
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    // Without the shrink guard, slice(bigLineCount) is empty and this edit is lost.
+    expect(marker.files['src/after.py']?.edits).toBe(1);
+  });
 });
 
 describe('kb-elicit SubagentStop (one-shot, still blocking)', () => {


### PR DESCRIPTION
## Problem (dogfood catch)

The Stop hook (`hooks/kb-elicit.mjs`) slices the transcript from a stored line offset (`state.lineCount`) each turn and processes only the new lines. Claude Code's **`/compact`** replaces the transcript with a much *shorter* compacted version. The stored offset then points **past the new end**, so `lines.slice(state.lineCount)` returns `[]` — an empty segment — and `lineCount` silently resets to the short length.

Effect: **after any `/compact`, capture evidence is dropped** for the rest of the session. Files stay marked `captured`, the trigger never re-arms, and no further captures fire. Confirmed live via `.coldstart/kb-hook.log` (heavy-edit turns logged `delta=0`) and the session marker (edited files stuck at `captured: true`). The trigger state machine itself is correct — this is purely lost input.

Claude-Code-only (Cursor/Codex have no compaction), but Claude Code is the primary host and long sessions compact routinely.

## Fix

Detect the shrink before slicing and reprocess the new transcript from its start:

```js
if (state.lineCount > lines.length) state.lineCount = 0;
```

Also covers log rotation / any transcript replacement. Constants (`T_ARM`, `SETTLE_ACTIVE_STOPS`) untouched — a separate replay grid showed no data-backed reason to change them.

## Test

New regression in `tests/kb-elicit-hook.test.ts`: a long first turn, then the transcript is overwritten with a short compacted stub, then a real edit — asserts the edit's evidence is captured (empty without the guard). Full suite: 581 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)