### PR TITLE
fix(site): close the gap between the prose column and the figures

### DIFF
--- a/site/docs.css
+++ b/site/docs.css
@@ -234,12 +234,15 @@ ul.tight li b { color: var(--ink); }
    ========================================================= */
 body.essay-page {
   --nav-wrap: 1080px;
-  /* The readable line length, ~66 characters at the 19px body size.
+  /* The readable line length, ~71 characters at the 19px body size — the top
+     of the comfortable range, chosen so the figure bleed either side stays
+     small. Do not push past ~760px; beyond that the line is hard to track
+     back to the start of.
      MUST be an absolute length, never `ch`: ch resolves against each
      element's OWN font-size, so a 46px h1 and a 19px p would compute
      different widths, and margin-inline:auto would then centre them on
      different left edges. Every child of .essay-article shares this. */
-  --measure: 680px;
+  --measure: 740px;
 
   --bg: #fcfcfb;
   --surface: #f4f3f0;
@@ -374,8 +377,11 @@ body.essay-page .term { border-color: var(--term-border); }
   margin-inline: auto;
 }
 
-/* opt-out for anything that should run wider than the prose column */
-.essay-article > .wide { width: min(920px, 100%); }
+/* opt-out for anything that should run wider than the prose column. Kept close
+   to --measure on purpose: a figure that overhangs by a lot stops reading as
+   part of the same column and makes the prose look narrow next to it. 40px
+   either side is a deliberate bleed; 120px was an unrelated block. */
+.essay-article > .wide { width: min(820px, 100%); }
 
 .essay-article .back-link {
   display: block;
@@ -545,7 +551,9 @@ body.essay-page .term { border-color: var(--term-border); }
   line-height: 1.55;
   color: var(--muted);
   text-align: left;
-  max-width: 680px;
+  /* tied to --measure, never a literal: the caption must share the prose
+     left edge, and a fixed width silently indents it whenever --measure moves */
+  max-width: var(--measure);
   margin: 14px auto 0;
 }
 


### PR DESCRIPTION
The figures overhung the prose by 120px either side, so the page read as two columns rather than one.

### Closed from both ends

| | before | after |
|---|---|---|
| `--measure` | 680px (~66 chars) | **740px** (~71 chars) |
| `.essay-article > .wide` | 920px | **820px** |

Bleed goes from 120px either side to 40px — small enough to read as the same column.

**Why not just widen the prose to match the figures.** That was the other option and it is worse. 920px is roughly 90 characters per line at the 19px body size, well past the point where the eye reliably tracks back to the start of the next line. 740 is the top of the comfortable range. The comment now records not to push past ~760, so the next person has the reason and not just the number.

The figures could not simply shrink to the prose width either — their labels are sized for the space, and at 680 the type inside them drops under 11px.

### Caption bug this surfaced

`.essay-fig figcaption` had `max-width: 680px` hardcoded. The caption is supposed to share the prose left edge, but a literal silently indents it whenever `--measure` moves — at measure 740 it sat 30px right of the paragraph above it. Now `var(--measure)`, so the two stay locked.

### Verification

Headless render at essay width and at mobile, both themes.

One thing I checked and it is **not** a bug: essay pages looked like they overflowed at a 430px window. They do not. Chrome on macOS enforces a ~500px minimum window, so the screenshot was a 430px crop of a 500px page. Measured `scrollWidth == clientWidth == 500` with no overflowing element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)