### PR TITLE
chore(release): 2.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.12] - 2026-08-02
+
+### Added
+- **`kb repair-aliases`: a separate, paginated worklist for reconciling `identityAliases`.** A
+  note's `identityAliases` are meant to stay true forever, but a note rewritten several times can
+  carry words that were really symptom vocabulary for an earlier write — a different problem from
+  `kb repair`'s `missing-identity-aliases` check, which only catches notes with *no* aliases at
+  all. The new command surfaces every active file/flow note's current (capped) aliases alongside
+  what's hidden past the render cap, 10 notes at a time, so an agent can retract a stale alias
+  without blindly resurfacing an older one the cap was hiding. It changes nothing itself —
+  reconciling is always an agent judgment call through the ordinary `kb write` path. Wired as the
+  `kb repair-aliases` CLI verb, the `kb_repair_aliases` MCP tool, and `/repair-aliases` on Claude
+  Code, Cursor, and Codex, through the same command table `/capture-notes` and `/repair-notes`
+  already use. (`src/kb/alias-repair.ts`, #121)
+- **Anchor symbols now backfill automatically as notes are written.** Single-purpose file notes
+  missing `anchors[].symbols` get them filled in mechanically from the code index, capped at 15 and
+  never overriding a symbol an agent already curated. This already ran from `kb repair` and
+  `coldstart init`; it's now also fired by the keeper itself after every notebook write, so a fresh
+  note gets its symbols within one debounce cycle with no manual repair step. A streak counter caps
+  it at 3 consecutive auto-fixing passes as a loop guard. (`src/kb/repair.ts`, `src/index-manager.ts`, #121)
+
+### Changed
+- **A note's `aliases` field is now two fields: `identityAliases` and `incidentAliases`.**
+  `identityAliases` keep the old union-forever, capped-at-12 behavior — the file/flow's stable
+  name and role. `incidentAliases` are new: symptom words tied to *this* write's summary,
+  **replaced wholesale** (not unioned) the next time the summary changes, so bug-hunt vocabulary
+  from an old, fixed issue doesn't pile up forever. Retracting an alias works the same for either
+  field. (`src/kb/fold.ts`, `src/kb/types.ts`, `hooks/note-shape.mjs`, #121)
+
+### Fixed
+- **Notes written before the alias split would have silently lost alias search on upgrade.** Older
+  `.raw` logs use the flat `aliases` key the fold no longer read once the split landed — a real,
+  live-data regression caught before shipping (49 of this repo's own notes used the old shape). A
+  backward-compat fold rule now folds a bare `aliases` into `identityAliases`, matching its old
+  union-forever behavior, so every existing notebook stays searchable across the upgrade with no
+  migration step. (`src/kb/fold.ts`, #121)
+
 ## [2.2.8] - 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ coldstart kb write spec.json              # the write gate (two-phase dedup)
 coldstart kb commit                       # publish notes to git, nothing else rides along
 coldstart kb view                         # open a single-file HTML browser of the notebook
 coldstart kb repair                       # worklist of notes that are written but unfindable
+coldstart kb repair-aliases                # worklist of aliases that may no longer be true
 coldstart kb status / lint / render / init / migrate
 ```
 
@@ -109,7 +110,7 @@ coldstart kb status / lint / render / init / migrate
 - **Concurrent sessions are safe.** Multiple agents can write at once: per-note append-only logs, exclusive creation for new note ids (a same-moment duplicate becomes two visible notes, never a silent merge), lossless merging for shared file notes, and atomic renders (a reader never sees a half-written note).
 - **Corrections happen in-session.** If an agent finds a note wrong while the evidence is in its context, the guidance tells it to fix or retract the note right then — no better-placed future agent exists.
 
-**Setup:** the notebook comes with `coldstart init` — no separate step. It creates the notebook skeleton, sets union-merge for the logs, and (on Claude Code, Codex and Cursor) wires the two hooks — capture at session end, recall at prompt time. (`coldstart kb init` still exists as an alias if you want to (re-)wire just the notebook.) Other hosts can drive the notebook without the hooks: via the full `kb` CLI, or — for no-shell clients — the `kb_search` / `kb_lookup` / `kb_write` / `kb_status` / `kb_repair` MCP tools.
+**Setup:** the notebook comes with `coldstart init` — no separate step. It creates the notebook skeleton, sets union-merge for the logs, and (on Claude Code, Codex and Cursor) wires the two hooks — capture at session end, recall at prompt time. (`coldstart kb init` still exists as an alias if you want to (re-)wire just the notebook.) Other hosts can drive the notebook without the hooks: via the full `kb` CLI, or — for no-shell clients — the `kb_search` / `kb_lookup` / `kb_write` / `kb_status` / `kb_repair` / `kb_repair_aliases` MCP tools.
 
 **Language-agnostic.** The notebook's freshness machinery is content-hash based, so it works on any codebase — including languages the navigation index doesn't parse. Where the index does parse, notes additionally get symbol-level freshness.
 
@@ -172,7 +173,7 @@ coldstart find auth; coldstart find 'session cookie'; coldstart gs src/auth/serv
 coldstart ships as one binary with two front doors:
 
 - **CLI (primary)** — `coldstart find …` / `coldstart gs …` / `coldstart kb …`. For any shell-capable agent (Claude Code, Cursor, terminal use). This is the fast path.
-- **MCP (for no-shell clients)** — the `find` and `gs` tools, plus the notebook as `kb_search` / `kb_lookup` / `kb_write` / `kb_status` / `kb_repair`, all byte-identical to the CLI. For clients like Claude Desktop that have no shell. (`kb commit` stays CLI/human-only — publishing notes to git is never an agent action.)
+- **MCP (for no-shell clients)** — the `find` and `gs` tools, plus the notebook as `kb_search` / `kb_lookup` / `kb_write` / `kb_status` / `kb_repair` / `kb_repair_aliases`, all byte-identical to the CLI. For clients like Claude Desktop that have no shell. (`kb commit` stays CLI/human-only — publishing notes to git is never an agent action.)
 
 Same engine, same index, same results. Pick whichever your agent can reach.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cstart/coldstart",
-      "version": "2.2.11",
+      "version": "2.2.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstart/coldstart",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "mcpName": "io.github.AkashGoenka/coldstart",
   "publishConfig": {
     "access": "public"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AkashGoenka/coldstart",
     "source": "github"
   },
-  "version": "2.2.11",
+  "version": "2.2.12",
   "websiteUrl": "https://akashgoenka.github.io/coldstart/",
   "icons": [
     {
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cstart/coldstart",
-      "version": "2.2.11",
+      "version": "2.2.12",
       "transport": {
         "type": "stdio"
       }
@@ -33,12 +33,12 @@
         "install": "npm i -g @cstart/coldstart",
         "thenRun": "coldstart init",
         "runIn": "the repository root, once",
-        "why": "The MCP server exposes all six tools without it. `init` additionally wires the hooks that capture notes automatically when a task ends and surface matching notes when a prompt arrives — without it the notebook stays empty unless the agent calls kb_write itself.",
+        "why": "The MCP server exposes all eight tools without it. `init` additionally wires the hooks that capture notes automatically when a task ends and surface matching notes when a prompt arrives — without it the notebook stays empty unless the agent calls kb_write itself.",
         "docs": "https://akashgoenka.github.io/coldstart/docs.html"
       },
       "interfaces": ["cli", "mcp"],
       "primaryInterface": "cli",
-      "tools": ["find", "gs", "kb_search", "kb_lookup", "kb_write", "kb_status", "kb_repair"],
+      "tools": ["find", "gs", "kb_search", "kb_lookup", "kb_write", "kb_status", "kb_repair", "kb_repair_aliases"],
       "requiresApiKey": false,
       "requiresNetwork": false
     }

--- a/site/docs.html
+++ b/site/docs.html
@@ -331,12 +331,13 @@
 
     <section id="kb-maint" class="doc-sec">
       <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb status / lint / repair / render</span> <span class="badge">notebook</span></div>
+        <div class="name warm"><span class="c">coldstart kb status / lint / repair / repair-aliases / render</span> <span class="badge">notebook</span></div>
       </div>
       <div class="flags">
         <div class="flag-row"><span class="fk">kb status</span><span class="fv">Notebook health: note counts and per-note freshness at a glance.</span></div>
         <div class="flag-row"><span class="fk">kb lint</span><span class="fv">Check the notebook for structural problems (broken anchors, malformed notes).</span></div>
         <div class="flag-row"><span class="fk">kb repair</span><span class="fv">List the notes that are written but <em>unfindable</em> — missing the fields a note can't be retrieved without (search aliases, anchor symbols, a flow's verified paths). Notes written before those fields were required are correct but unreachable. It prints a worklist and changes nothing: your agent opens each note and the code it names and completes it with an ordinary <code>kb write</code>, because every gap needs a judgement about the code. Nothing to fix → <code>Nothing to repair here.</code> Also available as <code>/repair-notes</code>.</span></div>
+        <div class="flag-row"><span class="fk">kb repair-aliases</span><span class="fv">A different worklist: notes whose <code>identityAliases</code> exist but may no longer describe the file/flow (stale or really symptom words from an earlier write) — not notes missing aliases entirely, that's <code>kb repair</code> above. Shows each note's current aliases alongside what's hidden past the render cap, 10 notes per page, and changes nothing itself. Also available as <code>/repair-aliases</code>.</span></div>
         <div class="flag-row"><span class="fk">kb render</span><span class="fv">Regenerate the derived Markdown notes from the <code>.raw</code> logs.</span></div>
         <div class="flag-row"><span class="fk">kb init</span><span class="fv">Notebook-only setup — skeleton + hooks. Redundant if you ran <code>coldstart init</code>, which already does this.</span></div>
         <div class="flag-row"><span class="fk">kb migrate</span><span class="fv">Upgrade an older notebook's on-disk format.</span></div>
@@ -405,7 +406,7 @@
       <div class="flags">
         <div class="flag-row"><span class="fk">find · gs</span><span class="fv">The two navigation operations.</span></div>
         <div class="flag-row"><span class="fk">kb_search · kb_lookup</span><span class="fv">Read the notebook.</span></div>
-        <div class="flag-row"><span class="fk">kb_write · kb_status · kb_repair</span><span class="fv">Write to and inspect the notebook — the MCP server is a writer for <code>kb_write</code>. <code>kb_repair</code> lists notes that are written but unfindable.</span></div>
+        <div class="flag-row"><span class="fk">kb_write · kb_status · kb_repair · kb_repair_aliases</span><span class="fv">Write to and inspect the notebook — the MCP server is a writer for <code>kb_write</code>. <code>kb_repair</code> lists notes that are written but unfindable; <code>kb_repair_aliases</code> lists notes whose aliases exist but may no longer be true.</span></div>
       </div>
       <div class="callout"><span class="ct">Not exposed</span><code>kb commit</code> and <code>kb view</code> stay CLI/human-only — publishing to git and opening a browser are never agent actions.</div>
     </section>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,7 +8,7 @@ coldstart ships as an npm package (`@cstart/coldstart`) providing the `coldstart
 
 - `coldstart find <terms>` — ranks files by how many query terms each covers (filenames, path segments, exported symbols, plus a repo-wide reference scan), showing the evidence for each ranking.
 - `coldstart gs <file>` — one file's symbols (with line ranges), its imports, who imports it, and per-symbol cross-file callers, in one call.
-- `coldstart kb search|lookup|write|commit|view|status|lint|repair|render` — the notebook: durable, agent-written notes anchored to real files and content-hash freshness-checked. `kb repair` lists notes that are written but unfindable (missing the fields a note cannot be retrieved without) and writes nothing itself — completing them is agent work through `kb write`. `kb commit` and `kb view` are human-only, never MCP tools.
+- `coldstart kb search|lookup|write|commit|view|status|lint|repair|repair-aliases|render` — the notebook: durable, agent-written notes anchored to real files and content-hash freshness-checked. `kb repair` lists notes that are written but unfindable (missing the fields a note cannot be retrieved without) and writes nothing itself — completing them is agent work through `kb write`. `kb repair-aliases` is the same idea for aliases that exist but may no longer be true, paginated. `kb commit` and `kb view` are human-only, never MCP tools.
 - `coldstart init` — one-time setup: writes `coldstart.md`, wires the CLI/MCP client (Claude Code, Codex, Cursor, or other), creates the notebook, and registers navigation + notebook hooks.
 - `coldstart unwire` — the reverse of `init`: strips coldstart's per-repo wiring (never user content in shared files), keeping the notebook by default (`--purge` deletes it too).
 


### PR DESCRIPTION
## Summary
- Version bump for #121 (identity/incident alias split, mechanical symbol backfill + keeper auto-trigger, `kb repair-aliases`).
- CHANGELOG entry covering all three pieces of #121 — Added/Changed/Fixed sections, matching the pre-2.2.9 format (that habit had lapsed for a few releases; not backfilling the gap here, just not extending it).
- README + site/docs.html + site/llms.txt now list `kb repair-aliases` / `kb_repair_aliases` everywhere `kb repair` / `kb_repair` was already listed.
- `server.json`: bumped `version` + `packages[0].version` to 2.2.12 (both had drifted out of sync before, see 10dc9ef), added `kb_repair_aliases` to the tools array, fixed the `why` field's stale "six tools" claim (actually eight now).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 712/712 passing (re-run on `main` post-merge of #121)
- [x] After merge: tag + `gh release create` to trigger `npm-publish.yml`, then verify the published tarball's version matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)