### PR TITLE
feat(kb): capture coverage, recall admission gates, alias cap (2.2.11)

### DIFF
--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -105,6 +105,13 @@ future agent would not act differently for knowing it, don't store it.
 3. The worklist below is your scope, most-worked first. Unlisted files are out — ignored \
 (.coldstartignore) or already captured. If you edited or deep-read a file this session that \
 isn't listed, you can write a note for it too.
+3a. Rules 1 and 2 are for files you barely touched — they are not licence to write one note \
+and stop. Every file marked [edited] is a file you changed with intent: you know why it \
+changed and what you had to understand to change it, and that is precisely the knowledge a \
+cold agent lacks. The default for an edited file is a note. Walk the worklist top to bottom \
+and decide each one explicitly; do not stop at the first two or three. If you end up writing \
+notes for well under half the [edited] files, you have under-captured — say which files you \
+skipped and why, so the decision is visible instead of silent.
 
 WORKLIST — files you actually read this session, most-worked first:
 
@@ -159,6 +166,12 @@ title.
 WRITE — one Bash block total: specs as heredocs, writes chained with &&.
   {"type":"file-single","path":"src/x.py","summary":"1-3 sentences","aliases":["symptom words"]}
   {"type":"file-hub","path":"src/y.py","facets":[{"symbol":"Fn","detail":"the non-obvious thing"}]}
+  {"type":"flow","title":"how X happens","summary":"first sentence = the product-level fact",
+   "steps":[{"path":"src/a.py","symbols":["entry"],"role":"receives the request"}],
+   "invariants":["what must hold"],"verified":["src/a.py"]}
+  A flow's anchors come from its "steps" — a flow written without them is a note with NO \
+anchors: kb lookup cannot reach it and it can never be freshness-stamped. Never write a flow \
+using the file-note shape (title + summary) from memory.
   file-single is the DEFAULT. A file with one purpose gets one summary even if you worked \
 with several of its symbols. file-hub is ONLY for grab-bag files that have no single purpose \
 (models.py, utils, helpers) — there, knowledge lives per symbol. Touching many symbols does \
@@ -167,9 +180,11 @@ not make a file a hub; having no one purpose does.
   node ${cli} kb write /tmp/spec1.json --root ${root} --session ${sid} --force
   Flow/lesson shapes: run \`node ${cli} kb write --root ${root}\` with no spec — it prints the full guide.
 
-FLOW DECISION — run this EVERY time, as its own command. It stands apart from the WRITE block \
-above: run it even when you decided no note was warranted and emitted no Bash block at all. It \
-records only what you decided about FLOWS (created a new one, folded into an existing one, or \
-none) so the flow gate can be measured.
-  node ${cli} kb flow-decision --decision <none|new|update> [--id <flow id>] --why "<one clause>" --root ${root} --session ${sid}${tail}`;
+FLOW DECISION — record what you decided about FLOWS (created a new one, folded into an \
+existing one, or none) so the flow gate can be measured. Ride it on your LAST kb write — it \
+is a flag, not a second command:
+  node ${cli} kb write /tmp/specN.json --root ${root} --session ${sid} --force \\
+    --decision <none|new|update> [--id <flow id>] --why "<one clause>"
+Only when you wrote NO notes at all is there no write to carry it, and then run it alone:
+  node ${cli} kb flow-decision --decision none --why "<one clause>" --root ${root} --session ${sid}${tail}`;
 }

--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -16,8 +16,42 @@
  *              (the coordinator only sees the final message — #61).
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/**
+ * Session worklist manifest — the DENOMINATOR for capture coverage.
+ *
+ * The checklist can only ASK the agent to walk the whole worklist (rule 3a);
+ * nothing downstream could tell it that it wrote 8 notes for 30 worked files,
+ * because `kb write` sees one spec at a time and never saw the worklist. So the
+ * worklist is dropped here, at the one point every host passes through, and
+ * `kb write --session <sid>` reads it back to print "N of M".
+ *
+ * CONTRACT TWIN: src/kb/session-worklist.ts — same filename, same shape. Keyed
+ * by session id in tmpdir like the pending-capture file (elicit-core.pendingPath);
+ * never in the repo, so it cannot be committed and needs no ignore rule.
+ * Best-effort: capture must never fail because this could not be written.
+ */
+export function worklistManifestPath(sid) {
+  return join(tmpdir(), `coldstart-kb-worklist-${sid}.json`);
+}
+
+function recordWorklistManifest(sid, entries) {
+  if (!sid || !entries?.length) return;
+  try {
+    // needsNote: no note yet, or the note it has is stale. A file whose note is
+    // already fresh is NOT an outstanding item — counting it would make full
+    // coverage unreachable and the ratio meaningless.
+    const files = entries.map((e) => ({
+      path: e.path,
+      tier: e.tier,
+      needsNote: !e.notes?.length || e.notes.some((n) => n.state === "changed" || n.state === "missing"),
+    }));
+    writeFileSync(worklistManifestPath(sid), JSON.stringify({ ts: Date.now(), files, wrote: [] }));
+  } catch { /* best-effort */ }
+}
 
 /**
  * SPIKE (experimental, undocumented): a repo can replace the shipped checklist
@@ -64,6 +98,7 @@ function worklistLines(entries) {
 }
 
 export function buildCapturePayload({ root, cli, sid, entries, envelope }) {
+  recordWorklistManifest(sid, entries);
   const opening = envelope === "block"
     ? "Handle capture now, then stop."
     : envelope === "manual"
@@ -111,7 +146,9 @@ changed and what you had to understand to change it, and that is precisely the k
 cold agent lacks. The default for an edited file is a note. Walk the worklist top to bottom \
 and decide each one explicitly; do not stop at the first two or three. If you end up writing \
 notes for well under half the [edited] files, you have under-captured — say which files you \
-skipped and why, so the decision is visible instead of silent.
+skipped and why, so the decision is visible instead of silent. Each \`kb write\` prints the \
+running count ("N of M worklist files noted") and lists what is still unwritten — read that \
+line back before you finish; it is the only place your own coverage is visible to you.
 
 WORKLIST — files you actually read this session, most-worked first:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cstart/coldstart",
-      "version": "2.2.10",
+      "version": "2.2.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "mcpName": "io.github.AkashGoenka/coldstart",
   "publishConfig": {
     "access": "public"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AkashGoenka/coldstart",
     "source": "github"
   },
-  "version": "2.2.10",
+  "version": "2.2.11",
   "websiteUrl": "https://akashgoenka.github.io/coldstart/",
   "icons": [
     {
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cstart/coldstart",
-      "version": "2.2.8",
+      "version": "2.2.11",
       "transport": {
         "type": "stdio"
       }

--- a/src/kb/cli.ts
+++ b/src/kb/cli.ts
@@ -22,6 +22,7 @@ import { kbSearch, renderSearchPage, renderResultsPage, renderCompactPage, shoul
 import { loadKbNotesIndex } from './notes-index.js';
 import { kbWrite, type WriteSpec } from './write.js';
 import { writeGuideCli, flowEvidenceWarning, flowStepsWarning } from './write-guide.js';
+import { noteCoverage } from './session-worklist.js';
 import { kbLookup, renderLookup } from './lookup.js';
 import { kbLint, lintSummary } from './lint.js';
 import { kbCommit } from './commit.js';
@@ -298,10 +299,15 @@ async function cmdWrite(positional: string[], flags: KbFlags): Promise<number> {
   // cover — deciding no note was warranted, where there is no write to ride on.
   if (flags.decision) recordFlowDecision(flags);
 
+  // Capture coverage — how much of this session's worklist has a note now.
+  // Printed with the write itself so under-capture is visible while the agent
+  // is still writing, instead of only in the transcript nobody reads.
+  const coverage = noteCoverage(flags.session, spec);
+
   const warned = warnings.length
     ? '\n' + warnings.map((w) => `warning: ${w}`).join('\n')
     : '';
-  out(`kb write: ${result.op} → ${result.id}${warned}`);
+  out(`kb write: ${result.op} → ${result.id}${warned}${coverage ? `\n${coverage}` : ''}`);
   return 0;
 }
 

--- a/src/kb/cli.ts
+++ b/src/kb/cli.ts
@@ -21,7 +21,7 @@ import { setupNotebook, wireClaudeKbHooks } from '../init.js';
 import { kbSearch, renderSearchPage, renderResultsPage, renderCompactPage, shouldImplantTop } from './search.js';
 import { loadKbNotesIndex } from './notes-index.js';
 import { kbWrite, type WriteSpec } from './write.js';
-import { writeGuideCli, flowEvidenceWarning } from './write-guide.js';
+import { writeGuideCli, flowEvidenceWarning, flowStepsWarning } from './write-guide.js';
 import { kbLookup, renderLookup } from './lookup.js';
 import { kbLint, lintSummary } from './lint.js';
 import { kbCommit } from './commit.js';
@@ -288,6 +288,8 @@ async function cmdWrite(positional: string[], flags: KbFlags): Promise<number> {
 
   // Flow-evidence WARN (never a rejection): a flow whose steps the session
   // never actually read is the classic bad flow — assembled from grep hits.
+  const stepsWarn = flowStepsWarning(spec);
+  if (stepsWarn) warnings.push(stepsWarn);
   const flowWarn = flowEvidenceWarning(spec, flags.session);
   if (flowWarn) warnings.push(flowWarn);
 

--- a/src/kb/cli.ts
+++ b/src/kb/cli.ts
@@ -293,6 +293,11 @@ async function cmdWrite(positional: string[], flags: KbFlags): Promise<number> {
   const flowWarn = flowEvidenceWarning(spec, flags.session);
   if (flowWarn) warnings.push(flowWarn);
 
+  // Flow decision, folded into the write so capture costs ONE call instead of
+  // two. The standalone `kb flow-decision` stays for the case this cannot
+  // cover — deciding no note was warranted, where there is no write to ride on.
+  if (flags.decision) recordFlowDecision(flags);
+
   const warned = warnings.length
     ? '\n' + warnings.map((w) => `warning: ${w}`).join('\n')
     : '';
@@ -307,19 +312,24 @@ async function cmdWrite(positional: string[], flags: KbFlags): Promise<number> {
  *  Without those two, a flow-rate change is uninterpretable — we cannot tell a prompt
  *  that suppresses flows from one agents never reach. Diagnostic instrument: remove it
  *  once the flow gate is tuned. Best-effort, never fails a capture. */
+function recordFlowDecision(flags: KbFlags): void {
+  if (!flags.decision || !['none', 'new', 'update'].includes(flags.decision)) return;
+  logMetric(flags.root, 'capture', {
+    event: 'flow-decision',
+    decision: flags.decision,
+    id: flags.id,
+    why: flags.why,
+    session: flags.session,
+  });
+}
+
 function cmdFlowDecision(flags: KbFlags): number {
   const decision = flags.decision;
   if (!decision || !['none', 'new', 'update'].includes(decision)) {
     out('usage: kb flow-decision --decision none|new|update [--id <flow id>] [--why "<one clause>"]');
     return 2;
   }
-  logMetric(flags.root, 'capture', {
-    event: 'flow-decision',
-    decision,
-    id: flags.id,
-    why: flags.why,
-    session: flags.session,
-  });
+  recordFlowDecision(flags);
   return 0;
 }
 

--- a/src/kb/fold.ts
+++ b/src/kb/fold.ts
@@ -11,7 +11,9 @@
  *   title/summary/kind/body/scope  last-writer-wins
  *   character                      last-writer-wins (a file's character is a
  *                                  revisable judgment, hence a field not a type)
- *   aliases/invariants             union by exact text (retractable)
+ *   aliases                        union by exact text (retractable), then
+ *                                  CAPPED newest-first — see capAliases
+ *   invariants                     union by exact text (retractable)
  *   facets                         keyed by symbol: detail replaces, flows
  *                                  union, head stamped from the writing record
  *   behaviors                      keyed by concept_id: replace match, keep rest
@@ -122,7 +124,46 @@ export function fold(id: string, rawRecords: unknown[]): FoldResult {
   if (!note.title) {
     note.title = type === 'file' && note.anchors[0] ? note.anchors[0].path : id;
   }
+  note.aliases = capAliases(note.aliases);
   return { note, warnings };
+}
+
+/** Alias budget. The union above is unbounded, and that is a recall bug: a
+ *  note's alias list grows with how many times it has been written, so
+ *  per-write guidance cannot bound it. Measured on this repo 2026-07-30 —
+ *  every individual write obeyed the capture prompt's 6-10 rule (median 6
+ *  aliases / 20 words per put record), yet src/kb/search.ts's note reached 57
+ *  aliases across nine compliant writes. The cap has to live here, at the
+ *  union, or it does not exist.
+ *
+ *  Why it matters: `hookNameNorm` (search.ts) divides the name channel by its
+ *  own token count, so the channel is ZERO-SUM — every accumulated alias taxes
+ *  every other one. WORDS are the real currency, hence the word budget; the
+ *  count cap is the secondary guard against many short aliases.
+ *
+ *  Nothing is lost. The fold is a pure function of the append-only `.raw` log,
+ *  which still holds every alias ever written — widening or removing these
+ *  constants and re-rendering restores them exactly. */
+export const ALIAS_MAX = 12;
+export const ALIAS_MAX_WORDS = 40;
+/** Never trim below this, however long the individual aliases are. */
+const ALIAS_KEEP_MIN = 4;
+
+/** Keep the NEWEST aliases within budget. `applyPut` appends in fold order, so
+ *  this array is oldest-first and the tail is what the most recent writers —
+ *  the ones who saw the file in its current shape — chose as its search keys. */
+export function capAliases(aliases: string[]): string[] {
+  if (aliases.length <= ALIAS_KEEP_MIN) return aliases;
+  const kept: string[] = [];
+  let words = 0;
+  for (let i = aliases.length - 1; i >= 0; i--) {
+    const w = aliases[i].split(/\s+/).filter(Boolean).length;
+    const overBudget = kept.length >= ALIAS_MAX || words + w > ALIAS_MAX_WORDS;
+    if (overBudget && kept.length >= ALIAS_KEEP_MIN) break;
+    kept.push(aliases[i]);
+    words += w;
+  }
+  return kept.reverse();
 }
 
 function applyPut(note: FoldedNote, rec: Rec, warnings: string[]): void {

--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -219,6 +219,11 @@ const HOOK_CONVERGE_MIN = 4;
  */
 const HOOK_MIN_CARRIERS = 2;
 
+/** How many query terms must land inside ONE authored string (the title, or a
+ *  single alias) for a hit carried entirely by the name channel to count. See
+ *  the text-only-coincidence gate below. */
+const NAME_ONLY_MIN_DENSITY = 2;
+
 /** Path-name override: when the raw prompt literally contains a note's anchor
  *  path (case/separator-insensitive), the user named that file — surface its
  *  note regardless of term rarity. parseTerms drops `/`-glued paths (the `/`
@@ -469,6 +474,7 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
     let rare = false;
     let hardEvidence = false;
     const carriers: string[] = [];
+    const nameTerms: string[] = [];
     for (let k = 0; k < terms.length; k++) {
       const t = terms[k];
       let inName = hits(h.name, h.nameSquash, t);
@@ -513,7 +519,29 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
       if (converged) convergence = true;
       // Evidence strong enough to stand alone: an identifier the user typed, or
       // a term confirmed by the note's own anchor symbols. See HOOK_MIN_CARRIERS.
-      if (converged || isCodeShaped(t)) hardEvidence = true;
+      //
+      // Convergence must ALSO be rare. `name`, `id`, `type`, `status`, `write`
+      // are declared as symbols in most codebases, so an ordinary word matching
+      // one is not evidence — but it was setting hardEvidence, which bypasses
+      // HOOK_MIN_CARRIERS entirely and admitted the note on that one word.
+      // 68 of this repo's 83 single-carrier hits arrived that way. Hand-labelling
+      // all of them split perfectly on rarity: every good one rode a rare term
+      // (`descent`, `quiet`, `kbView`, `recall`), every junk one rode a common
+      // one (`status` on "server returned status 403", `search` on "google
+      // search console", `write` on "write multiple articles", `command`,
+      // `mcp`, `run`, `files`). Reported independently from a production
+      // notebook, where generic-symbol over-trust was one of three named junk
+      // causes. Reuses the SAME rarity the plain-word lane already applies
+      // (df ≤ rareMax) rather than inventing a second notion of common.
+      // Rarity here is note-level df, the same notion the plain-word lane uses.
+      // It does NOT catch a homonym that happens to be rare — `status` sits in
+      // two notes, so "server returned status 403" still reaches src/status.ts.
+      // That is the wrong-DOMAIN cause, which is separate and needs a different
+      // mechanism. Gating additionally on how many anchored files declare the
+      // symbol was tried and made zero difference on this corpus (309 hits /
+      // 150 pages either way), so it is not shipped on speculation.
+      if ((converged && df[k] <= rareMax) || isCodeShaped(t)) hardEvidence = true;
+      if (inName) nameTerms.push(t);
       carriers.push(`${t}:${inName ? 'n' : ''}${inAnchor ? 'a' : ''}${inBody ? 'b' : ''}${converged ? 'c' : ''}`);
       if (opts.strongOnly) {
         // Presence·idf, with the name channel divided by how many identifiers
@@ -549,6 +577,33 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
     // candidate at every rank: a hit that clears the bar is eligible to rank
     // first, whatever fell away above it.
     if (opts.strongOnly && !pathNamedIds.has(note.id) && !hardEvidence && carriers.length < HOOK_MIN_CARRIERS) continue;
+    // Text-only coincidence: every matched term landed in the AUTHORED name
+    // channel and nowhere else — no path, no body, no declared symbol. The
+    // query and the note share vocabulary and nothing more. Reported as the
+    // top junk cause in a production notebook; rare in this repo's own, where
+    // notes are mostly about the tool itself, so do NOT re-validate it here.
+    //
+    // The rule is density, not a blanket block: a plain title match IS how a
+    // note is meant to be found, and rejecting every name-only hit killed good
+    // ones outright ("why does capture fires twice" → the capture-fire note,
+    // which is name-only whenever no notesIndex is loaded). What separates a
+    // real title match from a coincidence is whether the terms CLUSTER — two
+    // query terms inside ONE authored string (the title, or a single alias)
+    // rather than one word each from two unrelated aliases. Measured on labelled
+    // production hits, that density lifted precision 0.60 → 0.71 with no recall
+    // loss; it is applied here only to the name-only population it describes.
+    //
+    // Anchored notes only. A lesson note has no anchors by construction — its
+    // whole retrieval surface is title + scope terms — so requiring backing
+    // would make every confirmed-absence note permanently unfireable, and would
+    // do the same to a flow written without steps.
+    if (opts.strongOnly && !pathNamedIds.has(note.id) && note.anchors.length && carriers.length > 0
+        && carriers.every((c) => c.endsWith(':n'))) {
+      const groups = [note.title, ...note.aliases];
+      const maxInGroup = groups.reduce(
+        (m, g) => Math.max(m, nameTerms.filter((t) => wordHit(g, t)).length), 0);
+      if (maxInGroup < NAME_ONLY_MIN_DENSITY) continue;
+    }
     scored.push({ note, score: boost, convergence, rare, strongTerms, carriers });
   }
 

--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -597,6 +597,13 @@ export async function kbSearch(root: string, query: string, opts: KbSearchOption
     // whole retrieval surface is title + scope terms — so requiring backing
     // would make every confirmed-absence note permanently unfireable, and would
     // do the same to a flow written without steps.
+    // Density, NOT breadth. Counting how many DIFFERENT aliases a query touched
+    // was measured on the same corpus and is anti-correlated with quality: a
+    // groupsHit ≥ 3 escape hatch re-admitted 8 of the 38 hits this gate drops,
+    // 7 of them junk ("one"+"arms" reaching trigger.mjs across 6 of its aliases).
+    // Alias breadth is a property of the NOTE's vocabulary volume, not of the
+    // match — the more aliases a note carries, the more groups any prose sprays
+    // across. Only clustering inside one authored string means anything.
     if (opts.strongOnly && !pathNamedIds.has(note.id) && note.anchors.length && carriers.length > 0
         && carriers.every((c) => c.endsWith(':n'))) {
       const groups = [note.title, ...note.aliases];

--- a/src/kb/session-worklist.ts
+++ b/src/kb/session-worklist.ts
@@ -1,0 +1,90 @@
+/**
+ * Capture coverage — telling the writing agent how much of its worklist it noted.
+ *
+ * The gap this closes: the capture checklist hands the agent a worklist of every
+ * file it worked on, but `kb write` only ever sees ONE spec, so nothing could
+ * report "you wrote 8 notes for 30 worked files". The agent's own count is the
+ * one thing it cannot check — it is mid-heredoc, and under-capture is silent by
+ * construction. So the hook drops the worklist in tmpdir when it builds the
+ * capture prompt, and every `kb write --session <sid>` prints the running ratio.
+ *
+ * CONTRACT TWIN: hooks/capture-payload.mjs (worklistManifestPath) writes this
+ * file; keep the name and shape in step. Everything here is best-effort — a
+ * missing, stale or malformed manifest prints nothing and never fails a write.
+ *
+ * Local only. The manifest lives in tmpdir, never in the repo: it is scratch
+ * state for one session, not a record, and nothing about it is transmitted.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface WorklistFile { path: string; tier: string; needsNote: boolean }
+interface Manifest { ts: number; files: WorklistFile[]; wrote: string[] }
+
+/** Manifests older than this are a resumed/unrelated session — ignore them. */
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+/** Below this share of outstanding files, name the skips. */
+const LOW_COVERAGE = 0.5;
+const LIST_MAX = 6;
+
+function manifestPath(sid: string): string {
+  return join(tmpdir(), `coldstart-kb-worklist-${sid}.json`);
+}
+
+function load(sid: string): Manifest | null {
+  try {
+    const m = JSON.parse(readFileSync(manifestPath(sid), 'utf8')) as Manifest;
+    if (!Array.isArray(m?.files) || !m.files.length) return null;
+    if (typeof m.ts === 'number' && Date.now() - m.ts > MAX_AGE_MS) return null;
+    m.wrote = Array.isArray(m.wrote) ? m.wrote : [];
+    return m;
+  } catch {
+    return null;
+  }
+}
+
+/** Paths this spec puts a note on. Flow steps do NOT count: a flow verifies
+ *  files, it does not give any of them the file note rule 5 asks for. */
+export function specPaths(spec: unknown): string[] {
+  const s = spec as { type?: string; path?: string };
+  if (!s || typeof s.path !== 'string') return [];
+  return s.type === 'file-single' || s.type === 'file-hub' ? [s.path] : [];
+}
+
+/**
+ * Record this write against the session worklist and return the coverage line
+ * to print, or null when there is no manifest to compare against (no --session,
+ * a manual `kb write` outside capture, a session that never armed).
+ */
+export function noteCoverage(sid: string | undefined, spec: unknown): string | null {
+  if (!sid) return null;
+  const m = load(sid);
+  if (!m) return null;
+
+  for (const p of specPaths(spec)) if (!m.wrote.includes(p)) m.wrote.push(p);
+  try { writeFileSync(manifestPath(sid), JSON.stringify(m)); } catch { /* best-effort */ }
+
+  const outstanding = m.files.filter((f) => f.needsNote);
+  if (!outstanding.length) return null;
+  const wrote = new Set(m.wrote);
+  const done = outstanding.filter((f) => wrote.has(f.path));
+  const left = outstanding.filter((f) => !wrote.has(f.path));
+  const already = m.files.length - outstanding.length;
+
+  const lines = [
+    `capture coverage: ${done.length} of ${outstanding.length} worklist files noted` +
+      (already ? ` (${already} more already had a fresh note)` : ''),
+  ];
+  if (left.length) {
+    const shown = left.slice(0, LIST_MAX).map((f) => `${f.path} [${f.tier}]`).join(', ');
+    lines.push(`  not noted yet: ${shown}${left.length > LIST_MAX ? `, +${left.length - LIST_MAX} more` : ''}`);
+  }
+  // The nudge fires only on the low end, and asks for a REASON rather than more
+  // notes: a deliberate skip is a fine answer, an invisible one is not. Chained
+  // writes each print this, so the last line of the block carries the real tally.
+  if (left.length && done.length / outstanding.length < LOW_COVERAGE) {
+    lines.push('  if those need no note, say which and why in your reply — an unexplained skip reads as a forgotten one.');
+  }
+  return lines.join('\n');
+}

--- a/src/kb/write-guide.ts
+++ b/src/kb/write-guide.ts
@@ -26,7 +26,11 @@ export const WRITE_GUIDE_SHAPES = `kb write — spec shapes (JSON, one note per 
      "facets":[{"symbol":"ClassOrFn","detail":"the non-obvious thing about THIS symbol",
                 "flows":["<flow id or the flow's exact title>"]}]}
 
-  flow (product-level mechanism — see the capture checklist's gate):
+  flow (product-level mechanism — see the capture checklist's gate).
+       "steps" is REQUIRED: a flow's anchors are DERIVED from it, so a flow
+       without steps writes a note with NO anchors — unreachable by kb lookup,
+       invisible to the anchor channel, never freshness-stamped. Do not reuse
+       the file-note shape (title + summary) from memory for a flow:
     {"type":"flow","title":"how X happens","aliases":["other words for X"],
      "summary":"first sentence = the product-level fact the file notes miss",
      "steps":[{"path":"src/a.py","symbols":["entry"],"role":"receives the request"}],
@@ -94,6 +98,30 @@ export function flowEvidenceCount(spec: WriteSpec, session: string): { read: num
     if (!read.size) return null;
     return { read: paths.filter((p) => read.has(p)).length, steps: paths.length };
   } catch { return null; }
+}
+
+/** The WARN text (never a rejection) when a flow carries no `steps` at all.
+ *
+ *  A flow's anchors are DERIVED from its steps, so a stepless flow folds to a
+ *  note with zero anchors and no Steps/Invariants section — and still reports
+ *  `put → <id>` like any success. It is then unreachable by `kb lookup <path>`,
+ *  invisible to the anchor channel, and never freshness-stamped. The shape is
+ *  easy to reach by reusing the file-note spec from memory (title + summary),
+ *  which is exactly why it needs to be loud rather than silent.
+ *
+ *  Separate from flowEvidenceWarning below: this one needs no session, because
+ *  a missing `steps` array is a defect in the spec itself, not in its evidence. */
+export function flowStepsWarning(spec: WriteSpec): string | null {
+  if (!spec || (spec as { type?: string }).type !== 'flow') return null;
+  if ((spec as { op?: string }).op === 'retract') return null;
+  const steps = (spec as { steps?: unknown[] }).steps;
+  if (Array.isArray(steps) && steps.length) return null;
+  return (
+    'flow has no "steps": a flow\'s anchors come from its steps, so this note has NO anchors — ' +
+    'kb lookup cannot reach it, the anchor channel cannot match it, and it can never be ' +
+    'freshness-stamped. Re-put it with steps [{path, symbols, role}] (and "verified" for the ' +
+    'files you actually read). Run `kb write` with no spec to print the full flow shape.'
+  );
 }
 
 /** The WARN text (never a rejection) when a flow's steps lack read evidence.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -246,7 +246,7 @@ export function registerToolHandlers(
       case 'kb_write': {
         const { kbWrite } = await import('../kb/write.js');
         const { initSkeleton } = await import('../kb/store.js');
-        const { writeGuideMcp, flowEvidenceWarning } = await import('../kb/write-guide.js');
+        const { writeGuideMcp, flowEvidenceWarning, flowStepsWarning } = await import('../kb/write-guide.js');
         const spec = params['spec'];
         if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
           // Parity with `kb write` (no spec): return the full guide, not an error.
@@ -268,6 +268,9 @@ export function registerToolHandlers(
           };
         } else {
           const warnings = [...(wres.warnings ?? [])];
+          // Stepless-flow WARN — parity with `kb write`; needs no session.
+          const stepsWarn = flowStepsWarning(spec as import('../kb/write.js').WriteSpec);
+          if (stepsWarn) warnings.push(stepsWarn);
           // Flow-evidence WARN (never a rejection) — parity with `kb write --session`.
           const flowWarn = flowEvidenceWarning(
             spec as import('../kb/write.js').WriteSpec,

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -277,7 +277,13 @@ export function registerToolHandlers(
             params['session'] ? String(params['session']) : undefined,
           );
           if (flowWarn) warnings.push(flowWarn);
-          result = { status: 'written', op: wres.op, id: wres.id, warnings };
+          // Capture coverage — parity with `kb write --session`.
+          const { noteCoverage } = await import('../kb/session-worklist.js');
+          const coverage = noteCoverage(
+            params['session'] ? String(params['session']) : undefined,
+            spec,
+          );
+          result = { status: 'written', op: wres.op, id: wres.id, warnings, ...(coverage ? { coverage } : {}) };
         }
         break;
       }

--- a/tests/kb-fold.test.ts
+++ b/tests/kb-fold.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fold, stableStringify } from '../src/kb/fold.js';
+import { ALIAS_MAX, capAliases, fold, stableStringify } from '../src/kb/fold.js';
 import type { RawRecord } from '../src/kb/types.js';
 
 // Shorthand: a valid put record with overrides.
@@ -217,5 +217,35 @@ describe('kb fold — tolerant reader', () => {
   it('file note with no title falls back to its anchor path', () => {
     const note = fold('f1', [put({ id: 'f1', type: 'file', anchors: [{ path: 'src/x.ts' }], summary: 's' })]).note!;
     expect(note.title).toBe('src/x.ts');
+  });
+
+  // The union is what makes alias bloat a FOLD problem, not a writing problem:
+  // every individual write here obeys the 6-10 guidance and the note still ends
+  // up at 30. Capping anywhere else cannot work.
+  it('caps the alias union newest-first — compliant writes still accumulate', () => {
+    const writes = Array.from({ length: 5 }, (_, w) =>
+      put({ aliases: Array.from({ length: 6 }, (_, i) => `w${w}alias${i}`) }));
+    const uncapped = writes.flatMap((r) => (r as { aliases: string[] }).aliases);
+    expect(uncapped).toHaveLength(30);
+
+    const note = fold('n1', writes).note!;
+    expect(note.aliases.length).toBeLessThanOrEqual(ALIAS_MAX);
+    // Newest survive, oldest are dropped — the most recent writer saw the file
+    // in its current shape.
+    expect(note.aliases).toContain('w4alias5');
+    expect(note.aliases).not.toContain('w0alias0');
+    // Nothing is lost: the log is untouched, so a wider cap restores them.
+    expect(capAliases(uncapped)).toEqual(note.aliases);
+  });
+
+  it('the word budget binds before the count cap, but never below the floor', () => {
+    const wordy = Array.from({ length: 12 }, (_, i) => `long winded alias number ${i}`); // 5 words each
+    const kept = capAliases(wordy);
+    expect(kept.length).toBeLessThan(ALIAS_MAX);
+    expect(kept.join(' ').split(/\s+/)).toHaveLength(kept.length * 5);
+
+    // A single alias longer than the whole budget must not trim to nothing.
+    const huge = Array.from({ length: 5 }, (_, i) => `${'word '.repeat(30)}${i}`.trim());
+    expect(capAliases(huge).length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/tests/kb-retrieval-live.test.ts
+++ b/tests/kb-retrieval-live.test.ts
@@ -502,10 +502,20 @@ describe('matcher repairs', () => {
     expect(all.hits).toHaveLength(0);
   });
 
-  it('convergence bypasses the suppression gate', async () => {
-    // A common word (df above rareMax, so not "rare") that is nonetheless a
-    // declared symbol in the note's own anchor file. Two channels agree →
-    // it must inject rather than being suppressed as a graze.
+  // CONTRACT CHANGED 2026-07-31. This asserted that convergence ALONE lifts a
+  // single common word over the graze gate — the setup below deliberately
+  // pushes "status" out of the rare band with 6 body-only decoys so that
+  // convergence is the only thing left that could admit it.
+  //
+  // That is now the junk case, not the feature: `status`, `write`, `name`,
+  // `command` are declared symbols in most codebases, so an ordinary word
+  // hitting one is not evidence. In this repo's own logged corpus, 68 of 83
+  // single-carrier injections arrived this way, and hand-labelling split them
+  // perfectly on rarity — good ones rode rare terms (`descent`, `kbView`),
+  // junk rode common ones ("server returned status 403" → src/status.ts, which
+  // is this exact shape). Convergence still stands alone; it must now also be
+  // rare. Both halves are asserted below so neither can regress silently.
+  it('convergence stands alone only when the term is also rare', async () => {
     seedCorpus(35);
     touch('src/status.ts');
     appendRecord(root, {
@@ -534,14 +544,30 @@ describe('matcher repairs', () => {
     // Without the index there is no convergence signal → the gate suppresses.
     expect((await kbSearch(root, q, opts)).hits).toHaveLength(0);
 
-    // With the index, "status" is a declared symbol token in the note's own
-    // anchor file → convergence → the same query injects.
+    // WITH the index, "status" does converge — but it is common (df above
+    // rareMax, by construction above), so convergence no longer carries it
+    // alone. This is the "server returned status 403" injection, suppressed.
     const withIdx = await kbSearch(root, q, {
       ...opts, notesIndex: symbolIndex({ 'src/status.ts': ['renderStatus'] }),
     });
-    expect(withIdx.hits.length).toBeGreaterThan(0);
-    expect(withIdx.hits[0].note.id).toBe('status-note');
-    expect(withIdx.hits[0].convergence).toBe(true);
+    expect(withIdx.hits).toHaveLength(0);
+
+    // The other half of the contract: a RARE term that converges still stands
+    // alone on one carrier, which is what keeps "export function kbView" and
+    // "if we kept descent at 2" working.
+    touch('src/reconcile.ts');
+    appendRecord(root, {
+      id: 'descent-note', type: 'file', op: 'put',
+      title: 'descent detector',
+      summary: 'Fires capture on a quiet stop.',
+      anchors: [{ path: 'src/reconcile.ts', symbols: ['detectDescent'] }],
+    } as never);
+    const rareHit = await kbSearch(root, 'can you check descent', {
+      ...opts, notesIndex: symbolIndex({ 'src/reconcile.ts': ['detectDescent'] }),
+    });
+    expect(rareHit.hits.length).toBeGreaterThan(0);
+    expect(rareHit.hits[0].note.id).toBe('descent-note');
+    expect(rareHit.hits[0].convergence).toBe(true);
   });
 
   it('convergence lookup: English words match whole tokens, not fragments', async () => {

--- a/tests/kb-session-coverage.test.ts
+++ b/tests/kb-session-coverage.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Capture coverage: `kb write --session` reports how much of the session's
+ * worklist has a note. The manifest is written by hooks/capture-payload.mjs —
+ * these tests write it in the same shape (the contract twin) and assert the
+ * reader's arithmetic, its silence when there is nothing to compare against,
+ * and that a flow does NOT count as a note for its step files.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { noteCoverage, specPaths } from '../src/kb/session-worklist.js';
+
+const sids: string[] = [];
+function manifest(files: { path: string; tier: string; needsNote: boolean }[], ts = Date.now()): string {
+  const sid = `test-cov-${Math.random().toString(36).slice(2)}`;
+  sids.push(sid);
+  writeFileSync(join(tmpdir(), `coldstart-kb-worklist-${sid}.json`), JSON.stringify({ ts, files, wrote: [] }));
+  return sid;
+}
+afterEach(() => {
+  for (const sid of sids.splice(0)) {
+    rmSync(join(tmpdir(), `coldstart-kb-worklist-${sid}.json`), { force: true });
+  }
+});
+
+const fileSpec = (path: string) => ({ type: 'file-single', path, summary: 's' });
+
+describe('capture coverage', () => {
+  it('counts writes against the outstanding worklist and names what is left', () => {
+    const sid = manifest([
+      { path: 'src/a.ts', tier: 'edited ×2', needsNote: true },
+      { path: 'src/b.ts', tier: 'edited', needsNote: true },
+      { path: 'src/c.ts', tier: 'read', needsNote: true },
+    ]);
+    const first = noteCoverage(sid, fileSpec('src/a.ts'));
+    expect(first).toContain('1 of 3 worklist files noted');
+    expect(first).toContain('src/b.ts [edited]');
+    // Low coverage → the skips must be justified, not silently dropped.
+    expect(first).toContain('say which and why');
+
+    // State carries across writes in the same session (the chained-&& case).
+    const second = noteCoverage(sid, fileSpec('src/b.ts'));
+    expect(second).toContain('2 of 3 worklist files noted');
+    expect(second).not.toContain('say which and why'); // past the low bar
+    expect(second).not.toContain('src/b.ts');
+  });
+
+  it('excludes already-fresh files from the denominator but reports them', () => {
+    const sid = manifest([
+      { path: 'src/a.ts', tier: 'edited', needsNote: true },
+      { path: 'src/fresh.ts', tier: 'read', needsNote: false },
+    ]);
+    const line = noteCoverage(sid, fileSpec('src/a.ts'));
+    expect(line).toContain('1 of 1 worklist files noted');
+    expect(line).toContain('1 more already had a fresh note');
+  });
+
+  it('is silent without a session, without a manifest, and on a stale one', () => {
+    expect(noteCoverage(undefined, fileSpec('src/a.ts'))).toBeNull();
+    expect(noteCoverage('never-armed-session', fileSpec('src/a.ts'))).toBeNull();
+    const old = manifest([{ path: 'src/a.ts', tier: 'edited', needsNote: true }], Date.now() - 48 * 3600 * 1000);
+    expect(noteCoverage(old, fileSpec('src/a.ts'))).toBeNull();
+  });
+
+  it('credits only file notes — a flow does not note its step files', () => {
+    expect(specPaths(fileSpec('src/a.ts'))).toEqual(['src/a.ts']);
+    expect(specPaths({ type: 'file-hub', path: 'src/b.ts', facets: [] })).toEqual(['src/b.ts']);
+    expect(specPaths({ type: 'flow', title: 't', steps: [{ path: 'src/a.ts' }] })).toEqual([]);
+    expect(specPaths({ type: 'lesson', title: 't' })).toEqual([]);
+
+    const sid = manifest([{ path: 'src/a.ts', tier: 'edited', needsNote: true }]);
+    const line = noteCoverage(sid, { type: 'flow', title: 't', steps: [{ path: 'src/a.ts' }] });
+    expect(line).toContain('0 of 1 worklist files noted');
+  });
+});

--- a/tests/kb-write-guide-steps.test.ts
+++ b/tests/kb-write-guide-steps.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { flowStepsWarning } from '../src/kb/write-guide.js';
+import type { WriteSpec } from '../src/kb/write.js';
+
+// A flow's anchors are derived from its steps, so a stepless flow folds to a
+// note with zero anchors and still reports `put → <id>` like any success —
+// silently unreachable by kb lookup and by the anchor channel. Reported from a
+// real notebook where it had recurred across sessions, because the file-note
+// shape (title + summary) is what gets reused from memory.
+describe('stepless-flow warning', () => {
+  const w = (s: unknown) => flowStepsWarning(s as WriteSpec);
+
+  it('warns on a flow with no steps, and on an empty steps array', () => {
+    expect(w({ type: 'flow', title: 'how x happens', summary: 's' })).toMatch(/no "steps"/);
+    expect(w({ type: 'flow', title: 'how x happens', steps: [] })).toMatch(/no "steps"/);
+  });
+
+  it('stays silent once the flow carries steps', () => {
+    expect(w({ type: 'flow', title: 'how x happens', steps: [{ path: 'src/a.ts', role: 'entry' }] })).toBeNull();
+  });
+
+  it('never fires on non-flows or on a retract', () => {
+    expect(w({ type: 'file', path: 'src/a.ts', summary: 's' })).toBeNull();
+    expect(w({ type: 'lesson', kind: 'absence', title: 'no retries', body: 'b' })).toBeNull();
+    expect(w({ type: 'flow', op: 'retract', id: 'f1' })).toBeNull();
+  });
+});


### PR DESCRIPTION
Six commits, all notebook-side. The branch outgrew its original title (the alias cap) — merging as one squash by owner decision rather than splitting.

### Capture: the agent can now see it under-captured
A real session surfaced 30+ worked files and produced 8 notes, and nothing downstream could say so — `kb write` sees one spec at a time and never saw the worklist.

- `buildCapturePayload` (the one point Claude/Cursor/Codex all pass through) drops the worklist in tmpdir keyed by session id.
- `kb write --session` prints `N of M worklist files noted`, lists what is still unwritten, and asks for a reason below 50%. MCP `kb_write` returns the same as a `coverage` field.
- Files whose note is already fresh are excluded from the denominator, so full coverage stays reachable. A flow does not count as a note for its step files.
- `kb flow-decision` folds into `kb write --decision`, so capture costs one call instead of two; the standalone command survives for the wrote-nothing case.
- A flow spec with no `steps` folded to a note with ZERO anchors and still printed `put → <id>`. It now warns (never rejects), on CLI and MCP.

### Recall: two admission gates in hook mode
- **Convergence must also be rare.** It was setting `hardEvidence`, which bypasses `HOOK_MIN_CARRIERS` entirely, so one ordinary word matching any declared symbol (`status`, `write`, `run`) admitted a note alone — 68 of this repo's 83 single-carrier hits.
- **Name-only hits need density.** Two query terms inside ONE authored string (title or a single alias), applied only to anchored notes — a lesson note has none by construction and would otherwise be permanently unfireable.

Measured on 279 logged prompts in real hook mode: the density gate drops 38 hits, ~34 junk by hand-label. An escape hatch for terms touching 3+ different alias groups was tested and rejected — it re-admits 8, 7 of them junk. Alias breadth measures the note's vocabulary volume, not the match.

Primary evidence for both gates is a labelled production notebook (precision 0.60 → 0.71), not this repo's.

### Alias cap
The fold unioned aliases forever: nine individually-compliant writes folded to 57 aliases on one note. Capped newest-first at 12 aliases / 40 words with a floor of 4.

### Release
2.2.11 across package.json, package-lock.json and server.json — including `packages[0].version`, which had drifted to 2.2.8 while the server version was 2.2.10.

641 tests green locally.