### PR TITLE
v2.2.6 — fix MCP registry namespace casing (403 on publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2026-07-23
+
+### Fixed
+- **MCP registry publish returned 403 on a namespace-casing mismatch.** The registry grants
+  `io.github.<GitHubUsername>/*` using the account's **exact** casing, and 2.2.4/2.2.5 shipped
+  the username lowercased — so `mcp-publisher publish` failed with *"You do not have permission
+  to publish this server. You have permission to publish: io.github.AkashGoenka/*"*. Corrected
+  in both `server.json` (`name`) and `package.json` (`mcpName`); the two must stay identical,
+  and the registry checks `mcpName` against the *published npm tarball*, which is why the fix
+  needs its own release.
+
 ## [2.2.5] - 2026-07-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.5",
-  "mcpName": "io.github.akashgoenka/coldstart",
+  "version": "2.2.6",
+  "mcpName": "io.github.AkashGoenka/coldstart",
   "publishConfig": {
     "access": "public"
   },

--- a/server.json
+++ b/server.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.akashgoenka/coldstart",
+  "name": "io.github.AkashGoenka/coldstart",
   "title": "coldstart",
   "description": "Codebase memory for AI agents: an AST index plus agent-written notes that self-stale.",
   "repository": {
     "url": "https://github.com/AkashGoenka/coldstart",
     "source": "github"
   },
-  "version": "2.2.5",
+  "version": "2.2.6",
   "websiteUrl": "https://akashgoenka.github.io/coldstart/",
   "icons": [
     {
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cstart/coldstart",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
`mcp-publisher publish` failed against 2.2.5:

```
403 Forbidden — You do not have permission to publish this server.
You have permission to publish: io.github.AkashGoenka/*
Attempting to publish: io.github.akashgoenka/coldstart
```

The registry derives the namespace from the GitHub account with its **exact casing**. 2.2.4 and 2.2.5 both shipped the username lowercased.

## Fix

`io.github.akashgoenka/coldstart` → `io.github.AkashGoenka/coldstart` in the only two places it appears: `server.json` `name` and `package.json` `mcpName`. They must stay identical.

Version → 2.2.6, because the registry validates `mcpName` against the **published npm tarball** — a repo-only edit would change nothing.

## Verified

- `mcpName` === `server.json` `name`
- `package.json` / `server.json` `version` / `packages[0].version` all agree at 2.2.6
- ajv against the published `2025-12-11` schema: **VALID**
- The name pattern `^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$` permits uppercase, so this was never a schema violation — schema validation could not have caught it. It's an authorization rule, only observable at publish time.
- `npm run build` clean; **596 tests, 41 files, all passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)