### PR TITLE
fix(notebook): capture no longer drops the session's edited/new files

### DIFF
--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -87,7 +87,7 @@ for it — your findings, not the notebook decision.`
     body = body.includes("{{WORKLIST}}")
       ? body.replaceAll("{{WORKLIST}}", worklist)
       : `${body.trimEnd()}\n\nWORKLIST — files you actually read this session, most-worked first \
-(the complete scope; never write a note for an unlisted file):\n\n${worklist}`;
+(your scope; if you edited or deep-read a file that isn't listed, you can note it too):\n\n${worklist}`;
     return `**Notebook capture point.** ${opening}\n\n${body.trimEnd()}${tail}`;
   }
 
@@ -102,8 +102,9 @@ branch, reviewing a PR, or reading vendored/generated code, that knowledge is ab
 or the future — write nothing and say so.
 2. If nothing about the current code is worth recording, no note is the right answer. If a \
 future agent would not act differently for knowing it, don't store it.
-3. The worklist below is the complete scope. Unlisted files are out — ignored \
-(.coldstartignore) or already captured. Never write a note for an unlisted file.
+3. The worklist below is your scope, most-worked first. Unlisted files are out — ignored \
+(.coldstartignore) or already captured. If you edited or deep-read a file this session that \
+isn't listed, you can write a note for it too.
 
 WORKLIST — files you actually read this session, most-worked first:
 

--- a/hooks/elicit-core.mjs
+++ b/hooks/elicit-core.mjs
@@ -16,7 +16,10 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, unlinkSync, appendFileSync, mkdirSync } from "node:fs";
 
-export const MAX_WORKLIST = 30;
+import { MAX_CAPTURE_FILES } from "./trigger.mjs";
+// One source of truth: the display cap equals what a fire claims, so the prompt
+// never shows fewer (or more) files than the fire marks captured.
+export const MAX_WORKLIST = MAX_CAPTURE_FILES;
 
 const noop = () => {};
 

--- a/hooks/kb-elicit.mjs
+++ b/hooks/kb-elicit.mjs
@@ -38,7 +38,7 @@ import { initialState, step } from "./trigger.mjs";
 import { loadIgnore } from "./ignore.mjs";
 import { buildCapturePayload } from "./capture-payload.mjs";
 import {
-  worklistEntries, freshNotedSet, gitHead, logCaptureEvent, writePendingCapture,
+  worklistEntries, freshNotedSet, gitHead, logCaptureEvent, writePendingCapture, MAX_WORKLIST,
 } from "./elicit-core.mjs";
 
 // hooks/ sits beside dist/ in both the repo and the published package.
@@ -180,7 +180,23 @@ if (process.argv.includes("--manual")) {
       process.exit(0);
     }
     const { sid, state, path: markerPath } = found;
-    const files = Object.keys(state.files).filter((rel) => !state.files[rel].captured);
+    // A manual /capture-notes is an EXPLICIT request to write up THIS session's
+    // work, so its scope is everything worked on — not merely what an automatic
+    // fire has yet to offer. Files EDITED this session are the highest-value
+    // notes (the fix, a brand-new helper), and an earlier automatic fire may
+    // have already marked them `captured` — a flag that means "offered once",
+    // never "a good note exists". Excluding them left the single most valuable
+    // note unwritten and a now-stale note unfixed (the Bug-1 report). So:
+    // include every edited file regardless of the flag, and drop only READ-ONLY
+    // files that were already offered (re-listing those on demand is just
+    // noise). Rank most-worked first (edits → retouches → reads) so new/edited
+    // files lead; the per-file annotations flag when a fresh note needs nothing.
+    const files = Object.entries(state.files)
+      .filter(([, f]) => (f.reads + f.edits + f.gs) > 0 && (f.edits > 0 || !f.captured))
+      .sort((a, b) => (b[1].edits - a[1].edits)
+        || ((b[1].retouches || 0) - (a[1].retouches || 0))
+        || (b[1].reads - a[1].reads))
+      .map(([rel]) => rel);
     if (!files.length) {
       process.stdout.write("Everything worked on so far is already captured — nothing new to write right now.\n");
       log(`MANUAL nothing-new session=${sid}`);
@@ -188,14 +204,16 @@ if (process.argv.includes("--manual")) {
     }
     const entries = worklistEntries(CLI, root, files, state.files, log);
     const payload = buildCapturePayload({ root, cli: CLI, sid, entries, envelope: "manual" });
-    // Mark ONLY the listed files captured. Re-read first: a Stop hook may have
-    // written the marker since we loaded it, and we must not clobber its
-    // counters. Best-effort — a failure here costs a duplicate ask, never the
-    // payload the user asked for.
+    // Mark ONLY the files actually LISTED (the worklist caps its display to
+    // MAX_WORKLIST) captured — any overflow stays uncaptured so it rolls into
+    // the next capture rather than being marked done but never shown. Re-read
+    // first: a Stop hook may have written the marker since we loaded it, and we
+    // must not clobber its counters. Best-effort — a failure here costs a
+    // duplicate ask, never the payload the user asked for.
     try {
       const live = JSON.parse(readFileSync(markerPath, "utf8"));
       if (live && live.files) {
-        for (const rel of files) if (live.files[rel]) live.files[rel].captured = true;
+        for (const rel of files.slice(0, MAX_WORKLIST)) if (live.files[rel]) live.files[rel].captured = true;
         writeFileSync(markerPath, JSON.stringify(live));
       }
     } catch (e) { log(`MANUAL mark-captured skipped ${e}`); }

--- a/hooks/trigger.mjs
+++ b/hooks/trigger.mjs
@@ -43,6 +43,12 @@
 
 export const T_ARM = 10;
 export const T_CAP = 20;
+/** Files a single fire CLAIMS (marks captured) and lists — the same cap the
+ *  worklist prompt renders (elicit-core slices its display to it). Files beyond
+ *  it stay UNCAPTURED so they roll into the NEXT fire's worklist, rather than
+ *  being marked done but never shown — which silently dropped notes on sessions
+ *  that touched more than this many files (a long autonomous grind). */
+export const MAX_CAPTURE_FILES = 30;
 export const SETTLE_ACTIVE_STOPS = 3;
 export const DESCENT_QUIET = 1;
 /** Uncaptured-file floor for the BLOCKING/backlog paths (head-drift, cap).
@@ -152,11 +158,15 @@ export function step(state, obs) {
 
   let decision = null;
   if (fire) {
-    // worklist = the uncaptured set, most-worked first (edits, then retouches)
-    const files = uncaptured
+    // worklist = the uncaptured set, most-worked first (edits, then retouches),
+    // capped to what one fire claims. Mark ONLY the listed files captured; the
+    // overflow stays uncaptured and rolls into the next fire (which re-fires
+    // soon, since the backlog keeps the score high).
+    const ranked = uncaptured
       .sort((a, b) => (b[1].edits - a[1].edits) || (b[1].retouches - a[1].retouches) || (b[1].reads - a[1].reads))
-      .map(([rel]) => rel);
-    for (const [, f] of uncaptured) f.captured = true;
+      .slice(0, MAX_CAPTURE_FILES);
+    const files = ranked.map(([rel]) => rel);
+    for (const [, f] of ranked) f.captured = true;
     s.armed = false;
     s.activeStops = 0;
     s.stopsSinceFire = 0;

--- a/tests/capture-trigger.test.ts
+++ b/tests/capture-trigger.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 // hooks/ modules are plain ESM — import them directly.
 import { compileIgnore, loadIgnore, DEFAULT_IGNORES } from '../hooks/ignore.mjs';
 import { extractEvidence, contentReadFiles, segmentStats } from '../hooks/evidence.mjs';
-import { initialState, step, T_ARM, T_CAP } from '../hooks/trigger.mjs';
+import { initialState, step, T_ARM, T_CAP, MAX_CAPTURE_FILES } from '../hooks/trigger.mjs';
 import { ensureColdstartignore } from '../src/init.js';
 import { appendRecord } from '../src/kb/raw-log.js';
 import { initSkeleton } from '../src/kb/store.js';
@@ -320,6 +320,26 @@ describe('trigger', () => {
     const edit = new Map([['a', { reads: 0, edits: 1, gs: 0 }]]);
     r = step(r.state, { ...QUIET, delta: edit });
     expect(r.state.files['a'].captured).toBe(false);
+  });
+
+  it('a fire claims at most MAX_CAPTURE_FILES; the overflow rolls into the next fire', () => {
+    const many = Array.from({ length: MAX_CAPTURE_FILES + 5 }, (_, i) => `f${i}.ts`);
+    // One big burst clears the cap threshold on the first stop.
+    let r = step(initialState(), { ...QUIET, delta: reads(...many) });
+    expect(r.decision?.fire).toBe('cap');
+    // Only a cap's worth is listed AND marked captured...
+    expect(r.decision?.files.length).toBe(MAX_CAPTURE_FILES);
+    const capturedAfterFirst = Object.values(r.state.files).filter((f) => f.captured).length;
+    expect(capturedAfterFirst).toBe(MAX_CAPTURE_FILES);
+    // ...the 5 overflow files stay UNCAPTURED (not marked done-but-unshown).
+    expect(Object.values(r.state.files).filter((f) => !f.captured).length).toBe(5);
+
+    // The uncaptured backlog keeps the score alive, so a later stop re-fires and
+    // picks up exactly the overflow — nothing is silently dropped.
+    let fired: string | undefined;
+    for (let i = 0; i < 25 && !fired; i++) { r = step(r.state, QUIET); fired = r.decision?.fire; }
+    expect(fired).toBeTruthy();
+    expect(Object.values(r.state.files).every((f) => f.captured)).toBe(true);
   });
 
   it('T_ARM sanity: exported constants match the frozen spec', () => {

--- a/tests/kb-elicit-hook.test.ts
+++ b/tests/kb-elicit-hook.test.ts
@@ -336,13 +336,35 @@ describe('kb-elicit --manual (on-demand capture)', () => {
     expect(out).toContain('src/b.ts');
   });
 
-  it('says nothing-new when every worked file is already captured', () => {
+  it('says nothing-new when every worked file is a read-only already-captured file', () => {
     seed(['src/a.ts']);
-    writeMarker({ 'src/a.ts': { edits: 2, captured: true } });
+    // Read-only + already offered → re-listing on demand is just noise.
+    writeMarker({ 'src/a.ts': { reads: 3, captured: true } });
 
     const out = manual();
     expect(out).toContain('already captured');
     expect(out).not.toContain('WORKLIST');
+  });
+
+  it('re-lists EDITED files even when a prior automatic fire marked them captured (Bug 1)', () => {
+    seed(['src/fix.ts', 'src/helper.ts', 'src/read.ts']);
+    // The session edited two files (the fix + a brand-new helper) and read one.
+    // An earlier AUTOMATIC fire already offered — and thus captured=true'd — all
+    // three. The edited ones are the highest-value notes and must still appear.
+    writeMarker({
+      'src/fix.ts': { edits: 3, captured: true },
+      'src/helper.ts': { edits: 1, captured: true },
+      'src/read.ts': { reads: 2, captured: true },
+    });
+
+    const out = manual();
+    expect(out).toContain('WORKLIST');
+    expect(out).toContain('src/fix.ts');
+    expect(out).toContain('src/helper.ts');
+    // Read-only + already-captured stays excluded (offered once, low value).
+    expect(out).not.toContain('src/read.ts');
+    // Most-worked leads: the 3× fix outranks the 1× helper.
+    expect(out.indexOf('src/fix.ts')).toBeLessThan(out.indexOf('src/helper.ts'));
   });
 
   it('explains itself when the repo has no capture evidence yet', () => {
@@ -352,18 +374,24 @@ describe('kb-elicit --manual (on-demand capture)', () => {
     expect(out).not.toContain('WORKLIST');
   });
 
-  it('marks the files it listed captured, so the next fire does not re-ask for them', () => {
-    seed(['src/a.ts']);
-    writeMarker({ 'src/a.ts': { edits: 2 } });
+  it('marks the files it listed captured, so the next AUTOMATIC fire does not re-ask', () => {
+    seed(['src/a.ts', 'src/b.ts']);
+    writeMarker({ 'src/a.ts': { edits: 2 }, 'src/b.ts': { reads: 1 } });
 
     const out = manual();
     expect(out).toContain('src/a.ts');
+    expect(out).toContain('src/b.ts');
 
     const after = JSON.parse(fs.readFileSync(markerPath(), 'utf8'));
     expect(after.files['src/a.ts'].captured).toBe(true);
+    expect(after.files['src/b.ts'].captured).toBe(true);
 
-    // …and a second manual run now has nothing outstanding.
-    expect(manual()).toContain('already captured');
+    // The read-only file, now captured, drops out of a second manual run; the
+    // edited file stays in scope (an explicit capture always shows this
+    // session's changes).
+    const second = manual();
+    expect(second).toContain('src/a.ts');
+    expect(second).not.toContain('src/b.ts');
   });
 
   it('touches ONLY captured — manual capture cannot perturb automatic firing', () => {


### PR DESCRIPTION
## Summary

Three related defects in the notebook capture worklist let an agent's most valuable notes — the files it **created or edited this session** — be silently skipped. Found while running `/capture-notes` and observing that a manual capture listed only read-only, already-noted files while every edited/new file was missing.

All three are in the capture path (`hooks/`); no changes to the search/recall engine.

## The bugs

### 1. Manual `/capture-notes` excluded edited files
The `--manual` path filtered out every `captured` file:
```js
const files = Object.keys(state.files).filter((rel) => !state.files[rel].captured);
```
But an **automatic** fire marks all the files it *offers* as `captured`. So a later explicit `/capture-notes` dropped exactly the session's changes — the fix and any brand-new helper — leaving the most valuable note unwritten and a now-stale note unfixed. `captured` means *"offered once"*, not *"a good note exists"*, so it's the wrong gate for an explicit user request.

**Fix:** include every **edited** file regardless of the flag (drop only read-only already-offered files), ranked most-worked first. Edit evidence comes straight from the transcript (Write/Edit), so untracked new files are covered with no index/git dependency.

### 2. The prompt treated the worklist as a hard ceiling
Capture Rule 3 said the worklist was the *"complete scope"* and to *"never write a note for an unlisted file"* — turning any gap in the heuristic, cross-host worklist derivation into an instruction for the agent to **suppress knowledge it already has** (a file it just created is in its own context).

**Fix:** relaxed to a one-liner — *if you edited or deep-read a file this session that isn't listed, you can write a note for it too.*

### 3. Overflow past the 30-file cap was marked done but never shown
On a fire, the trigger marked **all** uncaptured files `captured`, while the prompt only rendered the first `MAX_CAPTURE_FILES` (30). Files 31+ were flagged captured yet never put in front of the agent — and, being captured, never reappeared in a later fire. On a long autonomous session ("user just prompts, lots gets done") those notes were lost.

**Fix:** a fire now claims only the files it actually **lists**; the overflow stays uncaptured and rolls into the next fire (which re-fires quickly because the backlog keeps the score high). The display cap and the claim cap now share one constant. Applied to the manual path too.

## Tests
- `tests/kb-elicit-hook.test.ts` — manual capture re-lists edited files even when a prior automatic fire captured them; read-only already-captured files stay excluded; ranking.
- `tests/capture-trigger.test.ts` — a fire claims at most `MAX_CAPTURE_FILES`; the overflow stays uncaptured and is picked up by the next fire.
- Full suite: 609 passing.

## Not included
A separate false-**injection** issue (a generic positional alias word like "right" crossing the recall gate) was investigated but intentionally left out — the right fix needs corpus analysis rather than a word-list patch, and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyEXsxPQBeAoYm5zM7SY6m)_