### PR TITLE
v2.2.4 — MCP registry entry + memory-framed package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.4] - 2026-07-23
+
+### Changed
+- **Package metadata now says "memory."** The npm `description` and `keywords` still
+  carried the pre-2.0 "fast static navigation" framing and contained no *memory* token
+  at all, so npm search — and the aggregators that crawl those fields — had nothing to
+  match "codebase memory" or "agent memory" against. Both now lead with the notebook and
+  name the supported clients. No behaviour change.
+
+### Added
+- **`server.json` — listing in the official MCP registry.** `registry.modelcontextprotocol.io`
+  is the canonical index MCP-aware clients enumerate. Publishing there requires an
+  `mcpName` in `package.json` that the registry validates against the *published npm
+  tarball*, so the entry can only reference a version that already exists on npm — which
+  is why this ships as its own release.
+
 ## [2.2.3] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.3",
+  "version": "2.2.4",
+  "mcpName": "io.github.akashgoenka/coldstart",
   "publishConfig": {
     "access": "public"
   },
-  "description": "Fast static codebase navigation for AI agents — `find` ranks relevant files, `gs` shows a file's structure and callers. CLI-first; also a no-shell MCP server.",
+  "description": "Self-maintaining codebase memory for AI coding agents: a deterministic AST index that answers which files matter, plus agent-written notes that flag themselves stale when the code changes. No embeddings, no API key. CLI-first; also a no-shell MCP server for Claude Code, Cursor, and Codex.",
   "type": "module",
   "bin": {
     "coldstart": "./dist/index.js",
@@ -18,6 +19,11 @@
     "vendor/wasm"
   ],
   "keywords": [
+    "memory",
+    "codebase-memory",
+    "agent-memory",
+    "ai-memory",
+    "context",
     "cli",
     "mcp",
     "ai",
@@ -25,6 +31,9 @@
     "navigation",
     "code-navigation",
     "agent",
+    "claude-code",
+    "cursor",
+    "codex",
     "dependency",
     "indexer",
     "tree-sitter"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.akashgoenka/coldstart",
+  "description": "Self-maintaining codebase memory for AI coding agents: a deterministic AST index that answers which files matter, plus agent-written notes that flag themselves stale when the code changes. No embeddings, no API key.",
+  "repository": {
+    "url": "https://github.com/AkashGoenka/coldstart",
+    "source": "github"
+  },
+  "version": "2.2.4",
+  "websiteUrl": "https://akashgoenka.github.io/coldstart/",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@cstart/coldstart",
+      "version": "2.2.4",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes the package-metadata half of the discoverability work. GitHub topics (`codebase-memory`, `ai-memory-system`) and the site's SEO surface were already updated in earlier work — npm and the MCP registry were the remaining gaps.

## The gap

`package.json`'s `description` and `keywords` still carried the pre-2.0 "fast static navigation" pitch, with no *memory* token anywhere. npm search tokenizes exactly those two fields, and the secondary aggregators (Glama, mcp.so) crawl them too — so nothing could match "codebase memory" / "agent memory" no matter what the README said.

Separately, coldstart isn't in `registry.modelcontextprotocol.io`, which is now the canonical index (`modelcontextprotocol/servers` stopped taking README PRs to funnel publishers there) and the mechanism MCP-aware clients use to enumerate servers.

## Changes

- `description` + `keywords` — lead with codebase/agent memory, name Claude Code / Cursor / Codex
- `mcpName` + `server.json` — the official-registry entry
- CHANGELOG entry, version → 2.2.4

## Why this is a release and not just a metadata PR

The registry validates `server.json`'s `name` against the `mcpName` in the **published npm tarball**, and the entry references an npm version that must already exist. So the metadata only takes effect once republished — bundling the bump avoids doing this twice.

## Verification

- `server.json` checked against the `2025-12-11` schema: required `name` (matches the reverse-DNS pattern) / `description` / `version`, `repository.url`+`source`, and `packages[].registryType`/`identifier`/`transport`; `websiteUrl` and `registryBaseUrl` confirmed as real optional fields rather than assumed
- Full suite run locally — **596 tests, 41 files, all passing** (the publish workflow doesn't run tests)

## After merge

`mcp-publisher login github && mcp-publisher publish` — needs a GitHub device-code login, so that one's yours to run once 2.2.4 is on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)