### PR TITLE
fix(capture): freeze repo root against cwd drift + always log the flow decision

### DIFF
--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -159,6 +159,10 @@ not make a file a hub; having no one purpose does.
   Update = the same spec plus "id":"<id from the worklist>".
   node ${cli} kb write /tmp/spec1.json --root ${root} --session ${sid} --force
   Flow/lesson shapes: run \`node ${cli} kb write --root ${root}\` with no spec — it prints the full guide.
-  LAST line of the block, always — even when you wrote nothing at all:
+
+FLOW DECISION — run this EVERY time, as its own command. It stands apart from the WRITE block \
+above: run it even when you decided no note was warranted and emitted no Bash block at all. It \
+records only what you decided about FLOWS (created a new one, folded into an existing one, or \
+none) so the flow gate can be measured.
   node ${cli} kb flow-decision --decision <none|new|update> [--id <flow id>] --why "<one clause>" --root ${root} --session ${sid}${tail}`;
 }

--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -29,7 +29,7 @@
  */
 
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync, writeFileSync, appendFileSync, readFileSync, readdirSync, statSync } from "node:fs";
 
@@ -49,6 +49,31 @@ let LOG_FILE = join(tmpdir(), "coldstart-kb-hook.log");
 function setLogRoot(root) { if (root) LOG_FILE = join(root, ".coldstart", "kb-hook.log"); }
 function log(msg) {
   try { appendFileSync(LOG_FILE, `[${new Date().toISOString()}] elicit: ${msg}\n`); } catch { /* never fail logging */ }
+}
+
+// --- Repo-root resolution ----------------------------------------------------
+/**
+ * The Stop payload's `cwd` tracks the session's shell, which a `cd` inside a
+ * Bash call moves — sometimes clean OUT of the repo (e.g. into ~/.claude/…/memory
+ * to edit private files). Root was taken raw from that cwd, so normRel would then
+ * strip the WRONG prefix and admit a foreign absolute path into the worklist as if
+ * it were repo-local (observed 2026-07-25: MEMORY.md / drive.mjs entered a marker).
+ * A notebook-inited repo carries a `.coldstart/notebook/` dir, so walk up from cwd
+ * to the nearest ancestor that has one — that is the true root regardless of shell
+ * drift. `.coldstart/notebook` (not bare `.coldstart`) is the marker on purpose: the
+ * GLOBAL `~/.coldstart` dir holds daemon/searcher state and no notebook, so a drift
+ * into ~ must not resolve to the home directory.
+ * Returns "" when cwd is not inside any notebook-inited repo.
+ */
+function findRepoRoot(startDir) {
+  let dir = resolve(startDir || ".");
+  for (let i = 0; i < 40; i++) {
+    if (existsSync(join(dir, ".coldstart", "notebook"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "";
 }
 
 // --- Subagent transcript resolution ------------------------------------------
@@ -193,8 +218,8 @@ if (process.argv.includes("--manual")) {
   } catch (e) { log(`bad stdin ${e}`); }
 
   try {
-    const root = String(input.cwd || "");
-    setLogRoot(root);
+    const cwd = String(input.cwd || "");
+    setLogRoot(cwd);
 
     // Guard 1: already inside a hook-induced continuation → let it stop.
     if (input.stop_hook_active === true) { log("SKIP stop_hook_active"); process.exit(0); }
@@ -229,7 +254,6 @@ if (process.argv.includes("--manual")) {
     }
     if (!transcriptPath || !existsSync(transcriptPath)) { log("SKIP no-transcript"); process.exit(0); }
 
-    const ignore = loadIgnore(root);
     const marker = join(tmpdir(), `coldstart-kb-${sid}-${aid}.json`);
     let state = null;
     try {
@@ -238,6 +262,15 @@ if (process.argv.includes("--manual")) {
     } catch { /* first Stop of this session (or a pre-v5 marker: start fresh) */ }
     const freshMarker = !state; // no valid prior marker: we're attaching, not resuming our own place
     if (!state) state = initialState();
+
+    // Freeze the repo root in the marker: derive it once (walk-up from cwd), then
+    // reuse the stored value on every later stop so a mid-session `cd` out of the
+    // repo can never re-point root at a foreign tree. Fall back to the raw cwd only
+    // when neither a stored root nor a `.coldstart` ancestor exists.
+    const root = (typeof state.root === "string" && state.root) ? state.root : (findRepoRoot(cwd) || cwd);
+    state.root = root;
+    setLogRoot(root);
+    const ignore = loadIgnore(root);
 
     // This stop's transcript slice (everything since the last processed line).
     const text = readFileSync(transcriptPath, "utf8");

--- a/tests/kb-elicit-hook.test.ts
+++ b/tests/kb-elicit-hook.test.ts
@@ -46,13 +46,13 @@ function turn(tools: Array<{ name: string; input: Record<string, unknown> }>): s
 }
 
 /** Append lines to the session transcript and invoke one Stop. */
-function stop(lines: string[], opts: { event?: string; aid?: string; transcriptPath?: string } = {}): string {
+function stop(lines: string[], opts: { event?: string; aid?: string; transcriptPath?: string; cwd?: string } = {}): string {
   const tp = opts.transcriptPath ?? transcript;
   fs.appendFileSync(tp, lines.length ? lines.join('\n') + '\n' : '');
   const payload = JSON.stringify({
     session_id: sid,
     agent_id: opts.aid,
-    cwd: root,
+    cwd: opts.cwd ?? root,
     transcript_path: transcript,
     ...(opts.aid ? { agent_transcript_path: tp } : {}),
     hook_event_name: opts.event ?? 'Stop',
@@ -79,6 +79,26 @@ describe('kb-elicit v5 trigger', () => {
     const marker = JSON.parse(fs.readFileSync(path.join(os.tmpdir(), `coldstart-kb-${sid}-main.json`), 'utf8'));
     expect(marker.files['src/app.py'].reads).toBe(1);
     expect(fs.existsSync(pendingFile())).toBe(false);
+  });
+
+  it('a cwd that drifts OUT of the repo cannot admit a foreign file into the worklist', () => {
+    seed(['src/app.py']);
+    const markerPath = path.join(os.tmpdir(), `coldstart-kb-${sid}-main.json`);
+    // stop 1: a normal in-repo read freezes root = the repo (recorded in the marker).
+    stop(turn([{ name: 'Read', input: { file_path: path.join(root, 'src/app.py') } }]));
+    const m1 = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    expect(m1.root).toBe(root);
+    expect(m1.files['src/app.py'].reads).toBe(1);
+
+    // stop 2: the shell has cd'd clean out of the repo (e.g. into ~/.claude/…/memory)
+    // and edited a private file there. Its absolute path is OUTSIDE the frozen root,
+    // so it must be dropped — never stripped to a repo-relative-looking "MEMORY.md".
+    const foreign = path.join(os.tmpdir(), `not-the-repo-${sid}`, 'MEMORY.md');
+    stop(turn([{ name: 'Edit', input: { file_path: foreign } }]), { cwd: path.dirname(foreign) });
+    const m2 = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    expect(m2.root).toBe(root); // frozen root held against the drifted cwd
+    expect(m2.files['MEMORY.md']).toBeUndefined();
+    expect(Object.keys(m2.files)).toEqual(['src/app.py']);
   });
 
   it('arm on volume, fire on descent → pending file for next-prompt delivery, stop never blocked', () => {


### PR DESCRIPTION
Two capture defects, both observed in a live session.

## 1. The worklist admitted foreign files (correctness)

`kb-elicit` took the repo root straight from the Stop hook payload's `cwd`. That `cwd` tracks the session's shell, which a `cd` inside a Bash call moves — sometimes clean **out** of the repo (e.g. into `~/.claude/…/memory` to edit private files). `normRel` then stripped the *wrong* prefix, so an absolute foreign path was recorded as if it were repo-local.

Observed in a real marker: `MEMORY.md` (reads 2 / edits 9), `drive.mjs`, `proxy.log`, and several `project_*.md` files — none in the repo — sat in the worklist alongside legitimate files, each entering at exactly the stop where the shell had `cd`'d elsewhere. The blast radius is a committed notebook note about a file that isn't in the repo. (No bad note shipped this time — the agent's own judgment declined them — but that was luck, not design.)

**Fix:** derive the root once by walking up from `cwd` to the nearest `.coldstart/notebook/` ancestor, **freeze it in the session marker**, and reuse the stored value on every later stop so a mid-session `cd` can never re-point it. `.coldstart/notebook` (not bare `.coldstart`) is the marker on purpose — the global `~/.coldstart` holds daemon/searcher state and no notebook, so a drift into `~` must not resolve to the home directory.

Replayed against the exact offending transcript under the frozen root: all 7 foreign files drop; `site/sitemap.xml`, `src/server/mcp.ts`, `hooks/evidence.mjs` remain. Regression test reproduces the drift.

## 2. `none` flow-decisions went unrecorded (diagnostic completeness)

The `kb flow-decision` line lived *inside* the WRITE block, but an agent that decides no note is warranted emits no Bash block at all — so the `none` decline was never logged, biasing the flow-gate metric toward `new`/`update`. Promoted to a standalone step that runs every time, independent of whether any note was written.

## Test

`npm test` → 607 passing (was 606; +1 regression: "a cwd that drifts OUT of the repo cannot admit a foreign file into the worklist").

🤖 Generated with [Claude Code](https://claude.com/claude-code)