### PR TITLE
fix(kb): repair-aliases stops resurfacing reviewed notes, without breaking pagination

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -688,10 +688,11 @@ export const USER_COMMANDS: Record<'capture' | 'repair' | 'repairAliases', UserC
     // its own instructions and pagination pointer, so CLI/MCP/all three hosts
     // say the same thing.
     instructions:
-      'It prints a PAGINATED worklist (10 notes at a time) and changes nothing. Follow the '
-      + 'instructions it prints for each note, then if it says more notes remain, re-run the same '
-      + 'command with the `--offset` it gives you and continue until none remain. If it prints "No '
-      + 'file/flow notes to reconcile.", stop.',
+      'It prints a PAGINATED worklist (10 notes at a time) — each note you review must end with a '
+      + '`kb write` carrying `aliasesVerified:true` on it, even when you kept every alias unchanged, '
+      + 'or it reappears next run. Once a batch is marked, re-run the exact same command again (no '
+      + '`--offset`) — reviewed notes drop out on their own, so it keeps surfacing whatever is still '
+      + 'outstanding. Stop when it prints "No file/flow notes to reconcile."',
   },
 };
 

--- a/src/kb/alias-repair.ts
+++ b/src/kb/alias-repair.ts
@@ -19,6 +19,22 @@
  *
  * Paginated (default 10/page): a full-notebook pass over every file/flow note
  * would otherwise dump the whole notebook's alias history in one response.
+ *
+ * STOPS RESURFACING A NOTE ONCE IT'S BEEN REVIEWED: a note stays eligible
+ * until a `kb write` on it carries `aliasesVerified:true` (fold.ts stamps
+ * `aliasesVerifiedAtEdit = edits` at that record); it drops out of `eligible`
+ * below as soon as nothing has changed since. This is why pagination here is
+ * NOT "increment --offset by limit each call" the way a stable list would be:
+ * `eligible` shrinks out from under a fixed offset as notes get marked
+ * verified, so re-running with the previous `nextOffset` would silently skip
+ * whatever just shifted into that position. The sanctioned resume is: mark
+ * this batch's notes verified, then re-run with the SAME (default 0) offset —
+ * verified notes are simply gone from `eligible`, so a fresh slice from the
+ * top is always "whatever's still outstanding," no position-tracking needed.
+ * `offset`/`nextOffset` still work exactly as documented for anyone who wants
+ * to browse without marking anything (they just won't self-advance safely
+ * across a marking pass), so the parameter stays, but `aliasRepairWorklist`'s
+ * own prose never recommends incrementing it.
  */
 import { relative } from 'node:path';
 import type { NoteType } from './types.js';
@@ -66,6 +82,11 @@ export function planAliasRepair(root: string, offset = 0, limit = 10): AliasRepa
   const { notes } = loadAll(root);
   const eligible = notes
     .filter((n) => n.status === 'active' && (n.type === 'file' || n.type === 'flow'))
+    // Already reconciled and untouched since: drop it. `aliasesVerifiedAtEdit`
+    // is only ever set by an explicit `aliasesVerified:true` write (never
+    // implied by an ordinary put), so this can't hide a note whose aliases
+    // genuinely changed without anyone confirming them.
+    .filter((n) => n.aliasesVerifiedAtEdit === undefined || n.aliasesVerifiedAtEdit < n.edits)
     .sort((a, b) => a.id.localeCompare(b.id));
 
   const page = eligible.slice(Math.max(0, offset), Math.max(0, offset) + Math.max(1, limit));
@@ -101,12 +122,15 @@ export function aliasRepairWorklist(page: AliasRepairPage): string {
 
   const shown = page.entries.length ? `${page.offset + 1}-${page.offset + page.entries.length}` : '0';
   const parts: string[] = [
-    `kb repair-aliases — reconciling identityAliases, notes ${shown} of ${page.total}.`,
+    `kb repair-aliases — reconciling identityAliases, notes ${shown} of ${page.total} still outstanding.`,
     '',
     'For each note below: re-read the code at its files, then judge which identityAliases are still '
     + 'true (keep), which are now stale or symptom-shaped for an earlier write (retract), and whether '
     + 'a "hidden past cap" alias should come back into view. Chain the retracts + one re-put in a single '
-    + '`kb write` block with `&&` per note — this is a bulk pass, batch it rather than one call per alias.',
+    + '`kb write` block with `&&` per note — this is a bulk pass, batch it rather than one call per alias. '
+    + 'End that same chain with `{"id":"<note id>","aliasesVerified":true}` even when you kept every alias '
+    + 'as-is — that is what marks the note reviewed so it stops appearing here; without it, this exact note '
+    + 'reappears on your next run even though nothing was wrong with it.',
     '',
     'Never retract an alias without reading the current code first. incidentAliases are shown for '
     + 'context only — this pass does not touch them; they are replaced automatically the next time the '
@@ -126,8 +150,11 @@ export function aliasRepairWorklist(page: AliasRepairPage): string {
   if (page.more) {
     parts.push(
       '',
-      `${page.more.remaining} more note${page.more.remaining === 1 ? '' : 's'} not shown — re-run with `
-      + `--offset ${page.more.nextOffset} for the next batch.`,
+      `${page.more.remaining} more note${page.more.remaining === 1 ? '' : 's'} not shown. Mark this batch's `
+      + 'notes aliasesVerified:true first, then just re-run `kb repair-aliases` again with NO --offset — '
+      + 'verified notes drop out on their own, so the same command always surfaces whatever is still '
+      + 'outstanding next. (Advancing --offset yourself is unsafe once you start marking notes: the list '
+      + 'shrinks as you go, so a fixed offset silently skips whatever shifted into that position.)',
     );
   }
   return parts.join('\n');

--- a/src/kb/fold.ts
+++ b/src/kb/fold.ts
@@ -50,6 +50,10 @@ const PUT_KEYS = new Set([
   // it lands in identityAliases, not in `extra` (which would double-render it).
   'title', 'aliases', 'identityAliases', 'incidentAliases', 'anchors', 'verified', 'summary', 'character', 'facets',
   'behaviors', 'features', 'steps', 'invariants', 'kind', 'body', 'scope',
+  // 'aliasesVerified' is a transient signal, not stored content — handled in
+  // the main fold loop (needs the post-increment edit count), recognized here
+  // only so it isn't dumped into `extra`.
+  'aliasesVerified',
 ]);
 const OP_KEYS = new Set(['target', 'by']);
 const NOTE_TYPES = new Set<string>(['file', 'flow', 'lesson']);
@@ -138,6 +142,12 @@ export function fold(id: string, rawRecords: unknown[], opts: FoldOptions = {}):
       note.supersededBy = rec.by;
     }
     note.edits++;
+    // Stamped AFTER the increment, so it reads as "verified as of this edit" —
+    // an agent explicitly confirmed identityAliases against the current code
+    // in THIS record, whether or not it changed anything. Only a put can set
+    // it; any later record (put, retract, or supersede) pushes edits past it
+    // again with no extra bookkeeping, which is what makes the note reappear.
+    if (op === 'put' && rec.aliasesVerified === true) note.aliasesVerifiedAtEdit = note.edits;
     if (ts > note.updated) note.updated = ts;
   }
 

--- a/src/kb/render.ts
+++ b/src/kb/render.ts
@@ -39,6 +39,7 @@ export function renderNote(note: FoldedNote): string {
   if (note.supersededBy) fm.push(`superseded_by: ${note.supersededBy}`);
   fm.push(`updated: ${note.updated}`);
   fm.push(`edits: ${note.edits}`);
+  if (note.aliasesVerifiedAtEdit !== undefined) fm.push(`aliasesVerifiedAtEdit: ${note.aliasesVerifiedAtEdit}`);
   // Tolerant reader: unknown record fields survive into the frontmatter.
   for (const [k, v] of Object.entries(note.extra)) {
     if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) fm.push(`${k}: ${JSON.stringify(v)}`);

--- a/src/kb/types.ts
+++ b/src/kb/types.ts
@@ -141,6 +141,12 @@ export interface FoldedNote {
   supersededBy?: string;
   updated: string; // max ts folded
   edits: number; // count of applied records
+  /** `edits` at the moment a `kb write` last carried `aliasesVerified:true` —
+   *  i.e. an agent explicitly confirmed identityAliases against the current
+   *  code (whether or not it changed any). `edits > aliasesVerifiedAtEdit`
+   *  means something has landed since — `kb repair-aliases` uses this to stop
+   *  resurfacing a note nothing has touched since it was last reconciled. */
+  aliasesVerifiedAtEdit?: number;
 
   summary?: string;
   character?: FileCharacter;

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -175,12 +175,12 @@ export const TOOL_DEFINITIONS = [
     name: 'kb_repair_aliases',
     description:
       'List file/flow notes whose identityAliases may no longer describe them — a DIFFERENT problem from kb_repair: that one finds notes with NO aliases at all, this one is for aliases that exist but have gone stale (a note rewritten several times can carry words that were really symptoms of an earlier write, not stable facts). Paginated 10 notes at a time.\n\n' +
-      'Each entry shows the current (capped) identityAliases AND the full historical union hidden past the render cap — read both before retracting anything, because dropping a visible alias can resurface an older hidden one on the next fold. Re-read the note\'s code, then reconcile via kb_write (retract stale entries, re-put the rest) — never mechanically, every judgement needs the current code.\n\n' +
-      'Returns "No file/flow notes to reconcile." when done. If the response includes `more`, call again with `offset` set to `more.nextOffset` for the next batch.',
+      'Each entry shows the current (capped) identityAliases AND the full historical union hidden past the render cap — read both before retracting anything, because dropping a visible alias can resurface an older hidden one on the next fold. Re-read the note\'s code, then reconcile via kb_write (retract stale entries, re-put the rest) — never mechanically, every judgement needs the current code. End every note\'s kb_write with `aliasesVerified:true` on it, even when nothing changed — that is what stops it reappearing; without it the same note resurfaces on your next call.\n\n' +
+      'Returns "No file/flow notes to reconcile." when done. Once a batch is marked aliasesVerified, call again with NO offset (or offset 0) — verified notes drop out of the list on their own. Do not increment offset yourself across a reconciling pass: the list shrinks as notes get marked, so a fixed offset (including a stale `more.nextOffset`) silently skips whatever shifted into that position. `offset`/`more.nextOffset` still work for browsing the list WITHOUT marking anything — just not as a way to advance while reconciling.',
     inputSchema: {
       type: 'object',
       properties: {
-        offset: { type: 'number', description: 'Pagination offset (0-based). Use `more.nextOffset` from the previous response to continue.' },
+        offset: { type: 'number', description: 'Pagination offset (0-based). For browsing only — do NOT increment this across calls once you start marking notes aliasesVerified, since the eligible list shrinks as you go. Leave at 0 (or omit) and just call again; reviewed notes fall out automatically.' },
         limit: { type: 'number', description: 'Notes per page. Defaults to 10.' },
       },
     },

--- a/tests/kb-alias-repair.test.ts
+++ b/tests/kb-alias-repair.test.ts
@@ -130,12 +130,51 @@ describe('aliasRepairWorklist', () => {
     expect(text).toContain('kb write');
   });
 
-  it('tells the agent how to fetch the next batch when truncated', async () => {
+  it('tells the agent to mark the batch verified and re-run with no offset, when truncated', async () => {
     for (let i = 0; i < 11; i++) {
       await kbWrite(root, { type: 'file-single', path: `src/f${i}.ts`, summary: 's', identityAliases: ['a'] } as never, { force: true });
     }
     const text = aliasRepairWorklist(planAliasRepair(root, 0, 10));
-    expect(text).toContain('--offset 10');
+    expect(text).toContain('aliasesVerified:true');
+    expect(text).toContain('NO --offset');
     expect(text).toContain('1 more note');
+  });
+
+  it('a note marked aliasesVerified with nothing else changed does not resurface', async () => {
+    await kbWrite(root, { type: 'file-single', path: 'src/a.ts', summary: 's', identityAliases: ['a'] } as never, { force: true });
+    const id = planAliasRepair(root).entries[0].note;
+    expect(planAliasRepair(root).total).toBe(1);
+    await kbWrite(root, { id, type: 'file', path: 'src/a.ts', aliasesVerified: true } as never, { force: true });
+    expect(planAliasRepair(root).total).toBe(0);
+    expect(aliasRepairWorklist(planAliasRepair(root))).toBe('No file/flow notes to reconcile.');
+  });
+
+  it('a later unrelated write to identityAliases makes a verified note reappear', async () => {
+    await kbWrite(root, { type: 'file-single', path: 'src/a.ts', summary: 's', identityAliases: ['a'] } as never, { force: true });
+    const id = planAliasRepair(root).entries[0].note;
+    await kbWrite(root, { id, type: 'file', path: 'src/a.ts', aliasesVerified: true } as never, { force: true });
+    expect(planAliasRepair(root).total).toBe(0);
+    await kbWrite(root, { id, type: 'file', path: 'src/a.ts', identityAliases: ['b'] } as never, { force: true });
+    expect(planAliasRepair(root).total).toBe(1);
+  });
+
+  it('marking a batch verified does not skip notes on the next default-offset call — the pagination bug', async () => {
+    // 15 notes, page size 10: mark ALL of page 1 verified, then re-call with
+    // the SAME (default) offset — every one of the 5 that were originally at
+    // positions 10-14 must still show up, not just the ones that happen to
+    // land at the new front after the first 10 drop out.
+    for (let i = 0; i < 15; i++) {
+      await kbWrite(root, { type: 'file-single', path: `src/g${i}.ts`, summary: 's', identityAliases: ['a'] } as never, { force: true });
+    }
+    const page1 = planAliasRepair(root, 0, 10);
+    expect(page1.entries).toHaveLength(10);
+    const page1Ids = new Set(page1.entries.map((e) => e.note));
+    for (const e of page1.entries) {
+      await kbWrite(root, { id: e.note, type: 'file', path: e.paths[0], aliasesVerified: true } as never, { force: true });
+    }
+    const page2 = planAliasRepair(root, 0, 10); // no offset increment — the fix
+    expect(page2.total).toBe(5);
+    expect(page2.entries).toHaveLength(5);
+    for (const e of page2.entries) expect(page1Ids.has(e.note)).toBe(false); // none re-shown, none skipped
   });
 });


### PR DESCRIPTION
## Summary
- `kb repair-aliases` had no "done" state — a note judged still-accurate reappeared on every future run forever, since that judgment left no trace (unlike `kb repair`'s mechanical checks, which naturally clear once fixed).
- Adds `aliasesVerifiedAtEdit` (folded note field, `src/kb/fold.ts`): stamped only when a `kb write` explicitly carries `aliasesVerified:true`, never implied by an ordinary edit. `planAliasRepair` excludes a note once nothing has changed since its stamp; a later unrelated write to `identityAliases` bumps `edits` past it and it reappears.
- **The naive version of this breaks pagination**: `eligible` shrinks as notes get marked reviewed, so a fixed `--offset` from a prior call silently skips whatever slides into that position next. Fixed by changing the resume contract: mark a batch verified, then re-run with **no offset** (reviewed notes are just gone from the list, so a fresh call from the top is always "what's still outstanding"). `offset`/`nextOffset` still work for read-only browsing, just aren't the resume mechanism.
- Updated three independent copies of this guidance together: the CLI worklist text (`aliasRepairWorklist`), the `kb_repair_aliases` MCP tool description, and `/repair-aliases`'s `USER_COMMANDS` instructions.
- `aliasesVerifiedAtEdit` also renders in a note's frontmatter for visibility.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 715/715 passing (3 new: verified-note doesn't resurface, unrelated edit makes it reappear, and the actual pagination regression — 15 notes/page 10, mark page 1 verified, re-call at offset 0, confirm the other 5 with no skip/overlap)
- [x] Live smoke test against this repo's real notebook (`kb repair-aliases --root .`)

## Not in this PR
- Backfilling `aliasesVerified:true` onto the 53 notes already reconciled in this repo's real notebook earlier today (they predate this field) — separate follow-up, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)