### PR TITLE
site: port v4 redesign into site-astro, bring docs/blog in line

### DIFF
--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -1,19 +1,18 @@
 ---
 interface Props { variant?: 'home' | 'docs' | 'blog' }
 const { variant = 'docs' } = Astro.props;
-const tag = variant === 'docs' ? 'docs' : variant === 'blog' ? 'blog' : null;
 const installHref = variant === 'home' ? '#install' : '/#install';
 ---
 <nav>
   <div class="nav-in">
     <a class="brand" href="/">
       <svg class="mark s2" width="26" height="26" viewBox="0 0 32 32" aria-hidden="true"><use href="#flake" class="fl"/><circle class="fl" cx="16" cy="16" r="6" fill="none"/><circle class="core" cx="16" cy="16" r="3" fill="url(#core)"/></svg>
-      coldstart {tag && <span class="tag">{tag}</span>}
+      coldstart
     </a>
     <span class="nav-spacer"></span>
     <div class="nav-links">
-      <a href="/docs/">Docs</a>
-      <a href="/blog/">Blog</a>
+      <a href="/docs/" class={variant === 'docs' ? 'active' : ''}>Docs</a>
+      <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
       <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     </div>
@@ -23,8 +22,8 @@ const installHref = variant === 'home' ? '#install' : '/#install';
     </button>
   </div>
   <div class="nav-mobile" id="nav-mobile">
-    <a href="/docs/">Docs</a>
-    <a href="/blog/">Blog</a>
+    <a href="/docs/" class={variant === 'docs' ? 'active' : ''}>Docs</a>
+    <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
     <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
     <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     <a class="nav-cta" href={installHref}>Install →</a>

--- a/site-astro/src/components/SvgDefs.astro
+++ b/site-astro/src/components/SvgDefs.astro
@@ -1,4 +1,5 @@
 <svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs>
+  <filter id="rough"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="2.2"/></filter>
   <radialGradient id="core" cx="38%" cy="32%" r="75%"><stop offset="0" stop-color="#ffc884"/><stop offset="100%" stop-color="#ef9448"/></radialGradient>
   <radialGradient id="glow" cx="50%" cy="50%" r="50%"><stop offset="0" stop-color="#ef9448" stop-opacity=".5"/><stop offset="70%" stop-color="#ef9448" stop-opacity=".1"/><stop offset="100%" stop-color="#ef9448" stop-opacity="0"/></radialGradient>
   <radialGradient id="warm" gradientUnits="userSpaceOnUse" cx="16" cy="16" r="13"><stop offset="0" stop-color="#ffb267"/><stop offset="52%" stop-color="#ef9448"/><stop offset="100%" stop-color="#4fbfe0"/></radialGradient>

--- a/site-astro/src/layouts/BlogPostLayout.astro
+++ b/site-astro/src/layouts/BlogPostLayout.astro
@@ -62,6 +62,9 @@ const jsonLd = {
     twitterDescription={ogDescription}
     themeColor="#0b0e14"
   />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 </head>
 <body class="docs-page essay-page">

--- a/site-astro/src/pages/blog/index.astro
+++ b/site-astro/src/pages/blog/index.astro
@@ -38,6 +38,9 @@ const jsonLd = {
     ogDescription="Engineering notes about repeated repository orientation, codebase notes, and durable context for AI coding agents."
     themeColor="#0b0e14"
   />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 </head>
 <body class="docs-page essay-page">

--- a/site-astro/src/pages/docs.astro
+++ b/site-astro/src/pages/docs.astro
@@ -17,6 +17,9 @@ import '../styles/docs.css';
     ogDescription="Command reference for find, gs, the kb notebook family, team sharing, and how the index stays fresh."
     themeColor="#070a11"
   />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
 </head>
 <body class="docs-page">
 <SvgDefs />

--- a/site-astro/src/pages/index.astro
+++ b/site-astro/src/pages/index.astro
@@ -72,7 +72,7 @@ const faqJsonLd = {
 <html lang="en">
 <head>
   <Head
-    title="coldstart — codebase memory &amp; navigation for AI coding agents"
+    title="coldstart — persistent codebase memory for AI coding agents"
     description="coldstart gives a coding agent persistent, self-maintaining memory of your codebase — a notebook it writes itself, plus a fast static index to find the right file without wasted reads. No embeddings, no API key — it runs on the model you already pay for."
     keywords="AI coding agent, codebase navigation, code search, agent memory, persistent memory, codebase memory, session memory, notebook, Claude Code, Codex, Cursor, MCP, no embeddings, ripgrep, tree-sitter"
     canonicalPath="/"
@@ -83,7 +83,7 @@ const faqJsonLd = {
   <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
 </head>
 <body>
 
@@ -93,42 +93,25 @@ const faqJsonLd = {
 
 <!-- ===================== HERO ===================== -->
 <header class="hero">
-  <div class="wrap hero-grid">
-    <div>
-      <div class="eyebrow">Memory + navigation for coding agents</div>
-      <h1 class="title">Your agent relearns your codebase from <span class="cold">scratch</span> — every session.</h1>
-      <p class="hero-sub">coldstart gives a coding agent <b>persistent memory of your codebase</b> — a notebook it writes itself, so what one session figures out, the next already knows — plus a fast index to <b>find the right file without three wrong reads</b>. No embeddings, no API key: it runs on the model you already pay for.</p>
-      <div class="cta">
-        <a class="btn btn-primary" href="#install">Install →</a>
-        <a class="btn btn-ghost" href="/blog/">Read the blog</a>
-        <span class="hero-note">MIT · Node 18+ · runs offline</span>
-      </div>
+  <div class="wrap hero-in">
+    <div class="kicker">Memory and navigation for coding agents</div>
+    <h1 class="title">Your agent relearns your codebase from <span class="cold">scratch</span> — every session.</h1>
+    <p class="hero-sub">coldstart gives it <b>persistent memory of your codebase</b> — a notebook it writes itself, so what one session figures out, the next already knows — plus an exact index to <b>find the right file without three wrong reads</b>. No embeddings, no API key: it runs on the model you already pay for.</p>
+    <div class="cta">
+      <a class="btn btn-primary" href="#install">Install →</a>
+      <a class="btn btn-ghost" href="/blog/">Read the blog</a>
     </div>
-    <div class="term type" role="img" aria-label="Terminal: coldstart find returns ranked, evidence-backed files with a past agent's note, then gs shows one file's symbols and callers">
-      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">agent — coldstart</span></div>
-      <div class="term-body">
-<span class="l" style="animation-delay:.05s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart find</span> auth session cookie</span>
-<span class="gap"></span>
-<span class="l" style="animation-delay:.5s"><span class="p-frost">src/auth/service.ts</span>  <span class="p-hit">3/3</span> <span class="p-dim">defines</span> auth, session, cookie</span>
-<span class="l" style="animation-delay:.7s">  <span class="p-ember">note</span> <span class="p-dim">[fresh]</span> signs &amp; verifies session cookies · login/logout entry</span>
-<span class="l" style="animation-delay:.9s"><span class="p-frost">src/middleware/session.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">imports</span> session, cookie</span>
-<span class="l" style="animation-delay:1.1s"><span class="p-frost">src/routes/login.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">defines</span> auth · <span class="p-dim">imports</span> session</span>
-<span class="gap"></span>
-<span class="l" style="animation-delay:1.5s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart gs</span> src/auth/service.ts</span>
-<span class="l" style="animation-delay:1.7s"><span class="p-dim">symbols</span>  signCookie <span class="p-dim">L12</span> · verify <span class="p-dim">L34</span> · rotate <span class="p-dim">L61</span></span>
-<span class="l" style="animation-delay:1.9s"><span class="p-dim">callers</span>  verify ← <span class="p-file">middleware/session.ts</span>, <span class="p-file">routes/login.ts</span></span>
-<span class="l" style="animation-delay:2.1s"><span class="p-dim">imported by</span>  4 files <span class="p-frost">→ read only the body you need</span><span class="cursor"></span></span>
-      </div>
-    </div>
+    <div class="cmdline"><span class="p">$</span> <span class="c">coldstart init</span></div>
+    <p class="meta-line">MIT · Node 18+ · runs offline · no embeddings, no API key</p>
   </div>
 </header>
 
 <!-- ===================== NOTEBOOK (the lead value) ===================== -->
 <section id="notebook" class="nb">
   <div class="wrap">
-    <div class="rise">
+    <div class="rise nb-intro">
       <div class="eyebrow warm">The notebook</div>
-      <h2>The second time a question comes up,<br>the answer is <span class="warm">already written down.</span></h2>
+      <h2>The second time a question comes up, the answer is <span class="warm">already written down.</span></h2>
       <p class="lead">An agent writes down what it learns while it works. The next one gets it for free, checked against the code so a stale note never passes as fact.</p>
     </div>
 
@@ -138,7 +121,22 @@ const faqJsonLd = {
         <li><b>Kept honest by a content hash</b> — the background keeper flags it the moment the code moves.</li>
         <li><b>Injected automatically</b> when a prompt matches, before the agent starts searching.</li>
       </ol>
-      <div class="card">
+
+      <div class="nb-exhibit">
+        <div class="nb-exhibit-label">What step three actually injects</div>
+        <div class="card" id="noteCard">
+        <div class="stamp-wrap" id="stamp">
+          <svg viewBox="0 0 120 120">
+            <g filter="url(#rough)" fill="none" stroke="#a86a35" stroke-width="2.4">
+              <circle cx="60" cy="60" r="46"/>
+              <circle cx="60" cy="60" r="38"/>
+            </g>
+            <g filter="url(#rough)" fill="#a86a35">
+              <text x="60" y="55" text-anchor="middle" font-family="JetBrains Mono" font-size="15" font-weight="700" letter-spacing="1">FRESH</text>
+              <text x="60" y="72" text-anchor="middle" font-family="JetBrains Mono" font-size="7.5">HASH VERIFIED</text>
+            </g>
+          </svg>
+        </div>
         <div class="card-top">
           <div class="kick"><span class="pill-t">File note</span><span class="pill fresh"><span class="d"></span>fresh</span></div>
           <div class="card-title">src/models.py · Tile</div>
@@ -152,6 +150,7 @@ const faqJsonLd = {
               <span class="anc fresh"><span class="d"></span>src/models.py <span class="sym">· save</span></span>
             </div>
           </div>
+        </div>
         </div>
       </div>
     </div>
@@ -171,6 +170,38 @@ const faqJsonLd = {
       <h2>Memory compounds over time.<br>Navigation pays off on the first lookup.</h2>
       <p class="lead">No embeddings — just paths, symbols, and the import/call graph, patched in the background as you type. Two cheap lookups instead of three wrong reads.</p>
     </div>
+    <div class="flow-figure rise">
+      <svg class="flow-svg" viewBox="0 0 900 190" role="img" aria-labelledby="flowTitle">
+        <title id="flowTitle">Grepping around a codebase wanders through wrong files before landing; find then gs goes straight there.</title>
+        <g filter="url(#rough)" fill="none" stroke="#5d6b83" stroke-width="1.8" stroke-linecap="round">
+          <path d="M60 100 C 110 40, 150 150, 200 70 S 300 40, 330 110"/>
+        </g>
+        <g fill="#5d6b83">
+          <circle cx="60" cy="100" r="4"/>
+          <circle cx="152" cy="130" r="4"/>
+          <circle cx="200" cy="70" r="4"/>
+          <circle cx="278" cy="52" r="4"/>
+        </g>
+        <g filter="url(#rough)" stroke="#5d6b83" stroke-width="1.6" stroke-linecap="round">
+          <path d="M147 125 L157 135 M157 125 L147 135"/>
+          <path d="M195 65 L205 75 M205 65 L195 75"/>
+          <path d="M273 47 L283 57 M283 47 L273 57"/>
+        </g>
+        <rect filter="url(#rough)" x="322" y="100" width="18" height="18" rx="2" fill="none" stroke="#8b9ab2" stroke-width="1.8"/>
+        <line x1="430" y1="24" x2="430" y2="166" stroke="#1a2536" stroke-width="1" stroke-dasharray="3 5"/>
+        <g filter="url(#rough)" fill="none" stroke="#4fbfe0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M510 130 L 660 55 L 810 100"/>
+        </g>
+        <circle cx="510" cy="130" r="4.5" fill="#4fbfe0"/>
+        <circle cx="660" cy="55" r="4.5" fill="#4fbfe0"/>
+        <rect filter="url(#rough)" x="801" y="91" width="18" height="18" rx="2" fill="#4fbfe0" stroke="#4fbfe0" stroke-width="2"/>
+      </svg>
+      <div class="flow-cap">
+        <span class="before">grep, then guess — three files before the right one</span>
+        <span class="after">find, then gs — straight to it</span>
+      </div>
+    </div>
+
     <div class="ops rise">
       <div class="op">
         <div class="on">find <span class="sig">&lt;terms&gt;</span></div>
@@ -183,13 +214,24 @@ const faqJsonLd = {
         <p>One file's symbols with line ranges, who imports it, and who calls each symbol — in a single call. Not a grep: the actual answer to <em>who uses this?</em></p>
       </div>
     </div>
-    <div class="flow rise">
-      <div class="step cold"><div class="k">Which files?</div><div class="cmd">coldstart find</div><div class="cap">Ranked candidates, each with the evidence for why it ranked.</div></div>
-      <div class="arrow">→</div>
-      <div class="step cold"><div class="k">What is it? Who uses it?</div><div class="cmd">coldstart gs</div><div class="cap">One file's symbols, importers, and per-symbol callers.</div></div>
-      <div class="arrow">→</div>
-      <div class="step warm"><div class="k">Now read</div><div class="cmd">Read</div><div class="cap">Open the one method body that matters — not the whole file.</div></div>
+
+    <div class="term type rise" role="img" aria-label="Terminal: coldstart find returns ranked, evidence-backed files with a past agent's note, then gs shows one file's symbols and callers">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">agent — coldstart</span></div>
+      <div class="term-body">
+<span class="l" style="animation-delay:.05s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart find</span> auth session cookie</span>
+<span class="gap"></span>
+<span class="l" style="animation-delay:.5s"><span class="p-frost">src/auth/service.ts</span>  <span class="p-hit">3/3</span> <span class="p-dim">defines</span> auth, session, cookie</span>
+<span class="l" style="animation-delay:.7s">  <span class="p-ember">note</span> <span class="p-dim">[fresh]</span> signs &amp; verifies session cookies · login/logout entry</span>
+<span class="l" style="animation-delay:.9s"><span class="p-frost">src/middleware/session.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">imports</span> session, cookie</span>
+<span class="l" style="animation-delay:1.1s"><span class="p-frost">src/routes/login.ts</span>  <span class="p-hit">2/3</span> <span class="p-dim">defines</span> auth · <span class="p-dim">imports</span> session</span>
+<span class="gap"></span>
+<span class="l" style="animation-delay:1.5s"><span class="p-prompt">$</span> <span class="p-cmd">coldstart gs</span> src/auth/service.ts</span>
+<span class="l" style="animation-delay:1.7s"><span class="p-dim">symbols</span>  signCookie <span class="p-dim">L12</span> · verify <span class="p-dim">L34</span> · rotate <span class="p-dim">L61</span></span>
+<span class="l" style="animation-delay:1.9s"><span class="p-dim">callers</span>  verify ← <span class="p-file">middleware/session.ts</span>, <span class="p-file">routes/login.ts</span></span>
+<span class="l" style="animation-delay:2.1s"><span class="p-dim">imported by</span>  4 files <span class="p-frost">→ read only the body you need</span><span class="cursor"></span></span>
+      </div>
     </div>
+
     <div class="keynote cool rise">
       <span class="kk">Measured, not promised</span>
       <p><b>−64% tokens on Arches</b> (Python/Django), <b>−31% on JMRI</b> (Java) — head-to-head against a no-tool baseline on real applications, recall equal or better in both. <a href="/blog/what-the-numbers-actually-say/">How we measured it →</a></p>
@@ -252,14 +294,23 @@ const faqJsonLd = {
   window.addEventListener('scroll', onScroll, {passive:true});
   onScroll();
   var rises = Array.prototype.slice.call(document.querySelectorAll('.rise'));
+  var stamp = document.getElementById('stamp');
   if (reduce || !('IntersectionObserver' in window)){
     rises.forEach(function(el){ el.classList.add('in'); });
+    if (stamp) stamp.classList.add('in');
     return;
   }
   var obs = new IntersectionObserver(function(entries){
     entries.forEach(function(e){ if (e.isIntersecting){ e.target.classList.add('in'); obs.unobserve(e.target); } });
   }, {rootMargin:'0px 0px -12% 0px', threshold:.08});
   rises.forEach(function(el){ obs.observe(el); });
+  var noteCard = document.getElementById('noteCard');
+  if (stamp && noteCard){
+    var stampObs = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){ if (e.isIntersecting){ stamp.classList.add('in'); stampObs.unobserve(e.target); } });
+    }, {threshold:.5});
+    stampObs.observe(noteCard);
+  }
 })();
 (function(){
   var btn = document.getElementById('copy-install');

--- a/site-astro/src/styles/docs.css
+++ b/site-astro/src/styles/docs.css
@@ -1,4 +1,4 @@
-/* coldstart docs — dark design system, tokens matched to the home (styles.css)
+/* coldstart docs — dark design system, tokens matched to landing.css
    frost = navigation/index, ember = notebook/memory */
 
 :root {
@@ -19,10 +19,10 @@
   --ok-bg: #10241a;
   --warn: #ef9448;
   --warn-bg: #2a1e0c;
-  --mono: "SF Mono", ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, "Fira Code", Menlo, Consolas, monospace;
+  --sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --display: "Newsreader", Georgia, serif;
   --wrap: 1080px;
-  --nav-wrap: 1080px;
   --radius: 12px;
 }
 
@@ -46,28 +46,30 @@ code { font-family: var(--mono); }
   opacity: .7;
 }
 
-/* ---- NAV (shared; --nav-wrap lets docs.html run a wider bar) ---- */
+/* ---- NAV (shared chrome — same max-width/padding as landing.css so the
+   bar doesn't visibly resize between home, docs, and blog) ---- */
 nav {
   position: sticky; top: 0; z-index: 30;
   background: color-mix(in srgb, var(--bg) 80%, transparent);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--line);
 }
-.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; }
-.brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.02em; display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
+.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: 1120px; margin: 0 auto; padding: 0 28px; }
+.brand { font-family: var(--display); font-weight: 500; font-size: 19px; letter-spacing: -.01em; display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
 .brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, var(--ember-bright), var(--frost)); box-shadow: 0 0 10px color-mix(in srgb, var(--frost) 50%, transparent); }
 .brand .mark { flex: none; }
 .mark { fill: none; }
 .fl { stroke-width: 2.1; stroke-linecap: round; }
 .s2 .fl { stroke: url(#warm); }
 .core { stroke: none; }
-.brand .tag { font-size: 12px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
 .nav-spacer { flex: 1; }
-.nav-links { display: flex; gap: 22px; font-size: 14px; font-family: var(--mono); }
-.nav-links a { color: var(--muted); text-decoration: none; transition: color .15s; }
+.nav-links { display: flex; gap: 22px; font-size: 14px; }
+.nav-links a { position: relative; padding-bottom: 4px; color: var(--muted); text-decoration: none; transition: color .15s; }
 .nav-links a:hover { color: var(--ink); }
-.nav-cta { font-family: var(--mono); font-size: 13px; text-decoration: none; padding: 7px 14px; border: 1px solid var(--line); border-radius: 8px; color: var(--ink); transition: border-color .15s, background .15s; }
-.nav-cta:hover { border-color: var(--frost); background: color-mix(in srgb, var(--frost) 10%, transparent); }
+.nav-links a.active { color: var(--frost); }
+.nav-links a.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -4px; height: 2px; border-radius: 1px; background: var(--frost); }
+.nav-cta { font-family: var(--mono); font-size: 13.5px; text-decoration: none; padding: 9px 18px; border-radius: 6px; background: var(--frost); color: #04121a; font-weight: 600; transition: opacity .15s; }
+.nav-cta:hover { opacity: .88; }
 .nav-burger { display: none; flex: none; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer; padding: 0; align-items: center; justify-content: center; }
 .nav-burger span { display: block; width: 15px; height: 1.5px; background: var(--ink); border-radius: 2px; }
 .nav-burger span + span { margin-top: 3px; }
@@ -157,9 +159,9 @@ nav {
 .doc-sec .fcard h4 { font-size: 15px; margin: 9px 0 7px; }
 .doc-sec .fcard p { font-size: 14px; }
 
-/* ---- FOOTER (shared; --nav-wrap controls width) ---- */
+/* ---- FOOTER (shared chrome — same max-width/padding as nav) ---- */
 footer { border-top: 1px solid var(--line); padding: 48px 0; }
-.foot-in { max-width: var(--nav-wrap); margin: 0 auto; padding: 0 24px; display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; align-items: center; }
+.foot-in { max-width: 1120px; margin: 0 auto; padding: 0 28px; display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; align-items: center; }
 .foot-links { display: flex; gap: 22px; font-family: var(--mono); font-size: 13.5px; }
 .foot-links a { color: var(--muted); text-decoration: none; }
 .foot-links a:hover { color: var(--ink); }
@@ -168,8 +170,6 @@ footer { border-top: 1px solid var(--line); padding: 48px 0; }
 /* =========================================================
    DOCS PAGE — sidebar + reference layout
    ========================================================= */
-body.docs-page { --nav-wrap: 1200px; }
-
 .docs { max-width: 1200px; margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px 1fr; gap: 56px; align-items: start; }
 @media (max-width: 860px) { .docs { grid-template-columns: 1fr; gap: 0; } }
 
@@ -188,8 +188,8 @@ body.docs-page { --nav-wrap: 1200px; }
 .grp-head { border-top: 1px solid var(--line); padding-top: 40px; margin-top: 52px; }
 .grp-head:first-of-type { border-top: 0; margin-top: 0; padding-top: 0; }
 .kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--frost); margin-bottom: 12px; }
-.content h1 { font-family: var(--mono); font-size: clamp(30px, 5vw, 40px); letter-spacing: -.035em; line-height: 1.05; }
-.content h2 { font-family: var(--mono); font-size: clamp(21px, 3vw, 26px); letter-spacing: -.02em; }
+.content h1 { font-family: var(--display); font-weight: 500; font-size: clamp(30px, 5vw, 40px); letter-spacing: -.01em; line-height: 1.1; }
+.content h2 { font-family: var(--display); font-weight: 500; font-size: clamp(21px, 3vw, 26px); letter-spacing: -.01em; }
 .content > p, .doc-sec > p, .prose p { color: var(--muted); font-size: 16px; margin-top: 14px; }
 .prose p + p { margin-top: 12px; }
 .lead-p { font-size: 18px !important; color: var(--muted); margin-top: 18px; }
@@ -245,7 +245,6 @@ ul.tight li b { color: var(--ink); }
    light default + an `@media (prefers-color-scheme: dark)` override.
    ========================================================= */
 body.essay-page {
-  --nav-wrap: 1080px;
   /* The readable line length, ~71 characters at the 19px body size — the top
      of the comfortable range, chosen so the figure bleed either side stays
      small. Do not push past ~760px; beyond that the line is hard to track
@@ -287,11 +286,11 @@ body.essay-page .term { border-color: var(--term-border); }
 .essay-hero { padding: 10px 0 30px; }
 
 .essay-hero h1 {
-  font-family: var(--sans);
-  font-weight: 700;
+  font-family: var(--display);
+  font-weight: 500;
   font-size: clamp(31px, 4.4vw, 46px);
-  line-height: 1.1;
-  letter-spacing: -.028em;
+  line-height: 1.12;
+  letter-spacing: -.01em;
   color: var(--ink);
 }
 
@@ -302,31 +301,42 @@ body.essay-page .term { border-color: var(--term-border); }
   margin-top: 16px;
 }
 
-/* ---- INDEX (blog.html) — a stacked list, not a grid.
-       Two posts in a 2-col grid looks like a page that failed to load. ---- */
+/* ---- INDEX (blog/) — a card grid. Nine posts and growing; a single
+       stacked list was the right call at two or three posts (a 2-col grid
+       of those looked like a page that failed to load) but now reads as a
+       long scroll with no overview. Same bordered-card language as the
+       landing page's .op cards, just reused here. ---- */
 .essay-list {
-  display: block;
-  margin-top: 4px;
-  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+  margin-top: 40px;
 }
+@media (max-width: 980px) { .essay-list { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px) { .essay-list { grid-template-columns: 1fr; } }
 
 .essay-card {
-  display: block;
-  padding: 30px 20px 30px 0;
-  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
   text-decoration: none;
-  transition: background .16s, padding-left .16s;
+  transition: border-color .16s, background .16s, transform .16s;
 }
 
 .essay-card:hover {
-  background: var(--surface-2);
-  padding-left: 20px;
+  border-color: color-mix(in srgb, var(--frost) 45%, var(--line));
+  background: color-mix(in srgb, var(--surface) 88%, var(--frost) 6%);
+  transform: translateY(-2px);
 }
 
 .essay-meta {
   display: flex;
   align-items: center;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 8px 10px;
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: .13em;
@@ -340,13 +350,12 @@ body.essay-page .term { border-color: var(--term-border); }
 .essay-meta .rt { color: var(--muted); letter-spacing: .06em; }
 
 .essay-card h2 {
-  font-family: var(--sans);
-  font-weight: 700;
-  font-size: clamp(20px, 2.2vw, 25px);
-  line-height: 1.22;
-  letter-spacing: -.022em;
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: clamp(19px, 2.2vw, 22px);
+  line-height: 1.26;
+  letter-spacing: -.01em;
   color: var(--ink);
-  max-width: 30ch;
 }
 
 .essay-card:hover h2 { color: var(--frost); }
@@ -354,9 +363,12 @@ body.essay-page .term { border-color: var(--term-border); }
 .essay-card p {
   color: var(--muted);
   margin-top: 10px;
-  font-size: 16px;
+  font-size: 14.5px;
   line-height: 1.6;
-  max-width: 68ch;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /* ---- ARTICLE — one centered column, everything constrained to the measure ---- */
@@ -415,11 +427,11 @@ body.essay-page .term { border-color: var(--term-border); }
 }
 
 .essay-article h2 {
-  font-family: var(--sans);
-  font-weight: 700;
+  font-family: var(--display);
+  font-weight: 500;
   font-size: clamp(22px, 2.8vw, 28px);
-  line-height: 1.2;
-  letter-spacing: -.024em;
+  line-height: 1.22;
+  letter-spacing: -.01em;
   color: var(--ink);
   margin-top: 54px;
 }

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -14,13 +14,18 @@
   --frost:#4fbfe0;
   --frost-dim:#2f89a8;
   --ember:#ef9448;
-  --ember-dim:#b96a28;
+  --ember-dim:#a86a35;
   --ok:#57cc92;
   --line:#1a2536;
   --line-warm:#2a2218;
-  --mono:"SF Mono",ui-monospace,"JetBrains Mono","Fira Code",Menlo,Consolas,monospace;
-  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
-  --display:"Space Grotesk",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+
+  --paper:#e5d9bd;
+  --paper-ink:#2a2620;
+  --paper-line:#c7b790;
+
+  --mono:"JetBrains Mono","SF Mono",ui-monospace,"Fira Code",Menlo,Consolas,monospace;
+  --sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --display:"Newsreader",Georgia,serif;
   --wrap:1120px;
 }
 *{box-sizing:border-box;}
@@ -44,9 +49,9 @@ code{font-family:var(--mono);}
 nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
   background:color-mix(in srgb,var(--void) 78%,transparent);
   border-bottom:1px solid var(--line);}
-.nav-in{max-width:var(--wrap);margin:0 auto;padding:0 28px;height:62px;
-  display:flex;align-items:center;gap:22px;}
-.brand{font-family:var(--mono);font-weight:700;font-size:17px;letter-spacing:-.02em;
+.nav-in{max-width:var(--wrap);margin:0 auto;padding:0 28px;height:64px;
+  display:flex;align-items:center;gap:28px;}
+.brand{font-family:var(--display);font-weight:500;font-size:19px;letter-spacing:-.01em;
   display:flex;align-items:center;gap:10px;color:var(--text);}
 .brand .dot{width:11px;height:11px;border-radius:50%;
   background:radial-gradient(circle at 34% 30%,var(--ember),var(--frost));
@@ -57,12 +62,14 @@ nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
 .s2 .fl{stroke:url(#warm);}
 .core{stroke:none;}
 .nav-sp,.nav-spacer{flex:1;}
-.nav-links{display:flex;gap:24px;font-family:var(--mono);font-size:13.5px;}
-.nav-links a{color:var(--muted);transition:color .15s;}
+.nav-links{display:flex;gap:26px;font-size:14px;}
+.nav-links a{position:relative;padding-bottom:4px;color:var(--muted);transition:color .15s;}
 .nav-links a:hover{color:var(--text);}
-.nav-cta{font-family:var(--mono);font-size:13px;padding:8px 16px;border-radius:8px;
-  border:1px solid var(--line);color:var(--text);transition:.15s;}
-.nav-cta:hover{border-color:var(--frost);background:color-mix(in srgb,var(--frost) 12%,transparent);}
+.nav-links a.active{color:var(--frost);}
+.nav-links a.active::after{content:"";position:absolute;left:0;right:0;bottom:-4px;height:2px;border-radius:1px;background:var(--frost);}
+.nav-cta{font-family:var(--mono);font-size:13.5px;padding:9px 18px;border-radius:6px;
+  background:var(--frost);color:#04121a;font-weight:600;transition:opacity .15s;}
+.nav-cta:hover{opacity:.88;}
 .nav-burger{display:none;flex:none;width:34px;height:34px;border:1px solid var(--line);border-radius:8px;
   background:transparent;cursor:pointer;padding:0;align-items:center;justify-content:center;}
 .nav-burger span{display:block;width:15px;height:1.5px;background:var(--text);border-radius:2px;}
@@ -84,8 +91,8 @@ section{padding:104px 0;position:relative;}
 .eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
   color:var(--frost);margin-bottom:22px;}
 .eyebrow.warm{color:var(--ember);}
-h2{font-family:var(--display);font-weight:600;font-size:clamp(29px,4.2vw,44px);
-  letter-spacing:-.03em;line-height:1.1;}
+h2{font-family:var(--display);font-weight:500;font-size:clamp(28px,4vw,42px);
+  letter-spacing:-.01em;line-height:1.18;}
 .lead{margin-top:20px;font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:60ch;}
 .lead b,.lead strong{color:var(--text);font-weight:600;}
 
@@ -94,24 +101,29 @@ h2{font-family:var(--display);font-weight:600;font-size:clamp(29px,4.2vw,44px);
 .rise.in{opacity:1;transform:none;}
 
 /* ---------- HERO ---------- */
-.hero{padding:132px 0 140px;position:relative;overflow:hidden;}
+.hero{padding:128px 0 100px;position:relative;overflow:hidden;text-align:center;}
 .hero::before{content:"";position:absolute;inset:0;z-index:-1;
   background:
-    radial-gradient(80% 60% at 78% -10%,color-mix(in srgb,var(--frost) 15%,transparent),transparent 60%),
-    radial-gradient(60% 50% at 0% 8%,color-mix(in srgb,var(--frost) 8%,transparent),transparent 55%);}
+    radial-gradient(70% 55% at 50% -10%,color-mix(in srgb,var(--frost) 13%,transparent),transparent 60%);}
 .hero::after{content:"";position:absolute;inset:0;z-index:-1;pointer-events:none;
   background-image:radial-gradient(rgba(255,255,255,.09) 1px,transparent 1.5px);
   background-size:30px 30px;
   -webkit-mask-image:radial-gradient(65% 55% at 50% 0%,#000,transparent 72%);
   mask-image:radial-gradient(65% 55% at 50% 0%,#000,transparent 72%);}
-.hero-grid{display:grid;grid-template-columns:1.02fr .98fr;gap:76px;align-items:center;}
-@media(max-width:940px){.hero-grid{grid-template-columns:1fr;gap:44px;}}
-h1.title{font-family:var(--display);font-weight:600;
-  font-size:clamp(38px,6vw,66px);line-height:1.04;letter-spacing:-.03em;max-width:17ch;}
+.hero-in{max-width:760px;margin:0 auto;}
+.kicker{font-family:var(--mono);font-size:13px;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--faint);margin-bottom:24px;}
+h1.title{font-family:var(--display);font-weight:500;margin:0 auto;
+  font-size:clamp(34px,5.4vw,58px);line-height:1.14;letter-spacing:-.01em;max-width:16ch;text-wrap:balance;}
 h1.title .cold{color:var(--frost);}
-.hero-sub{margin-top:30px;font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:52ch;}
-.hero-sub b{color:var(--text);font-weight:600;}
-.cta{margin-top:38px;display:flex;gap:14px;align-items:center;flex-wrap:wrap;}
+.hero-sub{margin:26px auto 0;font-size:clamp(16px,2vw,18px);color:var(--muted);max-width:50ch;line-height:1.65;}
+.hero-sub b{color:var(--text);font-weight:500;}
+.cta{margin-top:34px;display:flex;gap:14px;align-items:center;justify-content:center;flex-wrap:wrap;}
+.cmdline{margin:36px auto 0;display:inline-flex;align-items:center;gap:10px;
+  font-family:var(--mono);font-size:14px;color:var(--muted);}
+.cmdline .p{color:var(--frost);}
+.cmdline .c{color:var(--text);}
+.hero-note,.meta-line{margin-top:16px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
 .btn{font-family:var(--mono);font-size:14px;padding:12px 22px;border-radius:9px;
   display:inline-flex;align-items:center;gap:9px;transition:transform .12s,box-shadow .25s,border-color .15s,background .2s;}
 .btn-primary{background:var(--frost);color:#04121a;font-weight:600;}
@@ -121,8 +133,9 @@ h1.title .cold{color:var(--frost);}
 .hero-note{font-family:var(--mono);font-size:12px;color:var(--faint);}
 
 /* ---------- TERMINAL ---------- */
-.term{background:#05080e;border:1px solid var(--line);border-radius:14px;overflow:hidden;
+.term{background:#05080e;border:1px solid var(--line);border-radius:14px;overflow:hidden;margin-top:0;
   box-shadow:0 60px 120px -44px rgba(0,0,0,.95),0 0 0 1px rgba(255,255,255,.03) inset;}
+.navsec .term{margin-top:48px;}
 .term-bar{display:flex;align-items:center;gap:8px;padding:12px 15px;
   border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.015);}
 .tl{width:11px;height:11px;border-radius:50%;}
@@ -149,25 +162,24 @@ h1.title .cold{color:var(--frost);}
 
 /* ---------- NAVIGATION SECTION (the index) ---------- */
 .navsec{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
-.ops{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:44px;}
+
+/* hand-drawn comparison: wandering grep path vs. a straight two-hop find→gs path */
+.flow-figure{margin-top:48px;}
+.flow-svg{width:100%;height:auto;display:block;}
+.flow-cap{display:flex;justify-content:space-between;margin-top:14px;font-family:var(--mono);
+  font-size:12px;letter-spacing:.02em;flex-wrap:wrap;gap:8px;}
+.flow-cap .before{color:var(--faint);}
+.flow-cap .after{color:var(--frost);}
+
+.ops{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:48px;}
 @media(max-width:800px){.ops{grid-template-columns:1fr;}}
 .op{border:1px solid var(--line);border-radius:13px;background:var(--void);padding:30px;position:relative;overflow:hidden;}
 .op::before{content:"";position:absolute;top:0;left:0;right:0;height:2px;background:var(--frost);opacity:.7;}
 .op .on{font-family:var(--mono);font-weight:700;font-size:20px;color:var(--frost);}
 .op .on .sig{color:var(--faint);font-weight:400;font-size:14px;}
-.op h3{font-family:var(--mono);font-size:16px;margin:14px 0 8px;letter-spacing:-.01em;color:var(--text);}
+.op h3{font-family:var(--display);font-weight:500;font-size:19px;margin:14px 0 8px;letter-spacing:-.01em;color:var(--text);}
 .op p{color:var(--muted);font-size:14.5px;}
 .op p em{color:var(--text);font-style:normal;border-bottom:1px solid var(--frost-dim);}
-.flow{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;align-items:stretch;margin-top:22px;}
-@media(max-width:800px){.flow{grid-template-columns:1fr;gap:14px;}.flow .arrow{display:none;}}
-.step{border:1px solid var(--line);border-radius:12px;background:var(--void);padding:22px;}
-.step .k{font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint);}
-.step .cmd{font-family:var(--mono);font-weight:700;font-size:17px;margin-top:10px;letter-spacing:-.02em;}
-.step.cold .cmd{color:var(--frost);}.step.warm .cmd{color:var(--ember);}
-.step .cap{color:var(--muted);font-size:13.5px;margin-top:9px;}
-.arrow{display:grid;place-items:center;font-family:var(--mono);color:var(--faint);font-size:20px;padding:0 18px;}
-.tax-note{margin-top:24px;font-family:var(--mono);font-size:13px;color:var(--muted);}
-.tax-note b{color:var(--frost);font-weight:600;}
 
 /* ---------- NOTEBOOK (the lead value, warm) ---------- */
 .nb{background:
@@ -176,56 +188,63 @@ h1.title .cold{color:var(--frost);}
     var(--warm-ground);
   border-top:1px solid var(--line-warm);border-bottom:1px solid var(--line-warm);}
 .nb h2 .warm{color:var(--ember);}
-.beats{display:flex;flex-direction:column;gap:78px;margin-top:60px;}
-.beat{display:grid;grid-template-columns:.92fr 1.08fr;gap:54px;align-items:center;}
-.beat.rev .bv{order:-1;}
-@media(max-width:860px){.beat{grid-template-columns:1fr;gap:28px;}.beat.rev .bv{order:0;}}
-.bstep{font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;
-  color:var(--ember);display:flex;align-items:center;gap:12px;}
-.bstep .n{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;font-size:12px;flex:none;
-  border:1px solid color-mix(in srgb,var(--ember) 50%,var(--line-warm));color:var(--ember);}
-.beat h3{font-family:var(--mono);font-size:clamp(20px,2.6vw,25px);letter-spacing:-.025em;margin:18px 0 12px;}
-.bt p{color:var(--muted);font-size:15px;}
-.bt p+p{margin-top:11px;}
-.bt code{font-family:var(--mono);font-size:12.5px;background:rgba(239,148,72,.1);
-  border:1px solid var(--line-warm);border-radius:6px;padding:1px 7px;color:var(--ember);}
+
+/* the notebook reads as one centered, intimate column — a diary entry, not a
+   wide technical spread. The index section below stays left-set and full-width
+   on purpose: warm/close vs. cold/wide is the same duality as the accent colors. */
+.nb-intro{max-width:640px;margin-left:auto;margin-right:auto;text-align:center;}
+.nb-intro .lead{margin-left:auto;margin-right:auto;}
 .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);}
 
-.nb-main{display:grid;grid-template-columns:.85fr 1.15fr;gap:56px;align-items:center;margin-top:52px;}
-@media(max-width:860px){.nb-main{grid-template-columns:1fr;gap:30px;}}
-.nb-steps{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:22px;counter-reset:nbstep;}
-.nb-steps li{position:relative;padding-left:42px;font-size:15.5px;color:var(--muted);counter-increment:nbstep;line-height:1.5;}
-.nb-steps li::before{content:counter(nbstep);position:absolute;left:0;top:-3px;width:27px;height:27px;border-radius:50%;
-  display:grid;place-items:center;font-family:var(--mono);font-size:12px;color:var(--ember);
-  border:1px solid color-mix(in srgb,var(--ember) 50%,var(--line-warm));}
+.nb-main{display:flex;flex-direction:column;align-items:center;margin-top:52px;}
+.nb-steps{list-style:none;margin:0 auto;padding:0;max-width:560px;width:100%;
+  display:flex;flex-direction:column;gap:26px;text-align:left;}
+.nb-steps li{position:relative;padding-left:28px;font-size:15.5px;color:var(--muted);line-height:1.55;}
+.nb-steps li::before{content:"—";position:absolute;left:0;top:0;
+  font-family:var(--mono);font-size:15px;color:var(--ember);}
 .nb-steps b{color:var(--text);font-weight:600;}
 
-/* note card */
-.card{border:1px solid var(--line-warm);border-radius:13px;background:#0e0c09;overflow:hidden;
-  box-shadow:0 30px 70px -40px rgba(0,0,0,.9);}
-.card-top{padding:17px 20px 15px;border-bottom:1px solid var(--line-warm);}
+/* the exhibit: what step three actually produces, pulled out and shown */
+.nb-exhibit{margin:44px auto 0;max-width:560px;width:100%;text-align:left;}
+.nb-exhibit-label{display:flex;align-items:center;gap:11px;margin-bottom:18px;
+  font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--faint);}
+.nb-exhibit-label::before{content:"";width:26px;height:1px;background:var(--ember-dim);flex:none;}
+
+/* note card — paper, not chrome: it's a page from the notebook, not another dark panel */
+.card{border:1px solid var(--paper-line);border-radius:4px;background:var(--paper);color:var(--paper-ink);
+  overflow:visible;position:relative;transform:rotate(-.6deg);
+  box-shadow:0 26px 54px -30px rgba(0,0,0,.65),0 0 0 10px color-mix(in srgb,var(--ember) 5%,transparent),0 0 60px -12px color-mix(in srgb,var(--ember) 22%,transparent);}
+.card-top{padding:18px 22px 14px;border-bottom:1px solid var(--paper-line);}
 .kick{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
 .pill-t{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;
-  padding:3px 9px;border-radius:999px;border:1px solid color-mix(in srgb,var(--ember) 45%,var(--line-warm));color:var(--ember);}
+  padding:3px 9px;border-radius:999px;border:1px solid color-mix(in srgb,var(--ember-dim) 55%,var(--paper-line));color:var(--ember-dim);}
 .pill{font-family:var(--mono);font-size:10.5px;padding:3px 9px 3px 8px;border-radius:999px;
   display:inline-flex;align-items:center;gap:6px;font-weight:600;}
 .pill .d{width:7px;height:7px;border-radius:50%;}
-.pill.fresh{background:rgba(87,204,146,.14);color:var(--ok);}.pill.fresh .d{background:var(--ok);}
-.pill.chg{background:rgba(239,148,72,.14);color:var(--ember);}.pill.chg .d{background:var(--ember);}
-.card-title{font-family:var(--mono);font-size:16px;font-weight:700;letter-spacing:-.02em;margin-top:12px;color:var(--text);}
-.card-body{padding:16px 20px 20px;}
-.card-body p{font-size:13.5px;color:#cdd8e8;}
+.pill.fresh{background:rgba(87,204,146,.18);color:#2e7d54;}.pill.fresh .d{background:#2e7d54;}
+.pill.chg{background:rgba(168,106,53,.16);color:var(--ember-dim);}.pill.chg .d{background:var(--ember-dim);}
+.card-title{font-family:var(--display);font-weight:500;font-size:18px;letter-spacing:-.01em;margin-top:12px;color:var(--paper-ink);}
+.card-body{padding:16px 22px 20px;}
+.card-body p{font-size:14px;line-height:1.7;color:#4a4436;}
 .card-body p+p{margin-top:9px;}
-.mono-link{color:var(--frost);font-family:var(--mono);font-size:13px;}
-.warnbar{margin-top:11px;font-family:var(--mono);font-size:11.5px;color:var(--ember);
-  background:rgba(239,148,72,.1);border-radius:8px;padding:9px 11px;}
-.anchors{margin-top:15px;border-top:1px solid var(--line-warm);padding-top:13px;}
-.anchors .lbl{margin-bottom:9px;}
+.mono-link{color:var(--frost-dim);font-family:var(--mono);font-size:13px;}
+.warnbar{margin-top:11px;font-family:var(--mono);font-size:11.5px;color:var(--ember-dim);
+  background:rgba(168,106,53,.12);border-radius:8px;padding:9px 11px;}
+.anchors{margin-top:15px;border-top:1px solid var(--paper-line);padding-top:13px;}
+.anchors .lbl{margin-bottom:9px;color:#8a8066;}
 .arow{display:flex;flex-wrap:wrap;gap:8px;}
-.anc{font-family:var(--mono);font-size:11.5px;padding:4px 9px;border:1px solid var(--line-warm);
-  border-radius:7px;background:rgba(255,255,255,.02);color:#cdd8e8;display:inline-flex;align-items:center;gap:7px;}
+.anc{font-family:var(--mono);font-size:11.5px;padding:4px 9px;border:1px solid var(--paper-line);
+  border-radius:4px;background:#f6f2e6;color:#4a4436;display:inline-flex;align-items:center;gap:7px;}
 .anc .d{width:6px;height:6px;border-radius:50%;}
-.anc.fresh .d{background:var(--ok);}.anc.chg .d{background:var(--ember);}
+.anc.fresh .d{background:#2e7d54;}.anc.chg .d{background:var(--ember-dim);}
+.anc .sym{color:#8a8066;}
+
+/* hand-drawn ink stamp — reveals once the card scrolls into view */
+.stamp-wrap{position:absolute;top:14px;right:18px;width:84px;height:84px;
+  opacity:0;transform:rotate(-12deg) scale(.7);transition:opacity .5s ease,transform .5s cubic-bezier(.2,1.4,.4,1);}
+.stamp-wrap.in{opacity:1;transform:rotate(-9deg) scale(1);}
+.stamp-wrap svg{width:100%;height:100%;}
+@media(prefers-reduced-motion:reduce){.stamp-wrap{transition:none;}}
 .anc .sym{color:var(--faint);}
 
 /* kb view mock */


### PR DESCRIPTION
## Summary
- Landing page now runs the approved v4 concept directly in `site-astro` (Newsreader/IBM Plex Sans/JetBrains Mono, paper note-card, hand-drawn flow figure, centered hero/notebook sections) instead of living only as a standalone artifact.
- `docs.css` (docs + blog pages) had drifted out of sync with the redesigned `landing.css` — fonts, brand wordmark, and heading typography are now synced to match.
- Nav/footer chrome unified to 1120px everywhere — docs was rendering at 1200px and blog at 1080px via a `--nav-wrap` cascade-order bug (two body classes on blog pages, later rule silently won).
- Nav no longer shows a "docs"/"blog" text tag next to the wordmark; the active tab gets a frost underline instead.
- Blog index rebuilt from a single-column list into a 3-col card grid — there are 9 posts now, and the list layout was chosen back when there were only 2-3.
- Homepage title tag and hero copy tightened for the persistent/agent/codebase-memory search terms, restoring a line ("persistent memory of your codebase") that had been dropped from the live copy during the hero rebuild.

## Test plan
- [x] Verified home, docs, and blog index/post pages locally via `chrome-devtools-cli` at desktop + tablet widths
- [x] Confirmed nav bar renders at identical width (1120px) on all three page families via bounding-rect measurement
- [x] Confirmed blog card grid responds correctly at 3/2/1 columns
- [ ] Live smoke-check on coldstartmcp.dev after deploy

Note: this supersedes the nav-width portion of #138 (still open) — that PR's fix is now included here, so #138 will likely need closing or rebasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)