### PR TITLE
chore(glama): use Glama's exact badge markdown in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,4 @@ MIT — see [LICENSE](./LICENSE).
 
 ---
 
-<div align="center">
-
-<a href="https://glama.ai/mcp/servers/AkashGoenka/coldstart"><img alt="coldstart MCP server" src="https://glama.ai/mcp/servers/AkashGoenka/coldstart/badges/card.svg" width="380" height="200" /></a>
-
-</div>
+[![coldstart MCP server](https://glama.ai/mcp/servers/AkashGoenka/coldstart/badges/card.svg)](https://glama.ai/mcp/servers/AkashGoenka/coldstart)


### PR DESCRIPTION
One-line follow-up to #93.

#93 shipped the Glama directory card as an HTML anchor with hardcoded `380x200` dimensions inside a centered `<div>`:

```html
<div align="center">
<a href="…"><img alt="coldstart MCP server" src="…/card.svg" width="380" height="200" /></a>
</div>
```

The URLs were correct, but there was no reason to deviate from the snippet Glama publishes to maintainers — and pinning the dimensions would misrender if Glama ever changes the card's aspect ratio. Restored verbatim:

```markdown
[![coldstart MCP server](https://glama.ai/mcp/servers/AkashGoenka/coldstart/badges/card.svg)](https://glama.ai/mcp/servers/AkashGoenka/coldstart)
```

README-only, one line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)