### PR TITLE
fix(site): unify nav/footer chrome width, restore logo glow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ Key files:
 - `src/keeper-state.ts` — keeper-state.json + repair.jsonl (observability beside the cache)
 - `src/kb/` — notebook: store / raw-log / fold / render / search / write / freshness / notes-index / lint / cli
 - `src/types.ts`, `src/constants.ts`
-- `site/` — the GitHub Pages marketing site (`index.html` + `docs.html`, shared `styles.css`, `llms.txt`), deployed by `.github/workflows/pages.yml` on push to `main`. **When a change is meaningful to an outside user** (a command's behavior/flags change, a new `kb` subcommand ships, the notebook's guarantees change, the npm package name changes) — update `site/docs.html` (and `site/index.html` if it affects the pitch). Routine internal refactors don't need a site update.
+- `site-astro/` — the Astro marketing site on coldstartmcp.dev (migrated off GitHub Pages in #137; the old static `site/` is retired). Home (`src/pages/index.astro`), docs (`src/pages/docs.astro`), and blog (`src/pages/blog/`, content in `src/content/blog/`) share `Nav.astro`/`Footer.astro`/`Head.astro`; `landing.css` styles the home page, `docs.css` styles docs + blog. **When a change is meaningful to an outside user** (a command's behavior/flags change, a new `kb` subcommand ships, the notebook's guarantees change, the npm package name changes) — update `site-astro/src/pages/docs.astro` (and `index.astro` if it affects the pitch). Routine internal refactors don't need a site update.
+
+**Frontend/site work tooling:** when reshaping `site-astro/` UI —
+- Load the `frontend-design` skill (Anthropic plugin, installed globally) before making aesthetic/typography/layout calls. It's built to counter templated-default choices — exactly the risk `DESIGN.md`'s own self-critique note flags in the current design.
+- Use the `chrome-devtools-cli` skill (`.claude/skills/chrome-devtools-cli/`) to drive a live browser from the shell — `chrome-devtools navigate_page`, `take_screenshot`, `take_snapshot`, `evaluate_script`, etc. — for visual verification, instead of ad hoc headless-Chrome invocations.
+- Always verify UI changes by actually rendering the page (dev server + one of the above), never by reading the CSS/markup alone.
 
 @coldstart.md

--- a/site-astro/src/components/Footer.astro
+++ b/site-astro/src/components/Footer.astro
@@ -5,9 +5,9 @@ const { variant = 'sub' } = Astro.props;
 <footer>
   <div class="foot-in">
     {variant === 'home' ? (
-      <span class="foot-brand"><span class="brand" style="font-size:14px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</span> &nbsp; navigation + memory for coding agents · MIT</span>
+      <span class="foot-brand"><span class="brand" style="font-size:14px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><circle class="core" cx="16" cy="16" r="8" fill="url(#glow)"/><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</span> &nbsp; navigation + memory for coding agents · MIT</span>
     ) : (
-      <span class="foot-brand"><a class="brand" href="/" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
+      <span class="foot-brand"><a class="brand" href="/" style="font-size:15px"><svg class="mark s2" width="17" height="17" viewBox="0 0 32 32" aria-hidden="true"><circle class="core" cx="16" cy="16" r="8" fill="url(#glow)"/><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>coldstart</a> - blog · MIT</span>
     )}
     <div class="foot-links">
       <a href="/">Home</a>

--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -6,7 +6,7 @@ const installHref = variant === 'home' ? '#install' : '/#install';
 <nav>
   <div class="nav-in">
     <a class="brand" href="/">
-      <svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>
+      <svg class="mark s2" width="28" height="28" viewBox="0 0 32 32" aria-hidden="true"><circle class="core" cx="16" cy="16" r="8" fill="url(#glow)"/><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>
       coldstart
     </a>
     <span class="nav-spacer"></span>


### PR DESCRIPTION
## Summary
- `docs.css` tied nav/footer width to a `--nav-wrap` variable that differed per page (1200px docs, 1080px blog, 1120px home via a separate stylesheet) — the chrome visibly resized between pages. Hardcoded to 1120px/28px everywhere and removed the variable.
- Restored the glow circle behind the nav/footer snowflake logo, dropped silently during the Astro migration (`#glow` gradient was defined but unused).
- Documents the new `frontend-design` and `chrome-devtools-cli` skills in `CLAUDE.md`, and fixes a stale reference to the retired static `site/` (now `site-astro/`, migrated in #137).

## Test plan
- [x] `npm run build` in `site-astro/` completes cleanly
- [x] Verified nav bar is pixel-identical across home/docs/blog-index/blog-post via headless Chrome screenshots
- [x] Verified logo glow renders on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)