### PR TITLE
feat(site): blog with four engineering essays + a real reading surface

### DIFF
--- a/site/blog.html
+++ b/site/blog.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>coldstart blog - engineering writing on AI coding agents</title>
+<meta name="description" content="The coldstart blog: engineering notes on AI coding agents, repeated repository orientation, codebase notes, and why durable context is harder than generic memory." />
+<meta name="keywords" content="AI coding agents, codebase memory, repository orientation, coding agent notes, Claude Code, Codex, Cursor, coldstart blog" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog.html" />
+<link rel="icon" type="image/svg+xml" href="logo.svg" />
+<link rel="apple-touch-icon" href="logo.svg" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="coldstart blog - engineering writing on AI coding agents" />
+<meta property="og:description" content="Engineering notes about repeated repository orientation, codebase notes, and durable context for AI coding agents." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="coldstart blog - engineering writing on AI coding agents" />
+<meta name="twitter:description" content="Engineering notes about repeated repository orientation, codebase notes, and durable context for AI coding agents." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "name": "coldstart blog",
+  "description": "Engineering notes on AI coding agents, repeated repository orientation, and codebase notes.",
+  "url": "https://akashgoenka.github.io/coldstart/blog.html",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "blogPost": [
+    {
+      "@type": "BlogPosting",
+      "headline": "Where the tokens go in an agent session",
+      "url": "https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html",
+      "datePublished": "2026-07-25",
+      "author": { "@type": "Person", "name": "Akash Goenka" }
+    },
+    {
+      "@type": "BlogPosting",
+      "headline": "Why an index of your code cannot answer the same question twice",
+      "url": "https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html",
+      "datePublished": "2026-07-25",
+      "author": { "@type": "Person", "name": "Akash Goenka" }
+    },
+    {
+      "@type": "BlogPosting",
+      "headline": "The tool the agent does not call",
+      "url": "https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html",
+      "datePublished": "2026-07-25",
+      "author": { "@type": "Person", "name": "Akash Goenka" }
+    },
+    {
+      "@type": "BlogPosting",
+      "headline": "From four tools to two",
+      "url": "https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html",
+      "datePublished": "2026-07-25",
+      "author": { "@type": "Person", "name": "Akash Goenka" }
+    },
+    {
+      "@type": "BlogPosting",
+      "headline": "Notes about code should be written by whoever read the code",
+      "url": "https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html",
+      "datePublished": "2026-07-25",
+      "author": { "@type": "Person", "name": "Akash Goenka" }
+    }
+  ]
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+
+<main class="essay-wrap">
+  <section class="essay-hero">
+    <div class="kicker">Blog</div>
+    <h1>Notes on agents, codebases, and the work before the work.</h1>
+    <p class="lead-p">Problem-first engineering writing about why agents keep starting cold, why notes are different from documentation, and why some context should be captured only after real work.</p>
+  </section>
+
+  <section class="essay-list" aria-label="Blog">
+    <a class="essay-card" href="blog/where-the-tokens-go.html">
+      <span class="essay-meta">Cost <span class="sep">·</span> <time datetime="2026-07-25">25 Jul 2026</time> <span class="sep">·</span> <span class="rt">7 min</span></span>
+      <h2>Where the tokens go in an agent session</h2>
+      <p>Most of what a session bills for is not the answer it produced. It is the same context, re-sent on every turn. Decomposing that leaves exactly one lever worth pulling.</p>
+    </a>
+    <a class="essay-card" href="blog/an-index-cannot-answer-twice.html">
+      <span class="essay-meta">Codebase memory <span class="sep">·</span> <time datetime="2026-07-25">25 Jul 2026</time> <span class="sep">·</span> <span class="rt">9 min</span></span>
+      <h2>Why an index of your code cannot answer the same question twice</h2>
+      <p>A graph makes each hop cheaper. It does not reduce the number of hops, and because it is regenerated from source, the second investigation costs exactly what the first one did.</p>
+    </a>
+    <a class="essay-card" href="blog/the-tool-the-agent-doesnt-call.html">
+      <span class="essay-meta">Adoption <span class="sep">·</span> <time datetime="2026-07-25">25 Jul 2026</time> <span class="sep">·</span> <span class="rt">8 min</span></span>
+      <h2>The tool the agent does not call</h2>
+      <p>Availability, documentation, and an explicit instruction still do not add up to adoption. Including the hook-gating mistake I shipped and then found in someone else's source.</p>
+    </a>
+    <a class="essay-card" href="blog/from-four-tools-to-two.html">
+      <span class="essay-meta">Design <span class="sep">·</span> <time datetime="2026-07-25">25 Jul 2026</time> <span class="sep">·</span> <span class="rt">12 min</span></span>
+      <h2>From four tools to two</h2>
+      <p>An origin story told through deletions. Two traversal tools that turned out to be missing fields, a set of labels that were guesses in the costume of facts, and a server that served nothing.</p>
+    </a>
+    <a class="essay-card" href="blog/notes-should-be-written-by-whoever-read-the-code.html">
+      <span class="essay-meta">Codebase notes <span class="sep">·</span> <time datetime="2026-07-25">25 Jul 2026</time> <span class="sep">·</span> <span class="rt">6 min</span></span>
+      <h2>Notes about code should be written by whoever read the code</h2>
+      <p>A transcript is not the same thing as context. The agent that did the work is usually the only one qualified to write down what was learned.</p>
+    </a>
+  </section>
+</main>
+
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links">
+      <a href="index.html">Home</a>
+      <a href="docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/blog/README.md
+++ b/site/blog/README.md
@@ -1,0 +1,42 @@
+# Coldstart Article Strategy
+
+This section is for problem-first engineering writing, not product announcements.
+
+The goal is to make coldstart's site a useful source on the engineering problems around AI coding agents: repeated repository orientation, codebase notes, durable investigations, navigation, and the difference between finding code and remembering what was learned about it.
+
+## Editorial Rules
+
+- Start with a real engineering problem.
+- Explain why obvious approaches are incomplete.
+- Use observations from real development work where available.
+- Separate evidence, design judgment, and speculation.
+- Discuss tradeoffs plainly.
+- Introduce coldstart only near the end, as one implementation of the idea.
+- Keep each article useful even if the reader never installs coldstart.
+
+Avoid hype, exaggerated claims, AI buzzwords, and benchmark numbers that are not ready to publish.
+
+## Core Topics
+
+1. Why AI coding agents keep starting cold.
+2. Search is not memory.
+3. Why repositories are harder than documentation.
+4. What we learned benchmarking repository navigation.
+5. Why coldstart avoids embeddings.
+6. The cost of rediscovering code.
+7. Repository notebooks vs documentation.
+8. Building tools for AI agents without a server.
+9. The difference between navigation and understanding.
+10. Lessons learned building coldstart.
+
+## Audience
+
+Write for software engineers, engineering managers, open source contributors, and people using tools like Claude Code, Cursor, Codex, and Gemini CLI.
+
+Assume technical competence. Do not write like a launch post.
+
+## Publishing
+
+The canonical home is this site: `https://akashgoenka.github.io/coldstart/`.
+
+Blog can later be adapted for DEV, LinkedIn, GitHub Discussions, and relevant Reddit answers, but the source essay should live here first.

--- a/site/blog/an-index-cannot-answer-twice.html
+++ b/site/blog/an-index-cannot-answer-twice.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Why an index of your code cannot answer the same question twice - coldstart</title>
+<meta name="description" content="A code graph makes each step of a search cheaper. It does not reduce the number of steps, and it never makes the second occurrence of a question cheaper than the first. Why that gap needs a different kind of record." />
+<meta name="keywords" content="code knowledge graph, codebase index, call graph, code search ranking, agent codebase memory, static analysis limits" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<link rel="apple-touch-icon" href="../logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="Why an index of your code cannot answer the same question twice" />
+<meta property="og:description" content="A graph makes each hop cheaper. It does not reduce the number of hops, and the second time you ask, it is identical." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Why an index of your code cannot answer the same question twice" />
+<meta name="twitter:description" content="A graph makes each hop cheaper. It does not reduce the number of hops, and the second time you ask, it is identical." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="../docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Why an index of your code cannot answer the same question twice",
+  "description": "A code graph makes each step of a search cheaper. It does not reduce the number of steps, and it never makes the second occurrence of a question cheaper than the first.",
+  "url": "https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html",
+  "mainEntityOfPage": "https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html",
+  "image": "https://akashgoenka.github.io/coldstart/og.png",
+  "datePublished": "2026-07-25",
+  "dateModified": "2026-07-25",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "publisher": { "@type": "Person", "name": "Akash Goenka" },
+  "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="../index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="../blog.html">Blog</a>
+      <a href="../docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="../index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+<article class="essay-wrap essay-article">
+  <a class="back-link" href="../blog.html">← All posts</a>
+  <header class="essay-hero">
+    <div class="kicker">Codebase memory</div>
+    <h1>Why an index of your code cannot answer the same question twice</h1>
+    <p class="lead-p">Building a graph of a repository is a good idea and it works. It is also the wrong shape for one specific job that people keep expecting it to do, and the reason is not a quality problem you can fix with better parsing.</p>
+    <div class="article-meta">
+      <span>Akash Goenka</span>
+      <span class="sep">·</span>
+      <time datetime="2026-07-25">25 July 2026</time>
+      <span class="sep">·</span>
+      <span>9 min read</span>
+    </div>
+  </header>
+
+  <p>There is a category of tool that parses your repository into a graph. Files, symbols, imports, calls, sometimes inheritance and route definitions. The agent gets operations for querying it: find this symbol, show what calls it, walk from here to there. Some of them render the graph in three dimensions and it looks genuinely impressive.</p>
+  <p>I have spent time inside one of these, reading its source and its database rather than its documentation. I want to start by conceding what it does well, because the criticism only means something after the concession.</p>
+
+  <h2>What a graph genuinely gives you</h2>
+  <p>It makes each step cheaper.</p>
+  <p>Asking "what calls this function" without a graph means a text search, then reading candidates to work out which hits are real calls rather than a comment, a string, or an unrelated method with the same name. With a resolved call graph, the answer arrives directly. That is a real saving, it is not marketing, and any honest comparison has to start there.</p>
+  <p>The same applies to reverse imports, to inheritance chains, and to the general class of question where the answer is a relationship rather than a location. Text search is bad at those. A graph is good at them. Fine.</p>
+
+  <h2>The thing it does not change</h2>
+  <p>What a graph makes cheaper is the individual hop. What it does not touch is how many hops you need.</p>
+  <p>Consider what actually happens when an agent is given a task in an unfamiliar repository. Almost none of it is graph-shaped. The task arrives as a sentence in a human's vocabulary, something like "the export is timing out for large accounts." There is no node called that. Before any relationship question can be asked, the agent has to work out which files this sentence is even about, and that is a discovery problem, not a traversal problem.</p>
+  <p>You cannot traverse a graph until you know where to enter it. Finding the entry point is the expensive part, and it is the part the graph does not help with.</p>
+  <p>When I traced what these tools do at that first step, the answer was blunter than I expected. The entry point is found by text search. A grep, essentially, against the repository, with the results then sorted using the graph. The graph is not being traversed at all in the common case. It is being used to rank the output of a text search.</p>
+
+  <h2>Ranking by popularity has a specific failure</h2>
+  <p>That ranking step is worth looking at closely, because the way it usually works has a consequence people do not expect.</p>
+  <p>The natural signal a graph offers for ranking is how connected a node is. A file that many other files import is probably important. So results get ordered by something like incoming edge count, with adjustments for whether the hit is a function or a route, and penalties for vendored code and tests.</p>
+  <p>Read that scoring rule carefully and something is missing from it. The query. How well a file matches what you actually asked contributes nothing to its position. The ranking is a popularity prior, computed before your question existed and identical no matter what you type.</p>
+  <p>For a lot of questions that is fine, because popular files are often relevant. It fails in a specific and predictable way: any file that is important without being widely imported is structurally unrankable. A database migration. A configuration file. A one-off definition that exactly one caller uses. A test fixture that encodes the real expected behaviour. These have almost no incoming edges by construction, so they sort to the bottom regardless of how precisely they match the question.</p>
+  <p>And a fair share of real answers live in exactly those files. The migration is where the column was actually renamed. The config file is where the timeout is actually set. If your ranking is popularity, the leaf where the answer lives loses to a widely imported file that merely mentions the same word.</p>
+  <p>Relevance has to include the query. That sounds too obvious to state until you find a scoring function that omits it.</p>
+
+  <h2>More edges is not more correct edges</h2>
+  <p>The other thing worth checking is what the edges mean.</p>
+  <p>Resolving a call from one file to another is hard in a dynamic language. You see a method being called on something, and to know which definition that refers to you need the type, which often is not written down. So resolvers guess. A common approach is to match on name: if exactly one function in the project has this name, link to it, and if several do, pick by some heuristic.</p>
+  <p>I pulled the edges out of one of these databases and looked at what the guesses were. A large share pointed at language builtins, which is technically true and useless: knowing that a piece of code calls a dictionary lookup tells you nothing about your repository. Another large share were cases where the resolver had many candidates with the same name and picked one. Sampling those at random, the ones I checked were wrong. One linked a call in JavaScript to a Python test fixture that happened to share a name.</p>
+  <p>The edge count was several times larger than the one I maintain. Once builtins and coin flips came out, the real gap was much smaller than the headline. This is not an accusation of bad faith. It is what happens when a number becomes a feature: the incentive is to count edges, and nothing in the interface distinguishes a resolved edge from a guess. Confidence is often recorded internally and then not shown to the agent, which means the agent treats a coin flip and a certainty identically.</p>
+  <p>If you are evaluating one of these, the useful question is not how many edges. It is what fraction of call sites resolved at all, and of those, how many had exactly one candidate. Those two numbers are the honest ones and they are rarely published.</p>
+
+  <h2>The part that actually bothers me</h2>
+  <p>Everything so far is a quality argument, and quality arguments can be answered with better engineering. Someone can improve the resolver, add the query to the ranking, expose confidence. The next objection cannot be fixed that way, because it is about what kind of object a graph is.</p>
+  <p>A graph is derived from your source code. That is its great virtue. It is never out of date, because you can regenerate it, and if the code changed the graph changes with it.</p>
+  <p>It is also the limit. Everything in the graph is already in the code. The graph is a re-description, in a form that is faster to query. It contains no information that was not sitting in the repository already.</p>
+  <p>Which means it cannot record a conclusion.</p>
+  <p>Say someone spends two hours on a timeout bug. They check the obvious place, the request handler, and it is not there. They check the client configuration, also not there. Eventually they find that a connection pool is being exhausted by a retry loop three files away, and that two files have to change together because an invariant lives between them and neither one states it.</p>
+  <p>Now ask what of that is in the graph. The edges between those files, maybe, if the resolver was good. Not the fact that the handler was checked and cleared. Not the reason the two files are coupled. Not the invariant, which is not written anywhere in the code, which is precisely why the bug existed.</p>
+  <p>Six weeks later the same area breaks again. The graph is regenerated from the same source and it is byte for byte what it was before. It has learned nothing, because it is not the kind of thing that can learn. The second investigation starts exactly where the first one did, and re-derives the same conclusions at the same cost.</p>
+  <p>That is the claim in one line. A graph makes each hop cheaper. It does not reduce the number of hops, and it never makes the second occurrence of a question cheaper than the first.</p>
+
+  <h2>A note about the visualisation</h2>
+  <p>Since it comes up: the three-dimensional rendering of your codebase is for you, not for the agent. The agent receives text. It never sees the picture. A beautiful graph view is a fine thing to build and I understand why it demos well, but it is evidence about the tool's presentation layer and not about whether an agent finished a task in fewer steps.</p>
+  <p>The metric that would settle these arguments is unglamorous: for a fixed set of tasks, how many actions did the agent take before it had the right answer. Steps, not tokens, because tokens follow from steps. I have not seen that number published by anyone, including by me, and I am wary of any comparison that leads with something else.</p>
+
+  <h2>What has to be different</h2>
+  <p>If the missing thing is a conclusion, then the record has to be written by whoever reached it, and it has to be a separate object from the derived index.</p>
+  <p>That is the split coldstart is built around. There is a static index, and it is deliberately ordinary: it ranks files against the words in your question using paths, symbol names, exports, and references, and it can show you the shape of a file and who uses it. It is the cheap-hop layer and I make no larger claim for it.</p>
+  <p>Separately there is a notebook. After a real task, the agent writes down what it worked out, anchored to the files it actually used. That record is not derivable from the source, which is the whole point, and it is also the reason it can go stale in a way the index cannot. So each note carries the state of the files it was based on. If those files changed, the note is not served as truth. It is served as a claim that needs re-checking, which is roughly what a colleague saying "this was true last month" gives you.</p>
+  <p>Fewer notes that are true beat a large derived structure that cannot hold a conclusion. Both layers are useful. They are answering different questions, and the mistake worth avoiding is expecting the first one to do the second one's job.</p>
+
+  <div class="essay-end">
+    <span class="el">Next</span>
+    <a class="next" href="the-tool-the-agent-doesnt-call.html">The tool the agent does not call</a>
+    <p class="note">coldstart is open source. <a href="https://github.com/AkashGoenka/coldstart">Source on GitHub</a> · <a href="../docs.html">Docs</a></p>
+  </div>
+</article>
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="../index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links"><a href="../blog.html">Blog</a><a href="../docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/blog/from-four-tools-to-two.html
+++ b/site/blog/from-four-tools-to-two.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>From four tools to two - coldstart</title>
+<meta name="description" content="An origin story told through deletions: the two traversal tools that were really missing fields, the architectural role labels, and the server that served nothing. What survived was two operations." />
+<meta name="keywords" content="tool design for AI agents, MCP server design, CLI for coding agents, code index architecture, deleting features, agent tool surface" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<link rel="apple-touch-icon" href="../logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="From four tools to two" />
+<meta property="og:description" content="An origin story told through deletions. What survived was two operations, and the cutting was the design work." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="From four tools to two" />
+<meta name="twitter:description" content="An origin story told through deletions. What survived was two operations, and the cutting was the design work." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="../docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "From four tools to two",
+  "description": "An origin story told through deletions: the two traversal tools that were really missing fields, the architectural role labels, and the server that served nothing.",
+  "url": "https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html",
+  "mainEntityOfPage": "https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html",
+  "image": "https://akashgoenka.github.io/coldstart/og.png",
+  "datePublished": "2026-07-25",
+  "dateModified": "2026-07-25",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "publisher": { "@type": "Person", "name": "Akash Goenka" },
+  "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="../index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="../blog.html">Blog</a>
+      <a href="../docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="../index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+<article class="essay-wrap essay-article">
+  <a class="back-link" href="../blog.html">← All posts</a>
+  <header class="essay-hero">
+    <div class="kicker">Design</div>
+    <h1>From four tools to two</h1>
+    <p class="lead-p">This is an origin story told through deletions. Almost everything I consider a real design decision in this project was a removal, and each one taught me something I could not have reasoned my way to beforehand.</p>
+    <div class="article-meta">
+      <span>Akash Goenka</span>
+      <span class="sep">·</span>
+      <time datetime="2026-07-25">25 July 2026</time>
+      <span class="sep">·</span>
+      <span>12 min read</span>
+    </div>
+  </header>
+
+  <p>The tool now has two operations. One finds the files relevant to a concept. One takes a single file and returns its shape along with who uses it. That is the whole navigation surface.</p>
+  <p>It started with four. There was an overview operation for locating files, a structure operation for inspecting one, and two traversal operations: trace the dependencies of a thing, and trace the impact of changing it. That set looks well designed to me even now. It maps cleanly onto the four questions an agent actually has.</p>
+  <p>Both traversal operations were deleted. The path there is more instructive than the destination.</p>
+
+  <h2>Deletion one: the two tools that were really missing fields</h2>
+  <p>The important thing about removing the traversal tools is what did not get removed. The graph stayed. The import edges, the call edges, the reverse lookups, all of it survived and is still there.</p>
+  <p>What went away was the idea that reaching that data deserved its own front door. The relationships became fields on the output of the operations that were already being called.</p>
+  <p>The reason is a pattern I only saw by reading a lot of session transcripts in a row. The traversal tools were never called first. They could not be, because you cannot trace the impact of a symbol until you know which symbol, and finding that out is what the other two tools were for. Every single invocation of a traversal tool followed an invocation of a different tool, in the previous step, answering a question that the previous step's output had raised and failed to answer.</p>
+  <p>Once you see it stated that way the conclusion is forced. A tool that is only ever called immediately after another tool, in response to a gap in that tool's output, is not a tool. It is a field that is missing from that output. And keeping it as a separate operation means the agent pays a full extra round trip to get information the first call could have included.</p>
+  <p>That is a much worse trade than it looks, because a round trip in an agent session is not a cheap operation. Every turn re-sends the entire conversation so far. Splitting one answer across two calls does not cost you a small message. It costs you the whole context again.</p>
+  <p>So the relationships moved into the results. Asking where something lives now tells you what imports it in the same breath, and asking about a file returns who calls each of its symbols without a second question. Four operations became two, and the capability count did not go down.</p>
+
+  <h2>The part that did go down, stated honestly</h2>
+  <p>One thing was genuinely lost and I would rather name it than let it be discovered.</p>
+  <p>The impact tool could follow a chain. Ask what breaks if this signature changes and it would walk outward through several levels of callers. What replaced it does one hop. You get the direct callers of a symbol and the direct importers of a file, and if you want the level beyond that you ask again about one of the results.</p>
+  <p>This was a deliberate trade and it was recorded as a known regression at the time rather than quietly dropped. My reasoning was that multi-hop traversal is the rarest question by a wide margin, that the answers were long enough to be expensive when they did arrive, and that an agent given the first hop is entirely capable of asking for the second when it actually needs it. I still think that is right. It is a trade, though, and if your work is dominated by refactors across deep call chains you should know that this particular tool will make you do the walking.</p>
+
+  <h2>Why those fields are on by default</h2>
+  <p>There is a middle step here that I got wrong twice, and it is the most transferable thing in this essay.</p>
+  <p>When the relationship data first moved into the other operations, I made it optional. Sensible, I thought. The data is expensive to render, most calls do not need it, so put it behind a parameter and describe the parameter well. I wrote careful documentation explaining exactly when to ask for importers and when to ask for callers.</p>
+  <p>The agent almost never set it.</p>
+  <p>I assumed the description was not clear enough, so I rewrote it as a bulleted list with examples, which is what you do when you think the problem is legibility. That version measured worse than the one before it. Not neutral. Worse, because the longer description was itself resident context on every turn, and it bought nothing.</p>
+  <p>The finding underneath is that an agent does not read a parameter list looking for opportunities. It has a goal, it forms an intent, and it fills in the arguments that intent requires. A parameter that would only be requested by an agent that already knew what it was going to find is not discoverable by describing it better. You cannot document your way to a behaviour the agent has no reason to attempt.</p>
+  <p>Which leaves two real options. Default it on and accept the cost, or move it to an operation that is already in the workflow for a different reason. I ended up doing both. The relationship data is on by default, and it lives on the operation the agent was going to call anyway.</p>
+  <p>The general version: if a capability requires the agent to opt in, and the agent only knows to opt in after seeing the result, it will not get used. Make it the default or fold it into something else. A third option of explaining it more clearly does not exist.</p>
+
+  <h2>Deletion three: the labels</h2>
+  <p>The first version tried to tell the agent what each file <em>was</em>.</p>
+  <p>Results came back annotated. A file had an architectural role. It was flagged as an entry point or not. It carried a depth, meaning roughly how far it sat from the top of the dependency tree. The idea was that an agent facing an unfamiliar repository would benefit from being told which files were controllers and which were utilities, the way a good README would.</p>
+  <p>Every one of those fields is gone now, removed in a single commit that also switched the parser to work purely from the syntax tree.</p>
+  <p>The reason they went is that they were guesses wearing the costume of facts. "Entry point" is not a property a parser can read off a file. It is a judgement, produced by heuristics over path names and import counts, and the heuristics were wrong often enough that the label was worse than silence. A file labelled a utility that is actually the core of the subsystem does not merely fail to help. It actively steers away from the answer, and it does so in confident language.</p>
+  <p>The deeper problem is a division of labour. The agent reading my output is a language model. It is extremely good at looking at a path, a set of exported symbols, and a few lines of code and concluding "this is the request handler." That is the one thing in this pipeline that does not need my help. What it cannot do cheaply is scan two thousand files to find which ones to look at.</p>
+  <p>So the rule I ended up with: return evidence, never classification. Paths, symbol names, exports, references, line numbers, the matched lines themselves. Things I can point at in a file. No role labels, no capability tags, no generated descriptions of what a file is for. Let the model do the interpreting, since it is better at it than my heuristics and it is going to redo the work anyway.</p>
+
+  <h2>Deletion four: the duplicate</h2>
+  <p>A smaller one, included because the lesson is not the obvious one.</p>
+  <p>The command line had a verb for searching. The server exposed a differently named tool that did the same thing. There was also a second search verb that had been added earlier and never removed. When I finally compared the two search paths properly, one was a duplicate of the other closely enough that deleting it changed no behaviour at all, and the old scoring engine behind it had no remaining callers.</p>
+  <p>That is embarrassing in the ordinary way that any duplicated code is embarrassing. What makes it worth writing about is the naming half, which I had not thought of as a problem.</p>
+  <p>The shell command and the server tool had drifted into different names for one operation. Internally that was untidy. Externally it was worse than untidy, because the agent sees both surfaces. Instructions written for one do not transfer to the other. A note in the project guidance saying "prefer this command" fails silently when the agent is on the other surface and the name does not exist. Every piece of documentation had to be written twice or be wrong half the time.</p>
+  <p>So the tools were renamed to match the shell verbs exactly, the duplicate verb was dropped, and the dead scorer went with it. One operation, one name, whichever way you reach it.</p>
+  <p>The cost of an extra name is not the code. It is that everything you write about your tool now has to be conditional.</p>
+
+  <h2>Deletion five: the server that served</h2>
+  <p>The third removal is the one I would not have predicted.</p>
+  <p>The architecture had a background process that held the index in memory and answered queries over a local connection. This is the obvious shape. The index is expensive to build, so build it once, keep it warm, and have the command line be a thin client that asks the running process. There was a bridge layer and an HTTP daemon to do exactly this.</p>
+  <p>Both are deleted. The commit that did it is titled, accurately, "daemon serves nothing."</p>
+  <p>What replaced it is that the background process only maintains a cache on disk and answers nothing. Every query is a fresh short-lived process that reads that cache, computes, prints, and exits.</p>
+  <p>This looks like a downgrade if you think about it as a server. It stops looking like one once you count what actually goes wrong in practice. A server introduces a liveness problem, a port, a protocol, a version skew between client and server, and a class of failure where the daemon is running but wrong. A file on disk has none of that. The reader either finds a valid cache or it does not.</p>
+  <p>The saving I imagined I was getting from keeping things warm was also not where the time went. Reading a prepared cache from disk is fast. The expensive part was always building the index, and that still happens once, in the background, exactly as before. I had optimised the cheap half of the operation and paid for it with a whole category of bugs.</p>
+  <p>Splitting the roles cleanly, one writer that keeps the cache fresh and many readers that only read, removed more failure modes than any feature I have added.</p>
+
+  <h2>What the removals have in common</h2>
+  <p>Looking back, each deletion was the same mistake wearing different clothes. In every case I had built for a model of the situation that turned out to be wrong.</p>
+  <p>With the traversal tools I assumed the agent's questions arrive independently. They arrive in chains, and a chain of two calls should usually have been one. With the optional parameters I assumed capability is discovered by reading. It is not; it is discovered by having it happen. With the labels I assumed the agent wanted interpretation. It wanted evidence, and it does its own interpreting better than my heuristics did. With the daemon I assumed the cost sat in serving queries. It sat in building the index.</p>
+  <p>None of these were reachable by thinking harder at the outset. They came from measuring, and in more than one case from reading my own code with a specific suspicion in mind rather than a general intention to review it.</p>
+
+  <h2>Why the surface stayed small after that</h2>
+  <p>There is a straightforward argument for keeping the tool count low that I only understood after decomposing where an agent session's cost actually goes.</p>
+  <p>The definition of every tool you expose is part of the prompt. It is not a one-time registration. It is re-sent on every single turn for the entire session, and you are billed for it whether the agent uses that tool or not. A generous surface of a dozen well-documented operations is a standing charge on every conversation, including all the ones where none of them get called.</p>
+  <p>So a new operation has to clear a bar that is higher than "this would occasionally be useful." It has to be worth its rent across every session where it goes untouched. Most candidate features do not clear that, which is a much more decisive test than my previous instinct of adding anything that seemed helpful.</p>
+  <p>The other reason is adoption. An agent with two commands learns both. An agent with twelve has to choose, and choosing costs a step, and the fallback when choosing is hard is to skip the whole surface and run a text search. A small surface is easier to actually get used, which is not a soft benefit. It is the only benefit that matters, since an operation nobody calls has all of the cost and none of the value.</p>
+
+  <h2>What did not shrink</h2>
+  <p>One part of the project went the other way, and the contrast is the point.</p>
+  <p>The notebook, where agents write down what they worked out after a real task, has grown steadily. It has its own set of commands, hooks in several editors, a linter, and a viewer. By the logic above that should be indefensible.</p>
+  <p>The difference is that navigation and memory are not the same problem, and only one of them is served by being small. Finding a file is a mechanical operation where the best implementation is boring and fast. Preserving what an investigation concluded is not mechanical at all. It needs writing, editing, staleness tracking, and a way to surface a note at the moment it is relevant rather than when someone remembers to ask.</p>
+  <p>Cutting to two operations was right for the part of the problem that is a lookup. It would have been the wrong instinct applied to the part that is a record. Knowing which half you are working on is most of the design.</p>
+
+  <div class="essay-end">
+    <span class="el">Next</span>
+    <a class="next" href="notes-should-be-written-by-whoever-read-the-code.html">Notes about code should be written by whoever read the code</a>
+    <p class="note">coldstart is open source. <a href="https://github.com/AkashGoenka/coldstart">Source on GitHub</a> · <a href="../docs.html">Docs</a></p>
+  </div>
+</article>
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="../index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links"><a href="../blog.html">Blog</a><a href="../docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/blog/notes-should-be-written-by-whoever-read-the-code.html
+++ b/site/blog/notes-should-be-written-by-whoever-read-the-code.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Notes about code should be written by whoever read the code - coldstart</title>
+<meta name="description" content="Why codebase notes for AI coding agents should be written by the agent that did the work, not reconstructed later from a transcript." />
+<meta name="keywords" content="AI coding agent notes, codebase notebook, agent memory, transcript summarization, durable investigations, coldstart" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<link rel="apple-touch-icon" href="../logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="Notes about code should be written by whoever read the code" />
+<meta property="og:description" content="A transcript is not the same thing as context. The agent that did the work is usually the only one qualified to write down what was learned." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Notes about code should be written by whoever read the code" />
+<meta name="twitter:description" content="A transcript is not the same thing as context. The agent that did the work is usually the only one qualified to write down what was learned." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="../docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Notes about code should be written by whoever read the code",
+  "description": "A transcript is not the same thing as context. The agent that did the work is usually the only one qualified to write down what was learned.",
+  "url": "https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html",
+  "mainEntityOfPage": "https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html",
+  "image": "https://akashgoenka.github.io/coldstart/og.png",
+  "datePublished": "2026-07-25",
+  "dateModified": "2026-07-25",
+  "wordCount": 1086,
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "publisher": { "@type": "Person", "name": "Akash Goenka" },
+  "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="../index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="../blog.html">Blog</a>
+      <a href="../docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="../index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+<article class="essay-wrap essay-article">
+  <a class="back-link" href="../blog.html">← All posts</a>
+  <header class="essay-hero">
+    <div class="kicker">Codebase notes</div>
+    <h1>Notes about code should be written by whoever read the code</h1>
+    <p class="lead-p">I maintain a tool that keeps notes about a codebase. An agent does a task, and at the end it writes down what it worked out. There is an easier way to build this. I chose not to take it.</p>
+    <div class="article-meta">
+      <span>Akash Goenka</span>
+      <span class="sep">·</span>
+      <time datetime="2026-07-25">25 July 2026</time>
+      <span class="sep">·</span>
+      <span>6 min read</span>
+    </div>
+  </header>
+
+  <p>The easier design is a background job. Coding agents already leave transcripts behind, so a tool can wake up later, read the finished sessions, decide whether anything durable happened, and write notes from the log.</p>
+  <p>That design has obvious advantages. It never interrupts you. It can backfill old sessions. You can improve the summarizer later and run it again over the whole archive. I understand the appeal. I still think it produces worse notes, for a reason that has nothing to do with how clever the summarizer is.</p>
+
+  <h2>What a transcript actually contains</h2>
+  <p>Say the agent opens a 400-line file, reads it, and says: "I see the problem. The retry loop never resets the counter, so the second failure trips the limit immediately."</p>
+  <p>The transcript now holds that sentence and a record that a file got read. It does not hold the file in the same way the agent held it while working. The agent had 400 lines in front of it when it reached the conclusion. The transcript has a short sentence about them.</p>
+  <p>A background job reading this later has two choices. It can write a note from the sentence, which means the note says roughly what the sentence said and nothing more. Or it can go open the file and work it out again.</p>
+
+  <h2>Re-reading is a different job than remembering</h2>
+  <p>If the background job opens the file, it is no longer summarizing the session. It is doing a fresh investigation, using the transcript as a hint about where to look.</p>
+  <p>That investigation is missing the thing that made the original investigation useful: the live task. The first agent had a failing test, a user asking for something specific, a trail of wrong guesses, and a reason to care about one part of the file rather than another. The later job has a file and a sentence.</p>
+  <p>So the note it writes tends to become a description of the code. That is the least interesting kind of note. Anyone can get that by reading the code. The thing worth preserving is usually what was not obvious from reading.</p>
+
+  <h2>The useful part is the correction</h2>
+  <p>The notes worth keeping are often about a wrong belief that got corrected: the fix that looked right and was not, the two files that had to change together for a reason hidden between them, the thing that looked like dead code and turned out to be load-bearing.</p>
+  <p>That kind of note only exists relative to the path the investigation took. A transcript records the conclusion. It records the wrong belief only if somebody happened to say it out loud, and most of the time nobody does. You do not narrate every assumption. You act on it, discover it was wrong, and quietly stop believing it.</p>
+  <p>The surprise is the part that often does not survive into the log. The surprise is also the part I most want written down.</p>
+
+  <h2>Long sessions make this worse</h2>
+  <p>You might expect a longer session to leave a better transcript. More turns, more detail, more material for the summarizer.</p>
+  <p>In practice, long sessions get compacted. The tool notices the conversation is running out of room, summarizes the earlier part, and drops the original turns. The detail is gone from the log even though the agent may still be operating from what it learned.</p>
+  <p>That means transcript-based capture loses the most detail on the sessions that probably mattered most: the long ones, where the hard problem was solved.</p>
+
+  <h2>What I do instead</h2>
+  <p>The capture runs at the end of a turn, inside the session that just happened.</p>
+  <p>It does not read the transcript to find out what was learned. It reads it to find out which files were touched, and how: opened, edited, looked up. That is a mechanical question, and a log answers it well enough.</p>
+  <p>Then it hands that list back to the agent that just did the work and asks it to write the notes. The files are still in context. The wrong assumption is still recent. Nothing has to be reconstructed.</p>
+  <p>The rule I settled on is short: if writing the note needs a read you have not already done, do not write the note. An agent that has to go look something up in order to write a note is not remembering. It is guessing, and a guess written into a file that another agent will trust later is worse than no file at all.</p>
+
+  <h2>Freshness is what makes the note usable</h2>
+  <p>Because the note is written by the agent that read the files, the tool knows which files it came from. It records a content hash for each one.</p>
+  <p>Later, when the note is shown, one of two things is true. Either the file has not changed since the note was written, and the note can be trusted without opening the file again. Or the file has changed, and the note is shown with a warning naming the file to check.</p>
+  <p>That is what "self-updating" means here. Not that a model rewrites prose on a schedule, but that the note knows when the ground moved under it.</p>
+
+  <h2>What it costs</h2>
+  <p>This design is not free.</p>
+  <p>It interrupts sometimes. Not often, and not after every session, but it does ask for a minute of writing when there is enough evidence that something durable happened. A background job would never interrupt.</p>
+  <p>It also does not know anything on day one. There is no bulk import of your git history, no instant knowledge base from old transcripts. It learns where work actually happens, which means it takes time to become useful.</p>
+  <p>I took those costs because fewer notes that are true seem more valuable than a large pile of notes reconstructed from partial context.</p>
+
+  <h2>How coldstart fits into this</h2>
+  <p>coldstart's notebook follows this design. Notes are written by agents after real work, stored in the repo, anchored to concrete files and symbols, and surfaced later only as reference data. If the evidence changed, the note says so.</p>
+  <p>The point is not to build a perfect memory. It is to stop pretending that a transcript is the same thing as the working context that produced it.</p>
+
+  <div class="essay-end">
+    <span class="el">Start here</span>
+    <a class="next" href="where-the-tokens-go.html">Where the tokens go in an agent session</a>
+    <p class="note">coldstart is open source. <a href="https://github.com/AkashGoenka/coldstart">Source on GitHub</a> · <a href="../docs.html">Docs</a></p>
+  </div>
+</article>
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="../index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links"><a href="../blog.html">Blog</a><a href="../docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/blog/the-tool-the-agent-doesnt-call.html
+++ b/site/blog/the-tool-the-agent-doesnt-call.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>The tool the agent does not call - coldstart</title>
+<meta name="description" content="You can ship a tool, document it, and inject an instruction telling the agent to prefer it, and the agent will still reach for grep. Why availability is not adoption, with the mistake I shipped myself." />
+<meta name="keywords" content="agent tool adoption, MCP tools ignored, Claude Code hooks, agent tool use, coding agent instructions, tool design for agents" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<link rel="apple-touch-icon" href="../logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="The tool the agent does not call" />
+<meta property="og:description" content="Availability, documentation, and an explicit instruction still do not add up to adoption." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="The tool the agent does not call" />
+<meta name="twitter:description" content="Availability, documentation, and an explicit instruction still do not add up to adoption." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="../docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "The tool the agent does not call",
+  "description": "You can ship a tool, document it, and inject an instruction telling the agent to prefer it, and the agent will still reach for grep.",
+  "url": "https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html",
+  "mainEntityOfPage": "https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html",
+  "image": "https://akashgoenka.github.io/coldstart/og.png",
+  "datePublished": "2026-07-25",
+  "dateModified": "2026-07-25",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "publisher": { "@type": "Person", "name": "Akash Goenka" },
+  "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="../index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="../blog.html">Blog</a>
+      <a href="../docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="../index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+<article class="essay-wrap essay-article">
+  <a class="back-link" href="../blog.html">← All posts</a>
+  <header class="essay-hero">
+    <div class="kicker">Adoption</div>
+    <h1>The tool the agent does not call</h1>
+    <p class="lead-p">You can install a tool, document it, and add an explicit instruction telling the agent to prefer it over searching. Then you watch the session and the agent runs a text search anyway. This is the most consistent result I have from building agent tooling, and it took me a long time to stop treating it as a bug.</p>
+    <div class="article-meta">
+      <span>Akash Goenka</span>
+      <span class="sep">·</span>
+      <time datetime="2026-07-25">25 July 2026</time>
+      <span class="sep">·</span>
+      <span>8 min read</span>
+    </div>
+  </header>
+
+  <p>I will start with my own numbers, because the argument is worthless coming from someone who only ever measured a competitor.</p>
+  <p>On a large Java repository, I checked how many of the agent's file reads had been preceded by the command I built specifically to tell it which files to read. The majority had not. The agent opened files without asking the tool that exists to rank them, in a repository where the tool was installed, working, and mentioned in the project instructions.</p>
+  <p>That is not a defect report about the model. It is a fact about how tool use actually happens, and it applies to whatever you are building too.</p>
+
+  <h2>Three things that look like adoption and are not</h2>
+  <p>The mental model I had was a chain. Make the tool available, describe it clearly, and instruct the agent to use it. Each link seemed necessary and the set seemed sufficient. None of the three does what it appears to.</p>
+  <p><b>Availability</b> means the tool is in the schema list. The agent knows it exists in the same way you know your kitchen contains a mandoline. Knowing is not reaching.</p>
+  <p><b>Documentation</b> is read once, at the start, along with everything else in your instruction files. By turn twenty it is a small and distant part of a conversation that now contains a stack trace, four files, and the user changing their mind. It has not been forgotten exactly. It has been outweighed.</p>
+  <p><b>An explicit instruction</b> is the one that feels like it should be decisive. "Prefer this command over grep when locating code." It is unambiguous, it is in context, and the agent will even agree with it if you ask. It still loses at the moment of choice, because the moment of choice does not feel like a policy decision. It feels like knowing where to look.</p>
+
+  <h2>What the agent is actually doing</h2>
+  <p>The agent has a habit that works.</p>
+  <p>Text search is universal, it is understood deeply from training, its failure mode is legible, and it never requires trusting an intermediary. When it returns nothing, that is informative. When it returns too much, the agent knows how to narrow it. There is no interpretation step between the tool and the answer.</p>
+  <p>A custom tool asks for something extra. It asks the agent to trust a ranking it cannot verify, in a format it has seen far less often, from a source it has no prior about. When your ranked output puts a file first, the agent has to decide whether to believe you. Believing you is a risk. Grepping is not.</p>
+  <p>So the bar is not "is my tool better than a text search." The bar is "is my tool better by enough, at the exact moment of choosing, to overcome a habit that is already working." Those are different bars and only the second one predicts behaviour.</p>
+
+  <h2>The mistake I shipped, and so did someone else</h2>
+  <p>There is a specific engineering error here that I want to describe properly, because I made it and then found the same shape in another project while reading its source, which suggests it is a trap rather than an oversight.</p>
+  <p>Most agent harnesses let you register a hook that fires before a tool runs. The obvious use is a gentle intervention: when the agent is about to run a search, notice, and point it at the better path first.</p>
+  <p>So you register the hook on the search tools. The dedicated grep tool, the file glob tool. Reasonable. That is where searching happens.</p>
+  <p>Then the agent runs a shell command that happens to contain <code>grep -r</code>.</p>
+  <p>Your hook is registered on the search tools. A shell call is not a search tool. Nothing fires. The agent searches the entire repository, pays for it, and your intervention was never in the path. The other project had the same structure, gated on exactly the tools an agent uses when it is being formal, and blind to the shell it uses when it is being quick.</p>
+  <p>Mine was slightly worse, and I only found it by reading my own code with this question in mind. The pattern that decides which calls to intercept did include the shell. The handler that runs afterwards only recognised one specific command inside it. So the hook fired on every shell call and then declined to act on almost all of them. It looked wired up. It was matching a broader surface than it could handle, which is the kind of bug that survives review because the tests pass and the logs look busy.</p>
+  <p>The general lesson is worth stating plainly. Instrument the surface the agent actually uses, not the one your tool taxonomy says it should. A general-purpose shell defeats every category-based gate, because anything can happen inside it.</p>
+
+  <h2>Injection is not adoption either</h2>
+  <p>The next thing you try is stronger. Do not wait to be called. Inject the relevant context into the conversation when the user submits their prompt, so it arrives before the agent decides anything.</p>
+  <p>This works better and I use it. It is also not a solution to the adoption problem, for a reason that took me a while to see.</p>
+  <p>Injection only fires on a trigger you can compute in advance, from the user's words, before any work has happened. That is exactly when you know least. The user says "the export is timing out" and you have to guess what that is about from a sentence with no file names in it. The moment when the agent most needs the right pointer, three turns in, having just discovered the real symbol involved, is a moment when nothing is being injected because nothing new was submitted.</p>
+  <p>So injection covers the case where the vocabulary happened to match, and misses the case where the vocabulary changed under you. Useful, partial, and not a way to compel use of a tool.</p>
+
+  <h2>What actually moves the needle</h2>
+  <p>I have ended up with three things that work, none of which involve trying harder to persuade the agent.</p>
+  <p>The first is to lose gracefully. If the agent is going to reach for a text search regardless, the tool should be useful in that world rather than sulking about it. Make the output good enough that when the agent does call it, the call ends the question, so the next occurrence has a positive prior. Adoption is earned per call and it compounds.</p>
+  <p>The second is to make the output final. Most of the times my tool got called and then the agent grepped anyway, the reason was legible in the transcript: my output raised a question it did not answer. It listed a file without saying whether the file defines the thing or merely mentions it, so the agent opened it to check. That is not the agent being stubborn. That is my output being incomplete. Every follow-up you force is a place where the habit gets to reassert itself.</p>
+  <p>The third is to say when the answer is nothing. A tool that returns an empty result is nearly useless, because the agent cannot tell "not present" from "your tool failed" and will grep to find out. A tool that says the identifier does not appear anywhere in this repository has actually ended a line of inquiry. Negative results are answers if you state them as answers.</p>
+  <p>What I stopped doing is trying to steer. Instructions telling the agent when not to read a file did nothing measurable in my tests. The interventions that worked were all about the quality of what gets surfaced, never about the discipline of the agent receiving it.</p>
+
+  <h2>How this shaped coldstart</h2>
+  <p>The design follows from the failure rather than from an ideal.</p>
+  <p>The commands are shell commands first, because the shell is where the agent already is. Results are ranked with the matched lines shown inline, so the common case is answered without opening anything. An empty result is phrased as a finding about the repository. And notes written after previous work are surfaced automatically at the start of a turn, because the note that has to be requested is the note that never gets read.</p>
+  <p>I would not claim this is solved. My own measurement says the agent still bypasses the tool often, and I would rather publish that than a story where instructions worked. If you are building something in this space, measure the bypass rate before you measure anything else. It is the number that tells you whether you have a tool or a feature nobody reaches for.</p>
+
+  <div class="essay-end">
+    <span class="el">Next</span>
+    <a class="next" href="from-four-tools-to-two.html">From four tools to two</a>
+    <p class="note">coldstart is open source. <a href="https://github.com/AkashGoenka/coldstart">Source on GitHub</a> · <a href="../docs.html">Docs</a></p>
+  </div>
+</article>
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="../index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links"><a href="../blog.html">Blog</a><a href="../docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/blog/where-the-tokens-go.html
+++ b/site/blog/where-the-tokens-go.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Where the tokens go in an agent session - coldstart</title>
+<meta name="description" content="Most of what an agent session costs is not the answer it produced. It is the same context, re-sent on every turn. How to decompose your own transcript and find the one lever that matters." />
+<meta name="keywords" content="agent token cost, Claude Code token usage, prompt caching, cache_read, agent session cost, coding agent context window" />
+<meta name="author" content="Akash Goenka" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<meta name="theme-color" content="#fcfcfb" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#0b0e14" media="(prefers-color-scheme: dark)" />
+<link rel="canonical" href="https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html" />
+<link rel="icon" type="image/svg+xml" href="../logo.svg" />
+<link rel="apple-touch-icon" href="../logo.svg" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="coldstart" />
+<meta property="og:title" content="Where the tokens go in an agent session" />
+<meta property="og:description" content="Most of what a session costs is not the answer. It is the same context, re-sent on every turn." />
+<meta property="og:url" content="https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html" />
+<meta property="og:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Where the tokens go in an agent session" />
+<meta name="twitter:description" content="Most of what a session costs is not the answer. It is the same context, re-sent on every turn." />
+<meta name="twitter:image" content="https://akashgoenka.github.io/coldstart/og.png" />
+<link rel="stylesheet" href="../docs.css" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Where the tokens go in an agent session",
+  "description": "Most of what an agent session costs is not the answer it produced. It is the same context, re-sent on every turn.",
+  "url": "https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html",
+  "mainEntityOfPage": "https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html",
+  "image": "https://akashgoenka.github.io/coldstart/og.png",
+  "datePublished": "2026-07-25",
+  "dateModified": "2026-07-25",
+  "author": { "@type": "Person", "name": "Akash Goenka" },
+  "publisher": { "@type": "Person", "name": "Akash Goenka" },
+  "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
+}
+</script>
+</head>
+<body class="docs-page essay-page">
+<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
+  <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>
+  <path id="arm" d="M16 14.5L16 4M16 8.2L13 5.6M16 8.2L19 5.6" fill="none" stroke-linecap="round"/>
+  <g id="flake"><use href="#arm"/><use href="#arm" transform="rotate(60 16 16)"/><use href="#arm" transform="rotate(120 16 16)"/><use href="#arm" transform="rotate(180 16 16)"/><use href="#arm" transform="rotate(240 16 16)"/><use href="#arm" transform="rotate(300 16 16)"/></g>
+</defs></svg>
+<nav>
+  <div class="nav-in">
+    <a class="brand" href="../index.html"><svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart <span class="tag">blog</span></a>
+    <span class="nav-spacer"></span>
+    <div class="nav-links">
+      <a href="../blog.html">Blog</a>
+      <a href="../docs.html">Docs</a>
+      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
+    </div>
+    <a class="nav-cta" href="../index.html#install">Install</a>
+  </div>
+</nav>
+<hr class="thread" />
+<article class="essay-wrap essay-article">
+  <a class="back-link" href="../blog.html">← All posts</a>
+  <header class="essay-hero">
+    <div class="kicker">Cost</div>
+    <h1>Where the tokens go in an agent session</h1>
+    <p class="lead-p">A long session bills for something. The instinct is to blame the tool that returned a big block of output. That instinct is almost always wrong, and the arithmetic that explains why also tells you the only thing worth optimising.</p>
+    <div class="article-meta">
+      <span>Akash Goenka</span>
+      <span class="sep">·</span>
+      <time datetime="2026-07-25">25 July 2026</time>
+      <span class="sep">·</span>
+      <span>7 min read</span>
+    </div>
+  </header>
+
+  <p>I spent a while building tooling for coding agents while assuming the thing I should optimise was output size. Return fewer lines. Trim the file listing. Compress the search result. It seemed obvious. The tool prints text into the conversation, the conversation costs money, so smaller output costs less.</p>
+  <p>Then I actually decomposed a session, and the picture was not the one I had in my head.</p>
+
+  <h2>What a turn actually bills for</h2>
+  <p>A chat with a model is stateless underneath. The model does not remember the previous turn. Every time the agent takes an action, the entire conversation so far is sent again: the system prompt, the tool definitions, every file that was read, every command that was run, every result that came back.</p>
+  <p>Providers soften this with prompt caching. The unchanged prefix of the conversation gets cached, and re-sending it is much cheaper than sending it fresh. Cheaper is not free. You are still billed for every cached token, on every single turn, for the rest of the session.</p>
+  <p>So a turn costs roughly the size of everything resident in the conversation at that moment. Not the size of what just happened. The size of everything that has happened.</p>
+  <p>Which gives you a rough model of a whole session:</p>
+  <pre><code>session cost  ≈  number of turns  ×  average resident context</code></pre>
+  <p>Two terms. Worth asking which one you can actually move.</p>
+
+  <h2>The resident context only grows</h2>
+  <p>Look at what sits in that second term.</p>
+  <ul>
+    <li>The harness system prompt. Fixed, and you do not control it.</li>
+    <li>Your project instruction files, loaded at the start.</li>
+    <li>The schema for every tool the agent has available.</li>
+    <li>Every file read so far, in full.</li>
+    <li>Every command and its output, in full.</li>
+  </ul>
+  <p>Only the last two grow during the session, and they grow in one direction. Nothing leaves the conversation. Reading a file is not a one-time cost of that file. It is a subscription: you pay for those lines again on every remaining turn.</p>
+  <p>The tool schemas deserve a specific mention, because this one surprised me. A tool definition is not billed once when you install it. It is part of the prompt, so it is billed on every turn like everything else. Connect a server that exposes a dozen richly documented operations and you have added rent to the whole session, paid whether the agent calls any of them or not. A tool surface is not a menu you browse for free. It is a standing charge.</p>
+  <p>The practical consequence is that the resident term is mostly not yours to shrink. You can be careful about what gets read. You can keep your tool surface small. Beyond that, it is a floor that rises.</p>
+
+  <h2>Output is a rounding error</h2>
+  <p>Here is the part that killed my original assumption.</p>
+  <p>What the model writes is a small fraction of what a session bills. Not a modest fraction. Small enough that halving it changes almost nothing. The reason is structural: output is generated once, then it becomes part of the conversation and is re-billed as cached context on every subsequent turn, at a much lower rate. The single largest share of a long session is re-reading context that was already established.</p>
+  <p>So the effort I put into trimming a tool's output was aimed at the term that mattered least. A tool that prints twenty extra lines has added twenty lines to the resident context. Real, but marginal.</p>
+  <p>A tool that causes one extra turn has re-billed the entire conversation.</p>
+
+  <h2>Turns are the lever</h2>
+  <p>If the resident context mostly cannot shrink, and output barely counts, then the number of turns is what you have left. And unlike the other two, it responds to design.</p>
+  <p>This reframes what a good tool for an agent looks like. The question is not "how much did it print." The question is "did the agent have to ask again."</p>
+  <p>A search that returns forty file paths with no way to tell which matters causes the agent to open several of them to find out. Each open is a turn, and each opened file joins the resident context permanently. The search looked cheap. It was not. It was the most expensive thing in the sequence, because of what it made happen next.</p>
+  <p>A search that returns eight paths, says which ones define the thing you asked about rather than merely mentioning it, and shows enough of the relevant lines to judge without opening the file, can end the question in one turn. It printed more. It cost less.</p>
+  <p>Same logic in the other direction. Ten small precise calls are worse than two calls that each carry more. Batch what you can. Answer the follow-up before it is asked.</p>
+
+  <h2>Measuring your own</h2>
+  <p>None of this needs to be taken on faith. If you use a harness that writes session transcripts to disk, the numbers are already there.</p>
+  <p>Each assistant message carries a usage record with separate counts for fresh input, cache reads, cache writes, and output. The total billed for that turn is the sum of all four. Two things to be careful about. Dedupe by message id first, because a streamed message can appear more than once and double counting will flatter or wreck your result. And group by turn, so you can watch the resident context climb rather than seeing one aggregate.</p>
+  <p>Then plot the per-turn total across the session. You are looking for two things: how fast the line rises, which tells you what is accumulating, and how many turns there are, which is the thing you can act on. Compare the same task done two ways and count turns, not tokens. Turns are the honest metric because tokens follow from them.</p>
+  <p>I would suggest doing this on your own sessions rather than trusting anyone's published figures, mine included. The shape holds across harnesses. The exact proportions depend on your system prompt, your instruction files, how many tools you have connected, and how large the files in your repository are. A codebase with long files behaves differently from one with short ones.</p>
+
+  <h2>What I changed</h2>
+  <p>The measurement changed what I build. I stopped trying to make output smaller and started trying to make answers final.</p>
+  <p>In practice that meant a few things. Ranked results instead of a list, so the agent does not open five files to find the one. Enough of the matching lines inline that the file often does not need to be opened at all. Relationships between files returned alongside the file, because "who calls this" being a second question is a second turn. And a deliberately small tool surface, since every operation I expose is charged on every turn of every session whether it earns that or not.</p>
+  <p>That last one is why coldstart is two commands rather than the larger set I started with. <code>find</code> locates the files for a concept and ranks them by evidence. <code>gs</code> takes one file and returns its shape along with who uses it. There is no third operation, and cutting the others was not a simplification for its own sake. Each one was rent.</p>
+  <p>The general form of the lesson is short. Work out the cost model of the thing you are building for before you optimise anything, because the obvious target and the real one are often not the same, and in this case they are not even close.</p>
+
+  <div class="essay-end">
+    <span class="el">Next</span>
+    <a class="next" href="an-index-cannot-answer-twice.html">Why an index of your code cannot answer the same question twice</a>
+    <p class="note">coldstart is open source. <a href="https://github.com/AkashGoenka/coldstart">Source on GitHub</a> · <a href="../docs.html">Docs</a></p>
+  </div>
+</article>
+<hr class="thread" />
+<footer>
+  <div class="foot-in">
+    <span class="foot-brand"><a class="brand" href="../index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+    <div class="foot-links"><a href="../blog.html">Blog</a><a href="../docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a></div>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/docs.css
+++ b/site/docs.css
@@ -223,3 +223,347 @@ ul.tight li b { color: var(--ink); }
 
 @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } html { scroll-behavior: auto !important; } }
 :focus-visible { outline: 2px solid var(--frost); outline-offset: 2px; border-radius: 4px; }
+
+/* =========================================================
+   BLOG / ESSAYS  —  a reading surface, not a product surface.
+   Light by default (long-form prose), dark when the OS asks.
+   Scoped to body.essay-page so index.html + docs.html stay dark.
+   To make the blog permanently dark: move the tokens inside the
+   prefers-color-scheme block up into body.essay-page and delete
+   the light set. Nothing else needs to change.
+   ========================================================= */
+body.essay-page {
+  --nav-wrap: 1080px;
+  --measure: 68ch;          /* ~65-70 characters — the readable line length */
+
+  --bg: #fcfcfb;
+  --surface: #f4f3f0;
+  --surface-2: #f8f7f5;
+  --ink: #14171c;           /* headings */
+  --prose: #2a2f38;         /* body copy — 14.5:1, NOT the grey used for meta */
+  --muted: #5f6875;         /* metadata, captions, secondary only */
+  --faint: #8b93a0;
+  --line: #e4e2dd;
+  --line-soft: #eeece8;
+  --frost: #12708f;
+  --frost-bright: #0d5a74;
+  --ember: #a8571a;
+  --ember-bright: #8c4813;
+  --term-border: #232a3a;
+  --sel: rgba(18,112,143,.16);
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.essay-page {
+    --bg: #0b0e14;          /* lifted off pure black — easier for sustained reading */
+    --surface: #141a24;
+    --surface-2: #10151d;
+    --ink: #eef3fb;
+    --prose: #c9d3e2;       /* 12.8:1 — was #8b9ab2 at 6.9:1 */
+    --muted: #8b9ab2;
+    --faint: #6b7789;
+    --line: #1e2735;
+    --line-soft: #182029;
+    --frost: #4fbfe0;
+    --frost-bright: #6fd3ef;
+    --ember: #ef9448;
+    --ember-bright: #ffb267;
+    --term-border: #1e2735;
+    --sel: rgba(79,191,224,.20);
+    color-scheme: dark;
+  }
+}
+
+body.essay-page ::selection { background: var(--sel); }
+body.essay-page .term { border-color: var(--term-border); }
+
+/* ---- shared shell ---- */
+.essay-wrap {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 40px 24px 96px;
+}
+
+.essay-hero { padding: 10px 0 30px; }
+
+.essay-hero h1 {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: clamp(31px, 4.4vw, 46px);
+  line-height: 1.1;
+  letter-spacing: -.028em;
+  color: var(--ink);
+}
+
+.essay-hero .lead-p {
+  color: var(--muted);
+  font-size: clamp(17px, 2vw, 19px) !important;
+  line-height: 1.6;
+  margin-top: 16px;
+}
+
+/* ---- INDEX (blog.html) — a stacked list, not a grid.
+       Two posts in a 2-col grid looks like a page that failed to load. ---- */
+.essay-list {
+  display: block;
+  margin-top: 4px;
+  border-top: 1px solid var(--line);
+}
+
+.essay-card {
+  display: block;
+  padding: 30px 20px 30px 0;
+  border-bottom: 1px solid var(--line);
+  text-decoration: none;
+  transition: background .16s, padding-left .16s;
+}
+
+.essay-card:hover {
+  background: var(--surface-2);
+  padding-left: 20px;
+}
+
+.essay-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  color: var(--frost);
+  margin-bottom: 12px;
+}
+
+.essay-meta .sep { color: var(--faint); letter-spacing: 0; }
+.essay-meta time,
+.essay-meta .rt { color: var(--muted); letter-spacing: .06em; }
+
+.essay-card h2 {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: clamp(20px, 2.2vw, 25px);
+  line-height: 1.22;
+  letter-spacing: -.022em;
+  color: var(--ink);
+  max-width: 30ch;
+}
+
+.essay-card:hover h2 { color: var(--frost); }
+
+.essay-card p {
+  color: var(--muted);
+  margin-top: 10px;
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 68ch;
+}
+
+/* ---- ARTICLE — one centered column, everything constrained to the measure ---- */
+.essay-article { max-width: 1080px; }
+
+.essay-article > *,
+.essay-article > .essay-hero > * {
+  width: min(var(--measure), 100%);
+  margin-inline: auto;
+}
+
+/* opt-out for anything that should run wider than the prose column */
+.essay-article > .wide { width: min(920px, 100%); }
+
+.essay-article .back-link {
+  display: block;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 13px;
+  text-decoration: none;
+  margin-bottom: 30px;
+}
+.essay-article .back-link:hover { color: var(--frost); }
+
+.essay-article .essay-hero {
+  width: 100%;
+  padding-bottom: 26px;
+  border-bottom: 1px solid var(--line);
+}
+
+.essay-article .kicker { margin-bottom: 14px; }
+
+.article-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.article-meta .sep { color: var(--faint); }
+
+.essay-article p {
+  color: var(--prose);
+  font-size: 19px;
+  line-height: 1.7;
+  margin-top: 22px;
+}
+
+.essay-article h2 {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: clamp(22px, 2.8vw, 28px);
+  line-height: 1.2;
+  letter-spacing: -.024em;
+  color: var(--ink);
+  margin-top: 54px;
+}
+
+.essay-article h3 {
+  font-family: var(--sans);
+  font-weight: 650;
+  font-size: 19.5px;
+  line-height: 1.3;
+  letter-spacing: -.015em;
+  color: var(--ink);
+  margin-top: 36px;
+}
+
+.essay-article h2 + p,
+.essay-article h3 + p { margin-top: 14px; }
+
+.essay-article b,
+.essay-article strong { color: var(--ink); font-weight: 650; }
+
+.essay-article em { color: inherit; font-style: italic; }
+
+.essay-article a:not(.back-link) {
+  color: var(--frost);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in srgb, var(--frost) 42%, transparent);
+}
+.essay-article a:not(.back-link):hover { text-decoration-color: currentColor; }
+
+/* prose furniture — lists, quotes, code, rules, tables.
+   None of this existed; anything beyond <p> fell back to browser defaults. */
+.essay-article ul,
+.essay-article ol {
+  color: var(--prose);
+  font-size: 19px;
+  line-height: 1.65;
+  margin-top: 20px;
+  padding-left: 26px;
+}
+.essay-article li { margin-top: 10px; }
+.essay-article li::marker { color: var(--faint); }
+.essay-article li > ul,
+.essay-article li > ol { margin-top: 8px; }
+
+.essay-article blockquote {
+  margin: 30px auto;
+  padding: 4px 0 4px 22px;
+  border-left: 2px solid color-mix(in srgb, var(--ember) 60%, transparent);
+}
+.essay-article blockquote p {
+  color: var(--muted);
+  font-size: 19px;
+  font-style: italic;
+  margin-top: 10px;
+}
+.essay-article blockquote p:first-child { margin-top: 0; }
+
+.essay-article code {
+  font-size: .82em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 1.5px 6px;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.essay-article pre {
+  margin-top: 24px;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--ink);
+}
+.essay-article pre code {
+  background: none; border: 0; padding: 0;
+  font-size: inherit; white-space: pre;
+}
+
+.essay-article hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 46px auto;
+}
+
+.essay-article figure { margin: 30px auto; }
+.essay-article img { max-width: 100%; height: auto; border-radius: var(--radius); display: block; }
+.essay-article figcaption {
+  margin-top: 10px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.essay-article .table-scroll { overflow-x: auto; margin-top: 24px; }
+.essay-article table { border-collapse: collapse; width: 100%; font-size: 15.5px; }
+.essay-article th,
+.essay-article td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--line); }
+.essay-article th {
+  font-family: var(--mono); font-size: 12px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--muted); font-weight: 600;
+}
+.essay-article td { color: var(--prose); }
+
+/* ---- end-of-article ---- */
+.essay-end {
+  margin-top: 60px;
+  padding-top: 28px;
+  border-top: 1px solid var(--line);
+}
+.essay-end .el {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--faint);
+}
+.essay-end .next {
+  display: block;
+  margin-top: 12px;
+  font-family: var(--sans);
+  font-weight: 650;
+  font-size: 21px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+  color: var(--ink);
+  text-decoration: none;
+}
+.essay-end .next:hover { color: var(--frost); }
+.essay-end .note {
+  margin-top: 20px;
+  font-size: 15.5px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.essay-end .note a { color: var(--frost); text-decoration: none; }
+.essay-end .note a:hover { text-decoration: underline; }
+
+@media (max-width: 640px) {
+  .essay-wrap { padding: 30px 20px 72px; }
+  .essay-article p,
+  .essay-article ul,
+  .essay-article ol,
+  .essay-article blockquote p { font-size: 17px; }
+  .essay-article h2 { margin-top: 44px; }
+  .essay-card { padding: 24px 0; }
+  .essay-card:hover { padding-left: 0; }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -51,6 +51,7 @@
     <span class="nav-spacer"></span>
     <div class="nav-links">
       <a href="index.html">Home</a>
+      <a href="blog.html">Blog</a>
       <a href="index.html#notebook">Notebook</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
@@ -435,6 +436,7 @@
     <span class="foot-brand"><a class="brand" href="index.html" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> — docs · MIT</span>
     <div class="foot-links">
       <a href="index.html">Home</a>
+      <a href="blog.html">Blog</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
       <a href="#notebook">Notebook</a>

--- a/site/index.html
+++ b/site/index.html
@@ -126,6 +126,7 @@
     <span class="nav-sp"></span>
     <div class="nav-links">
       <a href="docs.html">Docs</a>
+      <a href="blog.html">Blog</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     </div>
@@ -142,7 +143,7 @@
       <p class="hero-sub">coldstart gives a coding agent a <b>notebook it writes itself</b>, so what one session figures out, the next already knows — plus a fast index to <b>find the right file without three wrong reads</b>. No embeddings, no API key: it runs on the model you already pay for.</p>
       <div class="cta">
         <a class="btn btn-primary" href="#install">Install →</a>
-        <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">View on GitHub</a>
+        <a class="btn btn-ghost" href="blog.html">Read the blog</a>
         <span class="hero-note">MIT · Node 18+ · runs offline</span>
       </div>
     </div>
@@ -398,6 +399,32 @@
   </div>
 </section>
 
+<!-- ===================== ARTICLES ===================== -->
+<section id="blog" class="blog-sec">
+  <div class="wrap">
+    <div class="rise">
+      <div class="eyebrow">Blog</div>
+      <h2>Engineering notes from building coldstart.</h2>
+      <p class="lead">Longer pieces about the problem coldstart is built around: agents starting cold, repository orientation, and notes that stay tied to the code instead of becoming another stale document.</p>
+    </div>
+    <div class="article-grid rise">
+      <a class="article-card" href="blog/where-the-tokens-go.html">
+        <span>Cost</span>
+        <h3>Where the tokens go in an agent session</h3>
+        <p>Most of what a session bills for is not the answer it produced. It is the same context, re-sent on every turn.</p>
+      </a>
+      <a class="article-card" href="blog/an-index-cannot-answer-twice.html">
+        <span>Codebase memory</span>
+        <h3>Why an index of your code cannot answer the same question twice</h3>
+        <p>A graph makes each hop cheaper. It does not reduce the number of hops, and it is regenerated identical every time.</p>
+      </a>
+    </div>
+    <div class="cta rise">
+      <a class="btn btn-ghost" href="blog.html">All posts</a>
+    </div>
+  </div>
+</section>
+
 <!-- ===================== INSTALL ===================== -->
 <section id="install" class="install">
   <div class="wrap">
@@ -419,6 +446,7 @@
     </div>
     <div class="cta rise">
       <a class="btn btn-primary" href="docs.html">Read the docs →</a>
+      <a class="btn btn-ghost" href="blog.html">Read the blog</a>
       <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a class="btn btn-ghost" href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     </div>
@@ -429,7 +457,7 @@
   <div class="foot-in">
     <span class="foot-brand"><span class="brand" style="font-size:14px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</span> &nbsp; navigation + memory for coding agents · MIT</span>
     <div class="foot-links">
-      <a href="docs.html">Docs</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a><a href="#notebook">Notebook</a><a href="#philosophy">Philosophy</a>
+      <a href="docs.html">Docs</a><a href="blog.html">Blog</a><a href="https://github.com/AkashGoenka/coldstart">GitHub</a><a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a><a href="#notebook">Notebook</a><a href="#blog">Blog</a>
     </div>
   </div>
 </footer>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -8,8 +8,44 @@
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/docs.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html</loc>
+    <lastmod>2026-07-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -292,6 +292,20 @@ h1.title .warm{color:var(--ember);}
   border-radius:999px;color:var(--muted);background:var(--ink-1);}
 .chip.hot{color:var(--frost);border-color:color-mix(in srgb,var(--frost) 40%,var(--line));}
 
+/* ---------- BLOG ---------- */
+.blog-sec{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.article-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:42px;}
+@media(max-width:820px){.article-grid{grid-template-columns:1fr;}}
+.article-card{display:block;border:1px solid var(--line);border-radius:13px;background:var(--void);
+  padding:26px;text-decoration:none;transition:border-color .15s,background .15s,transform .15s;}
+.article-card:hover{border-color:color-mix(in srgb,var(--frost) 50%,var(--line));
+  background:color-mix(in srgb,var(--ink-2) 88%,var(--frost) 6%);transform:translateY(-1px);}
+.article-card span{display:block;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--frost);margin-bottom:13px;}
+.article-card h3{font-family:var(--mono);font-size:clamp(18px,2.4vw,23px);line-height:1.16;
+  letter-spacing:-.025em;color:var(--text);}
+.article-card p{margin-top:12px;color:var(--muted);font-size:14.5px;}
+
 /* ---------- INSTALL ---------- */
 .install-term{max-width:760px;margin-top:44px;}
 .install .cta{justify-content:flex-start;margin-top:30px;}


### PR DESCRIPTION
Four new engineering essays plus a rebuild of the blog's reading surface.

## Essays

Problem-first, tool introduced last, no competitor named anywhere.

| Essay | Claim |
|---|---|
| Where the tokens go in an agent session | Session cost decomposes to `turns × resident context`. Output is a rounding error; tool schemas are rent paid every turn. Turns are the only lever. |
| Why an index of your code cannot answer the same question twice | A graph makes each hop cheaper, not fewer, and is regenerated identical on the second ask. Ranking by in-degree makes leaf files structurally unrankable. |
| The tool the agent does not call | Availability, docs and an explicit instruction are not adoption. Self-implicating, including the hook-gating mistake: matcher on a broad surface, handler gated far narrower. |
| From four tools to two | Origin story via deletions. |

The last one is sourced from the actual commit history rather than recollection:

- `ebce6e1` removed `trace-deps` / `trace-impact` **while keeping the graph** — they became evidence fields on the other tools' output. The lesson is that a tool only ever called immediately after another tool, answering a gap in its output, is a missing field, and splitting it costs a whole extra round trip.
- `3750ed5` removed `archRole` / `isEntryPoint` / `depth` — heuristic labels presented as facts.
- `e908e59` deleted the query daemon ("daemon serves nothing").

The capability regression is stated in the essay rather than glossed: one hop only, no transitive multi-hop tracing.

## Reading surface

`docs.css`, scoped to `body.essay-page` so `index.html` and `docs.html` stay dark. Light by default with a `prefers-color-scheme: dark` variant.

Three measured defects fixed:

- body copy was `--muted` (**6.9:1**) for a thousand-word essay → dedicated `--prose` token, 14.5:1 light / 12.8:1 dark
- measure was `820px @ 18px` ≈ **100 characters** per line → `68ch`
- article clamped to 820px inside a 1080px wrap without centring → 260px dead gutter, now centred

Also added prose styles for `ul` / `ol` / `pre` / `blockquote` / `table`, none of which existed — anything beyond `<p>` fell back to browser defaults.

Reverting to permanent dark is one block; there's a comment at the top of the section saying which.

## Housekeeping

- per-post byline, date, reading time (from actual word counts), next-post link
- `BlogPosting` JSON-LD on all five posts, `Blog` JSON-LD on the index
- `sitemap.xml` updated to the five live posts; `index.html` features the two lead essays
- dropped `why-agents-start-cold` (never deployed, so nothing 404s): essay #1 covers the same problem with mechanism, and the two competed for identical search intent

Validated: JSON-LD parses, no broken internal links, tags balanced, sitemap is valid XML and every URL resolves to a file.

## Needs attention before the indexing request

**Publish dates are placeholders** (`2026-07-25`, the file creation date). They appear in the visible byline *and* the structured data on all five posts.

`site/blog/README.md` is included and will be publicly readable at `/coldstart/blog/README.md`. Say the word and I'll drop it from the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)