### PR TITLE
fix(kb): unblock new flow notes + log the flow decision

### DIFF
--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -127,25 +127,27 @@ agent; there is no "next".
 11. Never copy secret VALUES (env contents, tokens, keys) into a note — notes are committed \
 to git.
 
-FLOWS — rare. While investigating you will see flows everywhere: every file connects to \
-something, every feature has a chain. Those connections are not flow notes — at that rate, \
-everything would be a flow.
-A flow note records PRODUCT-level knowledge: how the system behaves as a whole, knowledge no \
-single file owns. The test, for every candidate: is this about how the CODEBASE works, or \
-about how one file works? File-level → it belongs in that file's note. Product-level → flow.
-Examples that can qualify:
+FLOWS — the product-level layer. A flow note records knowledge no single file owns: how the \
+system behaves as a whole. The test, for every candidate: is this about how the CODEBASE \
+works, or about how one file works? File-level → it belongs in that file's note. \
+Product-level → flow.
+Examples that qualify:
 - how authentication works end-to-end
 - how UI components get rendered under different conditions
 - how a file is consumed along a path when its imports don't reveal it and the gotcha spans \
 the path (a single non-obvious consumer is NOT a flow — it goes in that file's own note, rule 6)
 The summary's FIRST sentence states the product-level fact — the thing a reader of all the \
-file notes would still be missing.
+file notes would still be missing. If you cannot write that sentence, there is no flow.
 Steps are the minimal chain, each with its role. kb write WARNS when fewer than two steps \
 are files you read this session — a flow assembled from grep hits is the classic bad flow; \
 take that warning seriously.
 Never a flow: a feature's parts-list, a relationship the import graph already shows, a \
 mechanism living in one file.
-kb search first — update the existing flow, never a near-duplicate.
+kb search first. UPDATE an existing flow only when your missing-fact sentence is THE SAME \
+fact it already leads with — new detail about a mechanism it already tells. A DIFFERENT \
+missing fact is a NEW flow, even in the same subsystem, even across the same files. Folding \
+an unrelated fact into a nearby flow buries it: nobody searching for your fact will find that \
+title.
 
 WRITE — one Bash block total: specs as heredocs, writes chained with &&.
   {"type":"file-single","path":"src/x.py","summary":"1-3 sentences","aliases":["symptom words"]}
@@ -156,5 +158,7 @@ with several of its symbols. file-hub is ONLY for grab-bag files that have no si
 not make a file a hub; having no one purpose does.
   Update = the same spec plus "id":"<id from the worklist>".
   node ${cli} kb write /tmp/spec1.json --root ${root} --session ${sid} --force
-  Flow/lesson shapes: run \`node ${cli} kb write --root ${root}\` with no spec — it prints the full guide.${tail}`;
+  Flow/lesson shapes: run \`node ${cli} kb write --root ${root}\` with no spec — it prints the full guide.
+  LAST line of the block, always — even when you wrote nothing at all:
+  node ${cli} kb flow-decision --decision <none|new|update> [--id <flow id>] --why "<one clause>" --root ${root} --session ${sid}${tail}`;
 }

--- a/src/kb/cli.ts
+++ b/src/kb/cli.ts
@@ -53,6 +53,8 @@ interface KbFlags {
   session?: string;
   message?: string;
   noOpen: boolean;
+  decision?: string;
+  why?: string;
 }
 
 function parseKbArgs(argv: string[]): { positional: string[]; flags: KbFlags } {
@@ -75,6 +77,8 @@ function parseKbArgs(argv: string[]): { positional: string[]; flags: KbFlags } {
       case '--paths': flags.paths = String(argv[++i] ?? '').split(',').map((s) => s.trim()).filter(Boolean); break;
       case '--session': flags.session = argv[++i]; break;
       case '-m': case '--message': flags.message = argv[++i]; break;
+      case '--decision': flags.decision = argv[++i]; break;
+      case '--why': flags.why = argv[++i]; break;
       default:
         if (a.startsWith('--')) err(`[coldstart kb] unknown flag: ${a}`);
         else positional.push(a);
@@ -106,6 +110,7 @@ export async function runKb(argv: string[]): Promise<number> {
     case 'lookup': return cmdLookup(positional, flags);
     case 'write': return cmdWrite(positional, flags);
     case 'status': return cmdStatus(flags);
+    case 'flow-decision': return cmdFlowDecision(flags);
     case 'lint': return cmdLint(flags);
     case 'render': {
       if (!requireNotebook(root)) return 2;
@@ -279,6 +284,29 @@ async function cmdWrite(positional: string[], flags: KbFlags): Promise<number> {
     ? '\n' + warnings.map((w) => `warning: ${w}`).join('\n')
     : '';
   out(`kb write: ${result.op} → ${result.id}${warned}`);
+  return 0;
+}
+
+/** Record the capture's flow decision — the one capture outcome writes cannot show.
+ *  `capture.jsonl` already logs every note WRITTEN with its type, so "a flow was
+ *  created/updated" is observable; "a flow was considered and declined" is not, and
+ *  neither is "the knowledge was folded into an existing flow instead of a new one".
+ *  Without those two, a flow-rate change is uninterpretable — we cannot tell a prompt
+ *  that suppresses flows from one agents never reach. Diagnostic instrument: remove it
+ *  once the flow gate is tuned. Best-effort, never fails a capture. */
+function cmdFlowDecision(flags: KbFlags): number {
+  const decision = flags.decision;
+  if (!decision || !['none', 'new', 'update'].includes(decision)) {
+    out('usage: kb flow-decision --decision none|new|update [--id <flow id>] [--why "<one clause>"]');
+    return 2;
+  }
+  logMetric(flags.root, 'capture', {
+    event: 'flow-decision',
+    decision,
+    id: flags.id,
+    why: flags.why,
+    session: flags.session,
+  });
   return 0;
 }
 


### PR DESCRIPTION
Zero new flow notes in six days. The notebook has 22 notes: 21 file, 1 flow — and that flow was written in the Jul 18 bootstrap batch, the first record in the notebook.

The metrics reframe it. capture.jsonl shows 36 file / 6 flow writes (14%, a healthy rate) — but all 6 flow writes target the SAME id. Agents are not skipping flows; they consider them repeatedly, then always fold into the existing one. The checklist said "update the existing flow, never a near-duplicate" with nothing describing when a NEW flow is warranted.

#70 tightened the gate for good reason (a 22-flow probe on arches found 32% junk). v5 (#77) then relaxed the criteria back to "product-level knowledge" with healthy examples — but kept "FLOWS — rare" and added the flows-everywhere paragraph. The test got easier while the permission got weaker.

Prompt (hooks/capture-payload.mjs):
- neutral opener; drop "rare" + the flows-everywhere paragraph
- the missing-fact gate absorbs the kill clause it lost: "if you cannot write that sentence, there is no flow"
- new update-vs-create rule: a DIFFERENT missing fact is a new flow, even in the same subsystem. Folding it into a nearby flow buries it.
- never-list, the two-step WARN, and the criteria are untouched — those are what killed the 32%.

Instrument (src/kb/cli.ts): kb flow-decision --decision none|new|update [--id] [--why] appends to capture.jsonl. Writes already record what was written; nothing records "considered and declined" or "folded into an existing flow" — without those a flow-rate change is uninterpretable. Diagnostic; remove once the gate is tuned. Coldstart stays local — this is our own notebook only, never telemetry.

606 tests pass.