### PR TITLE
fix(site): essay children were centring on different left edges

### DIFF
--- a/site/docs.css
+++ b/site/docs.css
@@ -234,7 +234,12 @@ ul.tight li b { color: var(--ink); }
    ========================================================= */
 body.essay-page {
   --nav-wrap: 1080px;
-  --measure: 68ch;          /* ~65-70 characters — the readable line length */
+  /* The readable line length, ~66 characters at the 19px body size.
+     MUST be an absolute length, never `ch`: ch resolves against each
+     element's OWN font-size, so a 46px h1 and a 19px p would compute
+     different widths, and margin-inline:auto would then centre them on
+     different left edges. Every child of .essay-article shares this. */
+  --measure: 680px;
 
   --bg: #fcfcfb;
   --surface: #f4f3f0;
@@ -383,7 +388,10 @@ body.essay-page .term { border-color: var(--term-border); }
 .essay-article .back-link:hover { color: var(--frost); }
 
 .essay-article .essay-hero {
-  width: 100%;
+  /* same width as every other child, so the divider under the byline ends
+     flush with the text column instead of overhanging it */
+  width: min(var(--measure), 100%);
+  margin-inline: auto;
   padding-bottom: 26px;
   border-bottom: 1px solid var(--line);
 }


### PR DESCRIPTION
Follow-up to #104. The live essay pages had every element on a different left edge — heading hard left, body inboard, byline appearing centred.

## Cause

`--measure` was `68ch`, and `ch` resolves against **each element's own font-size**:

| element | font-size | computed `68ch` |
|---|---|---|
| `h1` | 46px | ~2100px → clamped to 100% |
| `p` | 19px | ~646px |
| `.back-link` | 13px mono | narrower still |

Each box then centred itself with `margin-inline: auto`, so every one landed somewhere different.

## Fix

`--measure` is now an absolute `680px` (~66 characters at the 19px body size), with a comment explaining why it must never be `ch`. Also gives `.essay-hero` the same width so the divider under the byline ends flush with the text column instead of overhanging it on both sides.

Verified by rendering both themes in headless Chrome, including a forced-light build to exercise the default branch rather than only the `prefers-color-scheme: dark` one that the OS setting happens to select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)