### PR TITLE
chore(release): 2.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cstart/coldstart",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "mcpName": "io.github.AkashGoenka/coldstart",
   "publishConfig": {
     "access": "public"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AkashGoenka/coldstart",
     "source": "github"
   },
-  "version": "2.2.8",
+  "version": "2.2.9",
   "websiteUrl": "https://akashgoenka.github.io/coldstart/",
   "icons": [
     {


### PR DESCRIPTION
Version bump only — package.json, package-lock.json and server.json all set to 2.2.9 so the tag, the published tarball and the MCP registry entry agree.

Ships [#114](https://github.com/AkashGoenka/coldstart/pull/114):

- **graze rule** — a hook hit carried by one ordinary word no longer injects, unless the term is code-shaped, converged on a declared symbol, or the prompt named the note's path. Precision 31% → 47% on 140 hand-labelled injections; 86% of good hits retained.
- **session dedup** — `kb search --seen`, shared by all three recall hooks via `hooks/recall-seen.mjs`, resetting when the transcript shrinks (a compact) rather than on a clock.
- **harness stripping** — `hooks/recall-query.mjs` now actually runs; it was written but never wired into a published build, so editor/command telemetry was still being scored as user intent.
- **capture rule 7** — aliases are search keys (2–5 words, cover the file's own vocabulary), the root cause of alias bloat.

628 tests pass locally on main at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)