### PR TITLE
docs(readme): link the essays from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 <p>
   <a href="https://akashgoenka.github.io/coldstart/"><b>Website</b></a> &nbsp;·&nbsp;
   <a href="https://akashgoenka.github.io/coldstart/docs.html"><b>Docs</b></a> &nbsp;·&nbsp;
+  <a href="https://akashgoenka.github.io/coldstart/blog.html"><b>Blog</b></a> &nbsp;·&nbsp;
   <a href="./PHILOSOPHY.md"><b>Philosophy</b></a> &nbsp;·&nbsp;
   <a href="https://www.npmjs.com/package/@cstart/coldstart"><b>npm</b></a>
 </p>
@@ -271,6 +272,26 @@ See [PHILOSOPHY.md](./PHILOSOPHY.md) for why coldstart computes no semantics of 
 4. Hidden directories and files over 1 MB are skipped by the index.
 5. The keeper is per-repo and per-machine — no sharing across projects or hosts. The notebook _does_ travel: its `.raw` logs are committed and union-merge across branches and machines.
 6. Notebook quality is bounded by what writing agents actually read — notes are accurate about what they state, but a note is not a proof of completeness.
+
+## Writing
+
+Longer pieces on the problems behind this tool — what agent sessions actually cost, and what
+happened to the design when the measurements disagreed with the plan.
+
+- [Where the tokens go in an agent session](https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html)
+  — session cost is roughly turns × resident context, and output is a rounding error. How to
+  decompose your own transcripts instead of trusting anyone's published numbers.
+- [An index cannot answer the same question twice](https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html)
+  — a code graph makes each hop cheaper without reducing how many hops you take, and ranking by
+  in-degree makes leaf files structurally unrankable.
+- [The tool the agent doesn't call](https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html)
+  — availability, documentation, and an explicit instruction still don't add up to adoption.
+  Including the times our own agents bypassed our own command.
+- [From four tools to two](https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html)
+  — which tools got deleted, which capability genuinely went with them, and why the surface
+  stayed small afterwards.
+- [Notes about code should be written by whoever read the code](https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html)
+  — why the notebook captures in-session rather than summarizing transcripts later.
 
 ## License
 


### PR DESCRIPTION
## What

- Adds **Blog** to the header nav row.
- Adds a **Writing** section before License, linking all five essays with their canonical URLs and a one-line description each.

## Why

The README linked `Website` and `Docs` and **no blog post at all**. The five essays therefore had zero inbound links from `github.com`, which is the highest-authority domain this project has any presence on.

Search Console currently shows 1 of the 7 new blog URLs indexed. `akashgoenka.github.io` is on the Public Suffix List, so it inherits no authority from `github.io` and is a days-old domain with effectively no inbound links. Sitemap plumbing was investigated and ruled out — the sitemap serves valid XML over IPv4, IPv6, HTTP/1.1, HTTP/2 and gzip, from six CDN nodes byte-identically, so discovery was never the constraint. Link authority is.

## Checks

All 8 site URLs referenced in the README verified `200`:

```
/coldstart/                                            200
/coldstart/docs.html                                   200
/coldstart/blog.html                                   200
/coldstart/blog/where-the-tokens-go.html               200
/coldstart/blog/an-index-cannot-answer-twice.html      200
/coldstart/blog/from-four-tools-to-two.html            200
/coldstart/blog/the-tool-the-agent-doesnt-call.html    200
/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html  200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)