### PR TITLE
fix(site): GA4 tag was missing from every blog page

### DIFF
--- a/site/blog.html
+++ b/site/blog.html
@@ -71,6 +71,14 @@
   ]
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 

--- a/site/blog/an-index-cannot-answer-twice.html
+++ b/site/blog/an-index-cannot-answer-twice.html
@@ -40,6 +40,14 @@
   "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>

--- a/site/blog/from-four-tools-to-two.html
+++ b/site/blog/from-four-tools-to-two.html
@@ -40,6 +40,14 @@
   "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>

--- a/site/blog/notes-should-be-written-by-whoever-read-the-code.html
+++ b/site/blog/notes-should-be-written-by-whoever-read-the-code.html
@@ -41,6 +41,14 @@
   "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>

--- a/site/blog/the-tool-the-agent-doesnt-call.html
+++ b/site/blog/the-tool-the-agent-doesnt-call.html
@@ -40,6 +40,14 @@
   "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>

--- a/site/blog/where-the-tokens-go.html
+++ b/site/blog/where-the-tokens-go.html
@@ -40,6 +40,14 @@
   "isPartOf": { "@type": "Blog", "name": "coldstart blog", "url": "https://akashgoenka.github.io/coldstart/blog.html" }
 }
 </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D1Q44HNQ8H"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-D1Q44HNQ8H');
+</script>
 </head>
 <body class="docs-page essay-page">
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>


### PR DESCRIPTION
`index.html` and `docs.html` carry `G-D1Q44HNQ8H`. `blog.html` and all five posts did not, so the entire blog was invisible in analytics.

That's the half of the site about to be submitted for indexing, where the whole point of submitting is knowing whether it did anything. Without the tag there'd be no way to distinguish "indexed but not ranking" from "not indexed" — which is exactly the diagnosis that went wrong once before on the dev.to posts.

Same snippet, same placement (last in `<head>`), added to the six untagged pages.

Verified across all eight pages: exactly one tag each, inside `<head>`, `<head>`/`</head>` still balanced, JSON-LD still parses.

Worth noting for later: this is now a **fifth** per-page thing a new post has to remember, alongside the body class, the sitemap entry, the blog.html card, and the index.html feature cards. All hand-maintained, all failing silently. A shared head partial or a small build step would be the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)