### PR TITLE
chore(site): drop site/robots.txt — unreachable at this origin

### DIFF
--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://akashgoenka.github.io/coldstart/sitemap.xml


### PR DESCRIPTION
## What

Deletes `site/robots.txt`.

## Why

Crawlers read `robots.txt` only from the **origin root**. This file was served at:

```
https://akashgoenka.github.io/coldstart/robots.txt   → 200 (but nobody fetches it)
https://akashgoenka.github.io/robots.txt             → 404 (what crawlers actually request)
```

So its `Sitemap:` directive has never been read by Google or any other crawler, and the `Allow: /` was never in effect. We don't control the origin root from this repo — that would need a separate `akashgoenka.github.io` repo.

Removing it so the repo stops implying crawl directives that were never live.

## Checks

- No file in the repo references `robots.txt` (grepped html/yml/md/txt/ts).
- `site/sitemap.xml` is unaffected and still submitted directly in Search Console, which is how it was already being discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)