### PR TITLE
feat(site): hand-drawn figures across four essays

### DIFF
--- a/site/blog/an-index-cannot-answer-twice.html
+++ b/site/blog/an-index-cannot-answer-twice.html
@@ -124,6 +124,59 @@
   <p>Six weeks later the same area breaks again. The graph is regenerated from the same source and it is byte for byte what it was before. It has learned nothing, because it is not the kind of thing that can learn. The second investigation starts exactly where the first one did, and re-derives the same conclusions at the same cost.</p>
   <p>That is the claim in one line. A graph makes each hop cheaper. It does not reduce the number of hops, and it never makes the second occurrence of a question cheaper than the first.</p>
 
+  <figure class="wide essay-fig ">
+    <div class="fig-plot">
+    <svg viewBox="0 0 920 360" role="img" aria-labelledby="r3t r3d">
+      <title id="r3t">The second investigation costs what the first one did</title>
+      <desc id="r3d">Two identical tracks of five hops ending in the same conclusion, separated by a regeneration of the graph. The second run repeats every hop of the first because nothing about the first was recorded.</desc>
+      <defs>
+        <filter id="r3" x="-6%" y="-6%" width="112%" height="112%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="2" seed="11" result="n"/>
+          <feDisplacementMap in="SourceGraphic" in2="n" scale="2.6" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+      </defs>
+      <g filter="url(#r3)">
+        <path class="f-axis" d="M90 108 L640 108"/>
+        <circle class="f-hop" cx="100" cy="108" r="9"/>
+        <circle class="f-hop" cx="230" cy="108" r="9"/>
+        <circle class="f-hop" cx="360" cy="108" r="9"/>
+        <circle class="f-hop" cx="490" cy="108" r="9"/>
+        <circle class="f-hop" cx="620" cy="108" r="9"/>
+        <rect class="f-box-ok" x="690" y="77" width="170" height="62" rx="6"/>
+        <path class="f-pen" d="M650 108 L680 108"/>
+        <path class="f-pen" d="M669 102 L680 108 M669 114 L680 108"/>
+        <path class="f-axis" d="M90 286 L640 286"/>
+        <circle class="f-hop" cx="100" cy="286" r="9"/>
+        <circle class="f-hop" cx="230" cy="286" r="9"/>
+        <circle class="f-hop" cx="360" cy="286" r="9"/>
+        <circle class="f-hop" cx="490" cy="286" r="9"/>
+        <circle class="f-hop" cx="620" cy="286" r="9"/>
+        <rect class="f-box-ok" x="690" y="255" width="170" height="62" rx="6"/>
+        <path class="f-pen" d="M650 286 L680 286"/>
+        <path class="f-pen" d="M669 280 L680 286 M669 292 L680 286"/>
+        <path class="f-div" d="M70 197 L860 197"/>
+      </g>
+      <text class="f-head" x="90" y="72" text-anchor="start">first investigation</text>
+      <text class="f-head" x="90" y="250" text-anchor="start">six weeks later, the same question</text>
+      <text class="f-lab" x="100" y="138" text-anchor="middle">hop 1</text>
+      <text class="f-lab" x="230" y="138" text-anchor="middle">hop 2</text>
+      <text class="f-lab" x="360" y="138" text-anchor="middle">hop 3</text>
+      <text class="f-lab" x="490" y="138" text-anchor="middle">hop 4</text>
+      <text class="f-lab" x="620" y="138" text-anchor="middle">hop 5</text>
+      <text class="f-lab" x="100" y="316" text-anchor="middle">hop 1</text>
+      <text class="f-lab" x="230" y="316" text-anchor="middle">hop 2</text>
+      <text class="f-lab" x="360" y="316" text-anchor="middle">hop 3</text>
+      <text class="f-lab" x="490" y="316" text-anchor="middle">hop 4</text>
+      <text class="f-lab" x="620" y="316" text-anchor="middle">hop 5</text>
+      <text class="f-key" x="775" y="113" text-anchor="middle">conclusion</text>
+      <text class="f-key" x="775" y="291" text-anchor="middle">conclusion</text>
+      <text class="f-sub" x="465" y="188" text-anchor="middle">the graph is regenerated from the same source and is byte for byte what it was</text>
+      <text class="f-note" x="465" y="222" text-anchor="middle">it has learned nothing, because it is not the kind of thing that can learn</text>
+    </svg>
+    </div>
+    <figcaption>A graph makes each hop cheaper. It does not reduce how many hops you need, and because everything in it was already in the source, it cannot hold a conclusion — so the second occurrence of a question costs what the first one did.</figcaption>
+  </figure>
+
   <h2>A note about the visualisation</h2>
   <p>Since it comes up: the three-dimensional rendering of your codebase is for you, not for the agent. The agent receives text. It never sees the picture. A beautiful graph view is a fine thing to build and I understand why it demos well, but it is evidence about the tool's presentation layer and not about whether an agent finished a task in fewer steps.</p>
   <p>The metric that would settle these arguments is unglamorous: for a fixed set of tasks, how many actions did the agent take before it had the right answer. Steps, not tokens, because tokens follow from steps. I have not seen that number published by anyone, including by me, and I am wary of any comparison that leads with something else.</p>

--- a/site/blog/from-four-tools-to-two.html
+++ b/site/blog/from-four-tools-to-two.html
@@ -97,6 +97,46 @@
   <p>That is a much worse trade than it looks, because a round trip in an agent session is not a cheap operation. Every turn re-sends the entire conversation so far. Splitting one answer across two calls does not cost you a small message. It costs you the whole context again.</p>
   <p>So the relationships moved into the results. Asking where something lives now tells you what imports it in the same breath, and asking about a file returns who calls each of its symbols without a second question. Four operations became two, and the capability count did not go down.</p>
 
+  <figure class="wide essay-fig ">
+    <div class="fig-plot">
+    <svg viewBox="0 0 920 330" role="img" aria-labelledby="r2t r2d">
+      <title id="r2t">Two operations became fields on the other two</title>
+      <desc id="r2d">Top row: a first call finds the files but its output raises a question it cannot answer, so a second call traces the callers before the answer arrives. Bottom row: the same answer in one call, because the relationships are returned as fields of the first result.</desc>
+      <defs>
+        <filter id="r2" x="-6%" y="-6%" width="112%" height="112%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="2" seed="7" result="n"/>
+          <feDisplacementMap in="SourceGraphic" in2="n" scale="2.6" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+      </defs>
+      <g filter="url(#r2)">
+        <rect class="f-box" x="70" y="74" width="250" height="62" rx="6"/>
+        <rect class="f-box" x="400" y="74" width="250" height="62" rx="6"/>
+        <rect class="f-box-ok" x="730" y="74" width="120" height="62" rx="6"/>
+        <path class="f-pen" d="M330 105 L390 105"/>
+        <path class="f-pen" d="M379 99 L390 105 M379 111 L390 105"/>
+        <path class="f-pen" d="M660 105 L720 105"/>
+        <path class="f-pen" d="M709 99 L720 105 M709 111 L720 105"/>
+        <rect class="f-box" x="70" y="244" width="580" height="62" rx="6"/>
+        <rect class="f-box-ok" x="730" y="244" width="120" height="62" rx="6"/>
+        <path class="f-pen" d="M660 275 L720 275"/>
+        <path class="f-pen" d="M709 269 L720 275 M709 281 L720 275"/>
+      </g>
+      <text class="f-head" x="70" y="50" text-anchor="start">four operations</text>
+      <text class="f-head" x="70" y="220" text-anchor="start">two operations</text>
+      <text class="f-key" x="195" y="100" text-anchor="middle">find the files</text>
+      <text class="f-sub" x="195" y="120" text-anchor="middle">output raises a question it cannot answer</text>
+      <text class="f-key" x="525" y="100" text-anchor="middle">trace the callers</text>
+      <text class="f-sub" x="525" y="120" text-anchor="middle">a whole extra round trip</text>
+      <text class="f-key" x="790" y="110" text-anchor="middle">answer</text>
+      <text class="f-key" x="360" y="270" text-anchor="middle">find the files — callers and importers already in the result</text>
+      <text class="f-sub" x="360" y="290" text-anchor="middle">the relationships became fields, the graph never went anywhere</text>
+      <text class="f-key" x="790" y="280" text-anchor="middle">answer</text>
+      <text class="f-note" x="525" y="180" text-anchor="middle">this turn re-sent the entire conversation to ask one follow-up</text>
+    </svg>
+    </div>
+    <figcaption>The traversal tools were never called first — every invocation followed another call, answering a gap the previous output had left. A tool only ever called that way is a missing field, and keeping it separate charged a full round trip for it.</figcaption>
+  </figure>
+
   <h2>The part that did go down, stated honestly</h2>
   <p>One thing was genuinely lost and I would rather name it than let it be discovered.</p>
   <p>The impact tool could follow a chain. Ask what breaks if this signature changes and it would walk outward through several levels of callers. What replaced it does one hop. You get the direct callers of a symbol and the direct importers of a file, and if you want the level beyond that you ask again about one of the results.</p>

--- a/site/blog/notes-should-be-written-by-whoever-read-the-code.html
+++ b/site/blog/notes-should-be-written-by-whoever-read-the-code.html
@@ -94,11 +94,11 @@
   <p>The transcript now holds that sentence and a record that a file got read. It does not hold the file in the same way the agent held it while working. The agent had 400 lines in front of it when it reached the conclusion. The transcript has a short sentence about them.</p>
   <p>A background job reading this later has two choices. It can write a note from the sentence, which means the note says roughly what the sentence said and nothing more. Or it can go open the file and work it out again.</p>
 
-  <figure class="wide essay-fig ">
+  <figure class="wide essay-fig">
     <div class="fig-plot">
-    <svg viewBox="0 0 920 380" role="img" aria-labelledby="r4t r4d">
-      <title id="r4t">What the writer of a note can still see</title>
-      <desc id="r4d">Two timelines. In the first, capture fires before the session ends, while the files the agent read are still in context. In the second, the session ends and its context is discarded, leaving a background job to write from a single sentence in the transcript.</desc>
+    <svg viewBox="0 0 920 340" role="img" aria-labelledby="r4t r4d">
+      <title id="r4t">What the writer of a note can still see, over time</title>
+      <desc id="r4d">One timeline. While the session runs, everything the agent opened is in context, drawn as a tall band. When the session ends the band falls to a sliver, because the context is discarded and only the transcript remains. Two pins mark where a note could be written: one before the drop with the files still in hand, one after it with only a sentence.</desc>
       <defs>
         <filter id="r4" x="-6%" y="-6%" width="112%" height="112%">
           <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="2" seed="5" result="n"/>
@@ -106,25 +106,24 @@
         </filter>
       </defs>
       <g filter="url(#r4)">
-        <path class="f-area-a" d="M90 150 L560 150 L560 60 L90 60 Z"/>
-        <path class="f-axis" d="M90 150 L860 150"/>
-        <path class="f-tick" d="M560 44 L560 166"/>
-        <path class="f-area-a" d="M90 330 L560 330 L560 240 L90 240 Z"/>
-        <path class="f-area-b" d="M560 330 L860 330 L860 316 L560 316 Z"/>
-        <path class="f-axis" d="M90 330 L860 330"/>
-        <path class="f-tick" d="M560 224 L560 346"/>
+        <path class="f-area-a" d="M100 280 L100 90 L520 90 L520 266 L840 266 L840 280 Z"/>
+        <path class="f-axis" d="M86 280 L856 280"/>
+        <path class="f-tick" d="M520 62 L520 300"/>
+        <path class="f-pen" d="M470 86 L470 56"/>
+        <circle class="f-pin" cx="470" cy="90" r="6"/>
+        <path class="f-pen" d="M700 262 L700 214"/>
+        <circle class="f-pin" cx="700" cy="266" r="6"/>
       </g>
-      <text class="f-head" x="90" y="36" text-anchor="start">capture inside the session</text>
-      <text class="f-head" x="90" y="216" text-anchor="start">a background job, later</text>
-      <text class="f-key" x="300" y="110" text-anchor="middle">400 lines still in context</text>
-      <text class="f-key" x="300" y="290" text-anchor="middle">400 lines still in context</text>
-      <text class="f-key" x="710" y="296" text-anchor="middle">one sentence in the transcript</text>
-      <text class="f-lab" x="572" y="180" text-anchor="start">session ends — the context is gone</text>
-      <text class="f-note" x="548" y="52" text-anchor="end">the agent that read the code writes the note here</text>
-      <text class="f-note" x="710" y="356" text-anchor="middle">the job that never read the code writes the note here</text>
+      <text class="f-head" x="64" y="185" transform="rotate(-90 64 185)" text-anchor="middle">what the writer can still see</text>
+      <text class="f-note" x="470" y="44" text-anchor="middle">the agent that read the code writes here</text>
+      <text class="f-key" x="300" y="192" text-anchor="middle">every file it opened, still in context</text>
+      <text class="f-note" x="700" y="204" text-anchor="middle">a background job writes here, later</text>
+      <text class="f-key" x="770" y="304" text-anchor="middle">one sentence that survived into the transcript</text>
+      <text class="f-lab" x="520" y="316" text-anchor="middle">the session ends, its context is discarded</text>
+      <text class="f-lab" x="86" y="316">time →</text>
     </svg>
     </div>
-    <figcaption>The transcript does not hold the file the way the agent held it while working. Capture at the end of the session writes from 400 lines still in context; a job running later writes from the sentence that survived.</figcaption>
+    <figcaption>The same session either way. What changes is when the note gets written: before the drop, by the agent still holding the file, or after it, from the one sentence that made it into the log.</figcaption>
   </figure>
 
   <h2>Re-reading is a different job than remembering</h2>

--- a/site/blog/notes-should-be-written-by-whoever-read-the-code.html
+++ b/site/blog/notes-should-be-written-by-whoever-read-the-code.html
@@ -94,6 +94,39 @@
   <p>The transcript now holds that sentence and a record that a file got read. It does not hold the file in the same way the agent held it while working. The agent had 400 lines in front of it when it reached the conclusion. The transcript has a short sentence about them.</p>
   <p>A background job reading this later has two choices. It can write a note from the sentence, which means the note says roughly what the sentence said and nothing more. Or it can go open the file and work it out again.</p>
 
+  <figure class="wide essay-fig ">
+    <div class="fig-plot">
+    <svg viewBox="0 0 920 380" role="img" aria-labelledby="r4t r4d">
+      <title id="r4t">What the writer of a note can still see</title>
+      <desc id="r4d">Two timelines. In the first, capture fires before the session ends, while the files the agent read are still in context. In the second, the session ends and its context is discarded, leaving a background job to write from a single sentence in the transcript.</desc>
+      <defs>
+        <filter id="r4" x="-6%" y="-6%" width="112%" height="112%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="2" seed="5" result="n"/>
+          <feDisplacementMap in="SourceGraphic" in2="n" scale="2.6" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+      </defs>
+      <g filter="url(#r4)">
+        <path class="f-area-a" d="M90 150 L560 150 L560 60 L90 60 Z"/>
+        <path class="f-axis" d="M90 150 L860 150"/>
+        <path class="f-tick" d="M560 44 L560 166"/>
+        <path class="f-area-a" d="M90 330 L560 330 L560 240 L90 240 Z"/>
+        <path class="f-area-b" d="M560 330 L860 330 L860 316 L560 316 Z"/>
+        <path class="f-axis" d="M90 330 L860 330"/>
+        <path class="f-tick" d="M560 224 L560 346"/>
+      </g>
+      <text class="f-head" x="90" y="36" text-anchor="start">capture inside the session</text>
+      <text class="f-head" x="90" y="216" text-anchor="start">a background job, later</text>
+      <text class="f-key" x="300" y="110" text-anchor="middle">400 lines still in context</text>
+      <text class="f-key" x="300" y="290" text-anchor="middle">400 lines still in context</text>
+      <text class="f-key" x="710" y="296" text-anchor="middle">one sentence in the transcript</text>
+      <text class="f-lab" x="572" y="180" text-anchor="start">session ends — the context is gone</text>
+      <text class="f-note" x="548" y="52" text-anchor="end">the agent that read the code writes the note here</text>
+      <text class="f-note" x="710" y="356" text-anchor="middle">the job that never read the code writes the note here</text>
+    </svg>
+    </div>
+    <figcaption>The transcript does not hold the file the way the agent held it while working. Capture at the end of the session writes from 400 lines still in context; a job running later writes from the sentence that survived.</figcaption>
+  </figure>
+
   <h2>Re-reading is a different job than remembering</h2>
   <p>If the background job opens the file, it is no longer summarizing the session. It is doing a fresh investigation, using the transcript as a hint about where to look.</p>
   <p>That investigation is missing the thing that made the original investigation useful: the live task. The first agent had a failing test, a user asking for something specific, a trail of wrong guesses, and a reason to care about one part of the file rather than another. The later job has a file and a sentence.</p>

--- a/site/blog/where-the-tokens-go.html
+++ b/site/blog/where-the-tokens-go.html
@@ -115,51 +115,59 @@
   <p>So the effort I put into trimming a tool's output was aimed at the term that mattered least. A tool that prints twenty extra lines has added twenty lines to the resident context. Real, but marginal.</p>
   <p>A tool that causes one extra turn has re-billed the entire conversation.</p>
 
-  <figure class="wide essay-fig">
+  <figure class="wide essay-fig ">
     <div class="fig-plot">
-    <svg viewBox="0 0 920 410" role="img" aria-labelledby="figt figd">
-      <title id="figt">What a session bills for, turn by turn</title>
-      <desc id="figd">Eight columns, one per turn. Each column is the whole conversation resident at that moment, and every column is billed in full. A fixed base of system prompt and tool schemas repeats unchanged. Above it, everything read so far accumulates and never shrinks. The model's own output for that turn is the thin band on top, a small fraction of each column.</desc>
-      <rect class="f-base" x="78" y="16" width="13" height="13" rx="2"/>
-      <text class="f-key" x="99" y="27">fixed: system prompt + tool schemas</text>
-      <rect class="f-grow" x="372" y="16" width="13" height="13" rx="2"/>
-      <text class="f-key" x="393" y="27">everything read or run so far</text>
-      <rect class="f-out" x="666" y="16" width="13" height="13" rx="2"/>
-      <text class="f-key" x="687" y="27">what the model wrote this turn</text>
-      <line class="f-axis" x1="60" y1="340" x2="860" y2="340"/>
-      <rect class="f-base" x="78" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-out" x="78" y="288" width="58" height="8" rx="2"/>
+    <svg viewBox="0 0 920 410" role="img" aria-labelledby="r1t r1d">
+      <title id="r1t">What a session bills for, turn by turn</title>
+      <desc id="r1d">Eight columns, one per turn. Each is the whole conversation resident at that moment and each is billed in full. A fixed base of system prompt and tool schemas repeats unchanged. Above it, everything read so far accumulates and never shrinks. The model output for that turn is the thin band on top.</desc>
+      <defs>
+        <filter id="r1" x="-6%" y="-6%" width="112%" height="112%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.028" numOctaves="2" seed="3" result="n"/>
+          <feDisplacementMap in="SourceGraphic" in2="n" scale="2.6" xChannelSelector="R" yChannelSelector="G"/>
+        </filter>
+      </defs>
+      <g filter="url(#r1)">
+        <rect class="f-base" x="78" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-out" x="78" y="288" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="174" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="174" y="270" width="58" height="26" rx="6"/>
+        <rect class="f-out" x="174" y="262" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="270" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="270" y="244" width="58" height="52" rx="6"/>
+        <rect class="f-out" x="270" y="236" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="366" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="366" y="218" width="58" height="78" rx="6"/>
+        <rect class="f-out" x="366" y="210" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="462" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="462" y="192" width="58" height="104" rx="6"/>
+        <rect class="f-out" x="462" y="184" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="558" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="558" y="166" width="58" height="130" rx="6"/>
+        <rect class="f-out" x="558" y="158" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="654" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="654" y="140" width="58" height="156" rx="6"/>
+        <rect class="f-out" x="654" y="132" width="58" height="8" rx="6"/>
+        <rect class="f-base" x="750" y="296" width="58" height="44" rx="6"/>
+        <rect class="f-grow" x="750" y="114" width="58" height="182" rx="6"/>
+        <rect class="f-out" x="750" y="106" width="58" height="8" rx="6"/>
+        <path class="f-axis" d="M60 340 L860 340"/>
+        <rect class="f-mark" x="742" y="98" width="74" height="250" rx="6"/>
+      </g>
+      <g filter="url(#r1)"><rect class="f-base" x="78" y="16" width="13" height="13" rx="3"/></g>
+      <text class="f-key" x="99" y="27" text-anchor="start">fixed: system prompt + tool schemas</text>
+      <g filter="url(#r1)"><rect class="f-grow" x="372" y="16" width="13" height="13" rx="3"/></g>
+      <text class="f-key" x="393" y="27" text-anchor="start">everything read or run so far</text>
+      <g filter="url(#r1)"><rect class="f-out" x="666" y="16" width="13" height="13" rx="3"/></g>
+      <text class="f-key" x="687" y="27" text-anchor="start">what the model wrote this turn</text>
       <text class="f-lab" x="107" y="360" text-anchor="middle">1</text>
-      <rect class="f-base" x="174" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="174" y="270" width="58" height="26" rx="2"/>
-      <rect class="f-out" x="174" y="262" width="58" height="8" rx="2"/>
       <text class="f-lab" x="203" y="360" text-anchor="middle">2</text>
-      <rect class="f-base" x="270" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="270" y="244" width="58" height="52" rx="2"/>
-      <rect class="f-out" x="270" y="236" width="58" height="8" rx="2"/>
       <text class="f-lab" x="299" y="360" text-anchor="middle">3</text>
-      <rect class="f-base" x="366" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="366" y="218" width="58" height="78" rx="2"/>
-      <rect class="f-out" x="366" y="210" width="58" height="8" rx="2"/>
       <text class="f-lab" x="395" y="360" text-anchor="middle">4</text>
-      <rect class="f-base" x="462" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="462" y="192" width="58" height="104" rx="2"/>
-      <rect class="f-out" x="462" y="184" width="58" height="8" rx="2"/>
       <text class="f-lab" x="491" y="360" text-anchor="middle">5</text>
-      <rect class="f-base" x="558" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="558" y="166" width="58" height="130" rx="2"/>
-      <rect class="f-out" x="558" y="158" width="58" height="8" rx="2"/>
       <text class="f-lab" x="587" y="360" text-anchor="middle">6</text>
-      <rect class="f-base" x="654" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="654" y="140" width="58" height="156" rx="2"/>
-      <rect class="f-out" x="654" y="132" width="58" height="8" rx="2"/>
       <text class="f-lab" x="683" y="360" text-anchor="middle">7</text>
-      <rect class="f-base" x="750" y="296" width="58" height="44" rx="2"/>
-      <rect class="f-grow" x="750" y="114" width="58" height="182" rx="2"/>
-      <rect class="f-out" x="750" y="106" width="58" height="8" rx="2"/>
       <text class="f-lab" x="779" y="360" text-anchor="middle">8</text>
-      <text class="f-lab" x="60" y="384">turn →</text>
-      <rect class="f-mark" x="743" y="99" width="72" height="248" rx="5"/>
+      <text class="f-lab" x="60" y="384" text-anchor="start">turn →</text>
       <text class="f-note" x="808" y="398" text-anchor="end">one more turn re-bills every layer below it</text>
     </svg>
     </div>

--- a/site/blog/where-the-tokens-go.html
+++ b/site/blog/where-the-tokens-go.html
@@ -115,6 +115,57 @@
   <p>So the effort I put into trimming a tool's output was aimed at the term that mattered least. A tool that prints twenty extra lines has added twenty lines to the resident context. Real, but marginal.</p>
   <p>A tool that causes one extra turn has re-billed the entire conversation.</p>
 
+  <figure class="wide essay-fig">
+    <div class="fig-plot">
+    <svg viewBox="0 0 920 410" role="img" aria-labelledby="figt figd">
+      <title id="figt">What a session bills for, turn by turn</title>
+      <desc id="figd">Eight columns, one per turn. Each column is the whole conversation resident at that moment, and every column is billed in full. A fixed base of system prompt and tool schemas repeats unchanged. Above it, everything read so far accumulates and never shrinks. The model's own output for that turn is the thin band on top, a small fraction of each column.</desc>
+      <rect class="f-base" x="78" y="16" width="13" height="13" rx="2"/>
+      <text class="f-key" x="99" y="27">fixed: system prompt + tool schemas</text>
+      <rect class="f-grow" x="372" y="16" width="13" height="13" rx="2"/>
+      <text class="f-key" x="393" y="27">everything read or run so far</text>
+      <rect class="f-out" x="666" y="16" width="13" height="13" rx="2"/>
+      <text class="f-key" x="687" y="27">what the model wrote this turn</text>
+      <line class="f-axis" x1="60" y1="340" x2="860" y2="340"/>
+      <rect class="f-base" x="78" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-out" x="78" y="288" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="107" y="360" text-anchor="middle">1</text>
+      <rect class="f-base" x="174" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="174" y="270" width="58" height="26" rx="2"/>
+      <rect class="f-out" x="174" y="262" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="203" y="360" text-anchor="middle">2</text>
+      <rect class="f-base" x="270" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="270" y="244" width="58" height="52" rx="2"/>
+      <rect class="f-out" x="270" y="236" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="299" y="360" text-anchor="middle">3</text>
+      <rect class="f-base" x="366" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="366" y="218" width="58" height="78" rx="2"/>
+      <rect class="f-out" x="366" y="210" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="395" y="360" text-anchor="middle">4</text>
+      <rect class="f-base" x="462" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="462" y="192" width="58" height="104" rx="2"/>
+      <rect class="f-out" x="462" y="184" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="491" y="360" text-anchor="middle">5</text>
+      <rect class="f-base" x="558" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="558" y="166" width="58" height="130" rx="2"/>
+      <rect class="f-out" x="558" y="158" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="587" y="360" text-anchor="middle">6</text>
+      <rect class="f-base" x="654" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="654" y="140" width="58" height="156" rx="2"/>
+      <rect class="f-out" x="654" y="132" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="683" y="360" text-anchor="middle">7</text>
+      <rect class="f-base" x="750" y="296" width="58" height="44" rx="2"/>
+      <rect class="f-grow" x="750" y="114" width="58" height="182" rx="2"/>
+      <rect class="f-out" x="750" y="106" width="58" height="8" rx="2"/>
+      <text class="f-lab" x="779" y="360" text-anchor="middle">8</text>
+      <text class="f-lab" x="60" y="384">turn →</text>
+      <rect class="f-mark" x="743" y="99" width="72" height="248" rx="5"/>
+      <text class="f-note" x="808" y="398" text-anchor="end">one more turn re-bills every layer below it</text>
+    </svg>
+    </div>
+    <figcaption>A turn is billed for everything resident at that moment, not for what just happened. The base repeats unchanged all session. The middle only grows, because nothing leaves a conversation. What the model actually wrote is the band on top.</figcaption>
+  </figure>
+
   <h2>Turns are the lever</h2>
   <p>If the resident context mostly cannot shrink, and output barely counts, then the number of turns is what you have left. And unlike the other two, it responds to design.</p>
   <p>This reframes what a good tool for an agent looks like. The question is not "how much did it print." The question is "did the agent have to ask again."</p>

--- a/site/docs.css
+++ b/site/docs.css
@@ -524,6 +524,45 @@ body.essay-page .term { border-color: var(--term-border); }
   text-align: center;
 }
 
+/* ---- FIGURES — inline SVG only.
+       Every colour resolves through the essay-page tokens, so a figure
+       re-themes with the page instead of glowing in dark mode the way a
+       raster image would. Nothing here loads over the network. ---- */
+.essay-fig { margin: 40px auto; }
+.essay-fig .fig-plot {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  padding: 22px 20px 16px;
+  overflow-x: auto;
+}
+.essay-fig svg { display: block; width: 100%; height: auto; min-width: 620px; }
+/* the base figcaption is mono/centered, which reads as a code comment under
+   a diagram — captions here are prose and set like prose */
+.essay-fig figcaption {
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--muted);
+  text-align: left;
+  max-width: 680px;
+  margin: 14px auto 0;
+}
+
+.f-base { fill: var(--muted); opacity: .30; }
+.f-grow { fill: var(--frost); opacity: .55; }
+.f-out  { fill: var(--ember); }
+.f-axis { stroke: var(--line); stroke-width: 1; }
+.f-mark { stroke: var(--ember); stroke-width: 1.4; stroke-dasharray: 4 4; fill: none; opacity: .9; }
+.f-key  { fill: var(--prose); font-family: var(--sans); font-size: 13px; }
+.f-lab  { fill: var(--faint); font-family: var(--mono); font-size: 12px; }
+.f-note { fill: var(--ember); font-family: var(--sans); font-size: 13px; font-weight: 600; }
+
+@media (max-width: 640px) {
+  .essay-fig { margin: 30px auto; }
+  .essay-fig .fig-plot { padding: 16px 14px 12px; }
+}
+
 .essay-article .table-scroll { overflow-x: auto; margin-top: 24px; }
 .essay-article table { border-collapse: collapse; width: 100%; font-size: 15.5px; }
 .essay-article th,

--- a/site/docs.css
+++ b/site/docs.css
@@ -561,6 +561,7 @@ body.essay-page .term { border-color: var(--term-border); }
 .f-box    { fill: var(--surface); stroke: var(--prose); stroke-width: 1.9; }
 .f-box-ok { fill: var(--frost); fill-opacity: .16; stroke: var(--frost); stroke-width: 1.9; }
 .f-hop    { fill: var(--surface); stroke: var(--prose); stroke-width: 1.9; }
+.f-pin    { fill: var(--ember); stroke: var(--ember); stroke-width: 1.9; }
 .f-area-a { fill: var(--frost); fill-opacity: .34; stroke: var(--frost); stroke-width: 1.8; }
 .f-area-b { fill: var(--ember); fill-opacity: .5;  stroke: var(--ember); stroke-width: 1.8; }
 .f-axis { fill: none; stroke: var(--faint); stroke-width: 1.5; }

--- a/site/docs.css
+++ b/site/docs.css
@@ -549,12 +549,30 @@ body.essay-page .term { border-color: var(--term-border); }
   margin: 14px auto 0;
 }
 
-.f-base { fill: var(--muted); opacity: .30; }
-.f-grow { fill: var(--frost); opacity: .55; }
-.f-out  { fill: var(--ember); }
-.f-axis { stroke: var(--line); stroke-width: 1; }
-.f-mark { stroke: var(--ember); stroke-width: 1.4; stroke-dasharray: 4 4; fill: none; opacity: .9; }
-.f-key  { fill: var(--prose); font-family: var(--sans); font-size: 13px; }
+/* Hand-drawn look: a seeded feTurbulence displacement, applied per-figure to a
+   group that holds ONLY shapes. Text is never inside the filtered group — a
+   wobbly label is unreadable, and it is the strokes that should look drawn.
+   Everything is stroked rather than flat-filled so the roughness reads. */
+.essay-fig svg :is(path, rect, circle, line) { stroke-linecap: round; stroke-linejoin: round; }
+
+.f-base { fill: var(--muted); fill-opacity: .22; stroke: var(--muted); stroke-width: 1.7; }
+.f-grow { fill: var(--frost); fill-opacity: .38; stroke: var(--frost); stroke-width: 1.7; }
+.f-out  { fill: var(--ember); fill-opacity: .85; stroke: var(--ember); stroke-width: 1.7; }
+.f-box    { fill: var(--surface); stroke: var(--prose); stroke-width: 1.9; }
+.f-box-ok { fill: var(--frost); fill-opacity: .16; stroke: var(--frost); stroke-width: 1.9; }
+.f-hop    { fill: var(--surface); stroke: var(--prose); stroke-width: 1.9; }
+.f-area-a { fill: var(--frost); fill-opacity: .34; stroke: var(--frost); stroke-width: 1.8; }
+.f-area-b { fill: var(--ember); fill-opacity: .5;  stroke: var(--ember); stroke-width: 1.8; }
+.f-axis { fill: none; stroke: var(--faint); stroke-width: 1.5; }
+.f-pen  { fill: none; stroke: var(--prose); stroke-width: 1.9; }
+.f-div  { fill: none; stroke: var(--line);  stroke-width: 1.5; stroke-dasharray: 2 9; }
+.f-tick { fill: none; stroke: var(--faint); stroke-width: 1.5; stroke-dasharray: 5 5; }
+.f-mark { fill: none; stroke: var(--ember); stroke-width: 1.6; stroke-dasharray: 5 5; }
+
+.f-head { fill: var(--ink);   font-family: var(--sans); font-size: 13px; font-weight: 700;
+          letter-spacing: .07em; text-transform: uppercase; }
+.f-key  { fill: var(--prose); font-family: var(--sans); font-size: 13.5px; }
+.f-sub  { fill: var(--muted); font-family: var(--sans); font-size: 12px; }
 .f-lab  { fill: var(--faint); font-family: var(--mono); font-size: 12px; }
 .f-note { fill: var(--ember); font-family: var(--sans); font-size: 13px; font-weight: 600; }
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -14,11 +14,11 @@
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/blog/where-the-tokens-go.html</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/blog/an-index-cannot-answer-twice.html</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/blog/the-tool-the-agent-doesnt-call.html</loc>
@@ -26,10 +26,10 @@
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/blog/from-four-tools-to-two.html</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
   </url>
   <url>
     <loc>https://akashgoenka.github.io/coldstart/blog/notes-should-be-written-by-whoever-read-the-code.html</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Four figures in a sketch style, one per essay that had an argument a picture could carry.

| essay | what it draws |
|---|---|
| `where-the-tokens-go` | stacked turns: a base that repeats, a middle that only grows, output as the band on top |
| `from-four-tools-to-two` | the deleted round trip — two calls collapsing to one because the relationships became fields |
| `an-index-cannot-answer-twice` | the same five hops run twice, six weeks apart, with an unchanged graph in between |
| `notes-should-be-written-…` | one timeline: what the writer of a note can still see, with a cliff at the session end and a pin either side of it |

### The hand-drawn look

A seeded `feTurbulence` displacement, applied per figure to a group holding **only shapes**. Text is never inside the filtered group — a displaced label is unreadable, and it is the strokes that should look drawn. Everything is stroked rather than flat-filled so the roughness has an edge to show up on.

### Judgement calls worth flagging

- **No numbers on any axis, anywhere.** The essays argue qualitatively on purpose and the figures hold that line.
- **`from-four-tools-to-two` deliberately does not draw four boxes collapsing to two.** The essay says outright that the capability count did not go down, so a parts-count picture would contradict the argument it sits next to. It draws the removed round trip instead.
- **`the-tool-the-agent-doesnt-call` gets no figure.** Its claim is behavioural and anything drawn for it would be decoration.

### The notes figure was redrawn

The first version used two stacked rows and did not read. Block height carried the whole argument with no y-axis to say so, and the two quantities being compared sat in different rows at different x positions, so they never got compared. It is now a single timeline: one area, one cliff where the session ends and its context is discarded, and two pins on that same curve marking where a note could be written. The height difference between the pins is the argument.

### Also in here

- `.essay-article figcaption` sets `font-family: var(--mono)`, which rendered diagram captions as code comments. Captions are prose and are now set as prose.
- `sitemap.xml` lastmod bumped for the four changed essays, per the invariant added in #110.

### Verification

Headless render of every figure in both themes, light branch forced by stripping the `prefers-color-scheme: dark` block into a scratchpad copy. That caught four defects: the mono caption, a label colliding with the block it annotated, a leader line running through its own caption, and the two-row layout that had to be rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)