### PR TITLE
fix(kb): freshness labels a note, it no longer ranks it

### DIFF
--- a/src/kb/cli.ts
+++ b/src/kb/cli.ts
@@ -210,7 +210,10 @@ async function cmdSearch(words: string[], flags: KbFlags): Promise<number> {
       maxUsed: result.maxUsed,
       hits: result.hits.map((h) => ({
         id: h.note.id, type: h.note.type, kind: h.note.kind, title: h.note.title,
-        status: h.note.status, tier: h.inactive ? 'inactive' : h.note.status !== 'active' ? 'superseded' : h.tier === 1 ? 'stale' : h.stamped.some((s) => s.state === 'moved') ? 'moved' : 'fresh',
+        // Evidence state, derived from the live stamps — NOT from h.tier, which
+        // stopped encoding staleness in 2026-07-30 (freshness labels, it does
+        // not rank). The emitted vocabulary is unchanged for consumers.
+        status: h.note.status, tier: h.inactive ? 'inactive' : h.note.status !== 'active' ? 'superseded' : h.stamped.some((s) => s.state === 'changed' || s.state === 'missing') ? 'stale' : h.stamped.some((s) => s.state === 'moved') ? 'moved' : 'fresh',
         updated: h.note.updated, score: Math.round(h.score * 100) / 100,
         anchors: h.stamped, absence: h.absence,
         page: renderSearchPage(flags.root, query, { ...result, hits: [h] }),

--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -671,6 +671,16 @@ export function shouldImplantTop(result: KbSearchResult): boolean {
   return h.length === 1 || h[0].score >= 1.8 * h[1].score;
 }
 
+/** Which file a note is about, when its title no longer says so.
+ *
+ *  A file note's title defaults to its anchor path (fold.ts), so historically
+ *  the path was always on the line. Once notes carry a natural-language title
+ *  — which is the only way a prompt can reach them, since prose is scored but
+ *  cannot admit a match — a fresh note would otherwise never show its subject
+ *  anywhere: the freshness stamp only names paths when they changed or moved. */
+const subjectPath = (n: FoldedNote): string =>
+  n.type === 'file' && n.anchors[0] && n.anchors[0].path !== n.title ? ` · ${n.anchors[0].path}` : '';
+
 const gistLines = (hit: KbSearchHit): string[] => {
   const n = hit.note;
   const kind = n.type === 'lesson' && n.kind ? `/${n.kind}` : '';
@@ -686,7 +696,7 @@ const gistLines = (hit: KbSearchHit): string[] => {
   // symbol inventory (what the note knows about), not prose.
   const facetGist = n.facets.length ? `facets: ${n.facets.map((f) => f.symbol).join(', ')}` : '';
   const gistSrc = (n.summary || n.body || facetGist || n.invariants[0] || '').replace(/\s+/g, ' ').trim();
-  const lines = [`- **${n.title}**  [${n.type}${kind}${status}]${fresh}`];
+  const lines = [`- **${n.title}**  [${n.type}${kind}${subjectPath(n)}${status}]${fresh}`];
   lines.push(`  → open: ${NOTES_REL}/${n.id}.md`);
   // Same preview grade as the kb search results page (user ruling 2026-07-08:
   // precise delivery may not always work — every hit carries enough preview to
@@ -742,7 +752,7 @@ export function renderResultsPage(query: string, result: KbSearchResult): string
       changed.length ? `evidence changed: ${changed.slice(0, 2).map((s) => s.path).join(', ')}${changed.length > 2 ? ` +${changed.length - 2}` : ''}` :
       moved.length ? `moved → ${moved.slice(0, 2).map((s) => s.movedTo).join(', ')}${moved.length > 2 ? ` +${moved.length - 2}` : ''}` :
       hit.stamped.every((s) => s.state === 'fresh') ? 'fresh' : 'not fully verified';
-    parts.push(`${i + 1}. ${n.title}  [${n.type}${kind} · ${fresh} · ${n.updated.slice(0, 10)}]`);
+    parts.push(`${i + 1}. ${n.title}  [${n.type}${kind}${subjectPath(n)} · ${fresh} · ${n.updated.slice(0, 10)}]`);
     parts.push(`   → open: ${NOTES_REL}/${n.id}.md`);
     const facetGist = n.facets.length ? `facets: ${n.facets.map((f) => f.symbol).join(', ')}` : '';
     let prose = (n.summary || n.body || n.invariants[0] || facetGist || '').replace(/\s+/g, ' ').trim();

--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -12,8 +12,9 @@
  * scanning the code index here (C1 decoupling).
  *
  * Results carry freshness computed NOW (never trusted from write time);
- * absence notes print the keeper's re-run verdict stamp. Active+fresh
- * notes outrank stale/superseded ones as a hard tier, score within tier.
+ * absence notes print the keeper's re-run verdict stamp. Freshness is a LABEL,
+ * not a rank: only withdrawn notes (status) and notes whose subject is gone
+ * from this branch (inactive) are hard-tiered below score.
  *
  * Every zero-hit query is appended to the miss-log — the alias bet's failure
  * mode is SILENT (the agent just falls through to `find`), so the miss-log is
@@ -225,7 +226,7 @@ const HOOK_MIN_CARRIERS = 2;
  *  "arches/urls.py" yields ZERO terms; without this, naming a file is a no-op.
  *  The anchor-path squash must be ≥ this many chars to fire, so trivially short
  *  paths can't graze arbitrary prose. Boost dominates term scores so the named
- *  file leads its freshness tier. */
+ *  file leads its tier. */
 const PATH_MATCH_MIN_SQUASH = 6;
 const PATH_MATCH_BOOST = 100;
 
@@ -556,7 +557,8 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
     return { hits: [], terms, warnings };
   }
 
-  // Freshness NOW for everything scored, then hard-tier: fresh+active first.
+  // Freshness NOW for everything scored (never trusted from write time). It is
+  // LABELLED, never ranked — see the tier comment below.
   const rareById = new Map(scored.map((s) => [s.note.id, s.rare]));
   const withTier: KbSearchHit[] = scored.map(({ note, score, convergence, strongTerms, carriers }) => {
     // The keeper's rename overlay lets a note whose file was renamed resolve to
@@ -566,8 +568,27 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
     // Lessons are exempt (an absence lesson is ABOUT non-existence); any other
     // note whose anchored files are all gone is inactive on this branch.
     const inactive = note.type !== 'lesson' && anchorsAllMissing(stamped);
-    const stale = stamped.some((s) => s.state === 'changed' || s.state === 'missing');
-    const tier = inactive ? 3 : note.status !== 'active' ? 2 : stale ? 1 : 0;
+    // Tiers rank CLAIMS, not evidence age. Two conditions qualify: the note's
+    // subject is gone from this branch (inactive), or its author withdrew it
+    // (status). Anchor drift does NOT — "changed" means UNVERIFIED, not wrong,
+    // and the `[evidence changed: …]` label + the recall preamble's re-verify
+    // instruction already carry that.
+    //
+    // Staleness WAS a tier until 2026-07-30, and lexicographic order made it
+    // absolute: one moved byte in one cited file sank a note below every fresh
+    // one at any score. Measured over 249 logged prompts — the top-scoring note
+    // was buried on 50% of them (median 1.4×, max 4.3×, displaced to ranks
+    // 7-21), e.g. "why is the stop hook not firing" showed src/index.ts (3.9)
+    // while hooks/trigger.mjs (8.2) sat at rank 16. Flow notes were the
+    // systematic casualty: they anchor N files, so they go stale ~N× faster
+    // (100% of flows here vs 30% of file notes, 5.0 anchors vs 1.0) and reached
+    // a 3-slot page on 2% of queries — against ~30% by pure chance. Now 44%.
+    //
+    // Partial-`missing` is deliberately not a tier either: it is the same
+    // any-anchor binary rule one lane over, and it would re-sink exactly the
+    // multi-anchor flow notes this change frees. All-missing is `inactive`
+    // above, which is the real guard.
+    const tier = inactive ? 2 : note.status !== 'active' ? 1 : 0;
     return { note, score, tier, inactive, stamped, absence: absenceVerdict(note, opts.notesIndex), convergence, strongTerms, carriers };
   });
   // Recall (hook mode) must never inject a note whose subject doesn't exist on

--- a/src/kb/write.ts
+++ b/src/kb/write.ts
@@ -276,7 +276,16 @@ export async function kbWrite(root: string, spec: WriteSpec, opts: WriteOptions 
       ...(facets?.map((f) => f.symbol) ?? []),
     ])];
     record.anchors = [{ path, ...(symbols.length ? { symbols } : {}) }];
-    record.verified = [...new Set([path, ...(spec.verified ?? [])])];
+    // The file IS the anchor, and a write carrying KNOWLEDGE about it (summary,
+    // facets, body) could only come from having read it — that counts verified.
+    // A metadata-only touch does NOT. `verified` makes raw-log.ts stamp the
+    // file's live hash into the anchor, which resets freshness; auto-stamping on
+    // every put meant an alias or title fix silently re-certified the note
+    // against bytes nobody looked at. Caught 2026-07-30 by a 34-note title
+    // backfill that marked every one of them freshly verified. An explicit
+    // `verified` in the spec still wins — that is the agent's own claim.
+    const carriesKnowledge = !!(spec.summary?.trim() || facets?.length || spec.body?.trim());
+    record.verified = [...new Set([...(carriesKnowledge ? [path] : []), ...(spec.verified ?? [])])];
     if (character) record.character = character; // sugar form ("file-hub") lands here
   }
 

--- a/tests/kb-retrieval-live.test.ts
+++ b/tests/kb-retrieval-live.test.ts
@@ -157,7 +157,7 @@ describe('hook injection floor', () => {
 });
 
 describe('inactive projection — notes whose anchored files are absent on this branch', () => {
-  it('tool search keeps an absent-anchor note but flags it inactive (tier 3); a live one is active', async () => {
+  it('tool search keeps an absent-anchor note but flags it inactive (bottom tier); a live one is active', async () => {
     touch('src/live.py');
     appendRecord(root, {
       id: 'live-note', type: 'file', op: 'put', character: 'single',
@@ -176,7 +176,8 @@ describe('inactive projection — notes whose anchored files are absent on this 
     const live = tool.hits.find((h) => h.note.id === 'live-note');
     expect(live?.inactive).toBe(false);
     expect(gone?.inactive).toBe(true);
-    expect(gone?.tier).toBe(3);
+    // 2 since staleness stopped being a tier — inactive/superseded/active only.
+    expect(gone?.tier).toBe(2);
   });
 
   it('recall (hook mode) never injects a note whose anchored files are all absent', async () => {

--- a/tests/kb-search-write.test.ts
+++ b/tests/kb-search-write.test.ts
@@ -230,21 +230,30 @@ describe('kb search', () => {
     expect(withoutKb.hits).toHaveLength(0);
   });
 
-  it('tiers: active+fresh outranks stale outranks superseded — as a hard tier', async () => {
+  // Tiers rank CLAIMS (withdrawn / subject-gone), never evidence age. A stale
+  // note that answers the question beats a fresh note that doesn't; the
+  // `[evidence changed: …]` label is what tells the agent to re-verify. Until
+  // 2026-07-30 staleness was a hard tier and this expectation was the reverse,
+  // which buried the top-scoring note on 50% of real logged prompts.
+  it('staleness LABELS but does not rank; superseded is still a hard tier', async () => {
     writeRepoFile('src/fresh.ts', 'stable\n');
     writeRepoFile('src/stale.ts', 'v1\n');
     const freshHash = hashFile(root, 'src/fresh.ts');
     const oldHash = hashFile(root, 'src/stale.ts');
     fs.writeFileSync(path.join(root, 'src/stale.ts'), 'v2 drifted\n');
 
-    appendRecord(root, { id: 'stale-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared topic alpha beta', body: 'alpha beta gamma delta', anchors: [{ path: 'src/stale.ts', hash: oldHash }] });
-    appendRecord(root, { id: 'fresh-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared topic alpha', body: 'alpha', anchors: [{ path: 'src/fresh.ts', hash: freshHash }] });
-    appendRecord(root, { id: 'dead-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared topic alpha beta gamma', body: 'alpha beta gamma' });
+    // stale-note covers every query term; fresh-note covers two. dead-note
+    // covers everything too — it may only lose on status.
+    appendRecord(root, { id: 'stale-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared alpha beta gamma', body: 'alpha beta gamma', anchors: [{ path: 'src/stale.ts', hash: oldHash }] });
+    appendRecord(root, { id: 'fresh-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared alpha', body: 'alpha', anchors: [{ path: 'src/fresh.ts', hash: freshHash }] });
+    appendRecord(root, { id: 'dead-note', type: 'lesson', op: 'put', kind: 'absence', title: 'shared alpha beta gamma', body: 'alpha beta gamma' });
     appendRecord(root, { id: 'dead-note', type: 'lesson', op: 'supersede', by: 'fresh-note' });
 
-    const { hits } = await kbSearch(root, 'shared topic alpha', { maxResults: 10 });
-    expect(hits.map((h) => h.note.id)).toEqual(['fresh-note', 'stale-note', 'dead-note']);
-    const page = renderSearchPage(root, 'shared topic alpha', { hits, terms: [], warnings: [] });
+    const { hits } = await kbSearch(root, 'shared alpha beta gamma', { maxResults: 10 });
+    expect(hits.map((h) => h.note.id)).toEqual(['stale-note', 'fresh-note', 'dead-note']);
+    expect(hits.find((h) => h.note.id === 'stale-note')!.tier).toBe(0);
+    expect(hits.find((h) => h.note.id === 'dead-note')!.tier).toBe(1);
+    const page = renderSearchPage(root, 'shared alpha beta gamma', { hits, terms: [], warnings: [] });
     expect(page).toContain('[evidence changed: src/stale.ts]');
     expect(page).toContain('superseded by: fresh-note');
   });

--- a/tests/kb-search-write.test.ts
+++ b/tests/kb-search-write.test.ts
@@ -334,6 +334,36 @@ describe('kb write — two-phase gate', () => {
     expect((again as { id: string }).id).toBe((res as { id: string }).id);
   });
 
+  // `verified` makes raw-log stamp the file's LIVE hash into the anchor, which
+  // resets freshness. Auto-stamping it on every put let a metadata-only edit
+  // re-certify a note against bytes nobody read — staleness laundered by a
+  // title fix. Knowledge (summary/facets/body) implies a read; a title does not.
+  it('a metadata-only write does NOT re-verify the anchor; a knowledge write does', async () => {
+    writeRepoFile('src/drift.ts', 'v1\n');
+    const first = await kbWrite(root, { type: 'file-single', path: 'src/drift.ts', summary: 'the original' });
+    const id = (first as { id: string }).id;
+    const rawPath = path.join(root, '.coldstart/notebook/.raw', `${id}.jsonl`);
+    const h1 = JSON.parse(fs.readFileSync(rawPath, 'utf8').trim()).anchors[0].hash;
+    expect(h1).toMatch(/^sha256:/);
+
+    fs.writeFileSync(path.join(root, 'src/drift.ts'), 'v2 drifted\n');
+
+    // metadata only — no summary, no facets: must not claim a fresh read
+    await kbWrite(root, { type: 'file', path: 'src/drift.ts', title: 'plain words for the file' });
+    const metaRec = JSON.parse(fs.readFileSync(rawPath, 'utf8').trim().split('\n').at(-1)!);
+    expect(metaRec.verified ?? []).toEqual([]);
+    expect(metaRec.anchors[0].hash).toBeUndefined();
+    const stale = await kbSearch(root, 'plain words for the file', { maxResults: 5, noMissLog: true });
+    expect(stale.hits[0].stamped[0].state).toBe('changed'); // still measured against v1
+
+    // a write that carries knowledge could only come from reading it — re-stamps
+    await kbWrite(root, { type: 'file', path: 'src/drift.ts', summary: 'now describes v2' });
+    const knowRec = JSON.parse(fs.readFileSync(rawPath, 'utf8').trim().split('\n').at(-1)!);
+    expect(knowRec.verified).toEqual(['src/drift.ts']);
+    expect(knowRec.anchors[0].hash).toMatch(/^sha256:/);
+    expect(knowRec.anchors[0].hash).not.toBe(h1);
+  });
+
   it('facet flow-refs: exact title resolves to the coined id; unresolvable refs are KEPT and warned, never rejected', async () => {
     writeRepoFile('src/a.py', 'def entry(): pass\n');
     const flow = await kbWrite(root, {


### PR DESCRIPTION
## Freshness labels a note; it no longer ranks it

`kb search` sorted by freshness tier **before** score, lexicographically. One changed byte
in one cited file sank a note below every fresh note, at any score — an absolute demotion for
what is really just "unverified since".

Measured over 249 logged prompts from this repo's inject log:

- the **top-scoring note was buried on 50%** of them (median 1.4×, max 4.3×, displaced to ranks 7–21)
- e.g. *"why is the stop hook not firing"* surfaced `src/index.ts` (score 3.9) while
  `hooks/trigger.mjs` (8.2) sat at rank 16
- **flow notes were the systematic casualty**: they anchor N files, so they go stale ~N× faster
  (100% of flows here vs 30% of file notes; 5.0 anchors vs 1.0). They reached a 3-slot page on
  **2%** of queries — against ~30% by pure chance.

After: flow-in-top-3 **2% → 44%**; hook injections **137 → 150 with zero lost**.

Tiers now rank **claims**, not evidence age — a note is demoted only when its subject is gone
from this branch (`inactive`) or its author withdrew it (`status`). Drift stays a *label*: the
`[evidence changed: …]` marker and the recall preamble's re-verify instruction already carry it.

Partial-`missing` is deliberately **not** a tier either — it is the same any-anchor binary rule
one lane over, and would re-sink exactly the multi-anchor flow notes this frees. All-missing is
`inactive`, which is the real guard.

## Two fixes this surfaced

**A metadata-only edit no longer re-verifies its anchor.** `verified` is what makes `raw-log.ts`
stamp a file's live hash, which resets freshness. `write.ts` auto-added the path on *every*
file-note put, so an alias or title fix silently re-certified a note against bytes nobody read.
Caught when a 34-note title backfill marked every one of them freshly verified. Now only a write
carrying knowledge (summary / facets / body) counts; an explicit `verified` in the spec still wins.
This matters more now that the label is the only staleness signal left.

**A note renders the file it is about when its title isn't the path.** A file note's title
defaults to its anchor path, so the path was always on the line. Once a note carries a real title,
a *fresh* note would show its subject nowhere — the freshness stamp only names paths when they
changed or moved.

## Tests

629 pass. `tests/kb-search-write.test.ts` asserted the **opposite** tier order until now — the
rewritten test pins the new contract (a stale note covering every term outranks a fresher note
covering fewer; superseded stays last) plus the metadata-vs-knowledge write distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
