### PR TITLE
fix(mcp): survive directory introspection — empty resources/prompts, roots after handshake

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -4,6 +4,9 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   ListRootsResultSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListPromptsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { IndexContext } from '../index-manager.js';
 import { getCurrentVersion } from '../daemon-lock.js';
@@ -174,6 +177,12 @@ export function registerToolHandlers(
     tools: TOOL_DEFINITIONS,
   }));
 
+  // Stubs backing the empty resources/prompts capabilities declared in
+  // createMcpServer — coldstart exposes tools only.
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [] }));
+
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     const params = (args ?? {}) as Record<string, unknown>;
@@ -336,7 +345,17 @@ export const SERVER_INSTRUCTIONS = [
 export function createMcpServer(getContext: () => Promise<IndexContext>, opts: McpServerOptions = {}): Server {
   const server = new Server(
     { name: 'coldstart', version: getCurrentVersion() },
-    { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
+    {
+      // resources/prompts are declared EMPTY on purpose. coldstart has neither,
+      // and answering `-32601 Method not found` is spec-correct — but directory
+      // crawlers (Glama) introspect all three lists in one pass, and at least one
+      // treats an error reply as a failed inspection and stores nothing at all,
+      // losing the tools it had already read. An empty list costs nothing and
+      // cannot be misread. See registerToolHandlers for the stub handlers that
+      // make these declarations honest.
+      capabilities: { tools: {}, resources: {}, prompts: {} },
+      instructions: SERVER_INSTRUCTIONS,
+    },
   );
   registerToolHandlers(server, getContext, opts);
   return server;
@@ -352,10 +371,27 @@ export async function startMCPServer(
 ): Promise<void> {
   const server = createMcpServer(getContext, opts);
 
+  // Wait for `notifications/initialized` before originating any request of our
+  // own. `server.connect()` resolves when the TRANSPORT opens, not when the
+  // handshake completes — asking for roots straight after it put a server→client
+  // request on the wire BEFORE we had answered the client's `initialize`, and it
+  // carried outbound id 0, which collides with clients that number their own
+  // requests from 0. Spec-legal (ids are scoped per requestor) but a client
+  // keeping one id table for both directions loses its pending initialize.
+  const initialized = new Promise<void>((resolve) => {
+    server.oninitialized = () => resolve();
+  });
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  // After connect, ask for roots — cap at 1s so standalone runs don't stall
+  // Don't hang forever on a client that never sends `initialized`.
+  await Promise.race([
+    initialized,
+    new Promise<void>((resolve) => setTimeout(resolve, 2000).unref?.()),
+  ]);
+
+  // Handshake done — now ask for roots. Cap at 1s so standalone runs don't stall.
   let clientRoots: string[] = [];
   try {
     const result = await server.request(


### PR DESCRIPTION
## Why

Glama's container log showed the build running, the server starting, and all six tools serialized correctly over the wire — yet the listing's `tools[]` and `attributes[]` stayed empty and the schema page still reads *"Server capabilities have not been inspected yet."*

Nothing was stored from a conversation that demonstrably succeeded. So the inspection aborts partway through, and two defects on our side can cause that. Both are in the handshake.

## What

**1. `resources/list` and `prompts/list` answered `-32601`.** Spec-correct — we declare only the `tools` capability — but a crawler that introspects all three lists in one pass and treats an error reply as a failed inspection discards the tools it already read. That is the very next step after the successful `tools/list`, which is exactly where their job stops. Now both capabilities are declared empty and backed by stub handlers (plus `resources/templates/list`), so the pass completes.

**2. `roots/list` went out immediately after `server.connect()`,** which resolves when the transport opens rather than when the handshake completes. That put a server→client request on the wire *before* the `initialize` response, carrying outbound id `0` — colliding with clients that number their own requests from 0, as Glama's does. Ids are scoped per requestor so this is legal, but a client keeping one id table for both directions loses its pending initialize. Now waits for `notifications/initialized`, with a 2s cap so a client that never sends one can't hang startup.

## Testing

Every earlier local test passed because the simulator opened with id `1`. Re-tested with a client numbering from `0`, matching Glama's:

```
initialize        : OK
  capabilities    : {"tools":{},"resources":{},"prompts":{}}
  instructions    : 758 chars
  server-req before initialize response: NONE
tools/list        : OK (6 items)
resources/list    : OK (0 items)
prompts/list      : OK (0 items)
resources/templates/list: OK (0 items)
```

Full suite green — 606 tests, 41 files.

## Confidence

The ordering/id collision is **proven present**. That either defect *causes* Glama's empty `tools[]` is a strong hypothesis, not proven — their inspector is a black box. Both are genuine protocol-hygiene bugs worth fixing regardless. Glama builds from `main` HEAD (`pinnedCommit: null`), so a rebuild after merge is a clean test: if `tools[]` populates, that was it; if not, our side is eliminated and the log goes to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)