### PR TITLE
site: make the hero install command runnable and copyable

### DIFF
--- a/site-astro/src/pages/index.astro
+++ b/site-astro/src/pages/index.astro
@@ -101,7 +101,10 @@ const faqJsonLd = {
       <a class="btn btn-primary" href="#install">Install →</a>
       <a class="btn btn-ghost" href="/blog/">Read the blog</a>
     </div>
-    <div class="cmdline"><span class="p">$</span> <span class="c">coldstart init</span></div>
+    <button type="button" class="cmdline copy-btn" data-copy="npm install -g @cstart/coldstart && coldstart init" aria-label="Copy install command">
+      <span class="p">$</span> <span class="c">npm install -g @cstart/coldstart &amp;&amp; coldstart init</span>
+      <span class="copy-hint">Copy</span>
+    </button>
     <p class="meta-line">MIT · Node 18+ · runs offline · no embeddings, no API key</p>
   </div>
 </header>
@@ -313,27 +316,29 @@ const faqJsonLd = {
   }
 })();
 (function(){
-  var btn = document.getElementById('copy-install');
-  if (!btn) return;
-  btn.addEventListener('click', function(){
-    var text = btn.getAttribute('data-copy') || '';
-    function done(){
-      var prev = btn.textContent;
-      btn.textContent = 'Copied';
-      btn.classList.add('copied');
-      setTimeout(function(){ btn.textContent = prev; btn.classList.remove('copied'); }, 1600);
-    }
-    if (navigator.clipboard && navigator.clipboard.writeText){
-      navigator.clipboard.writeText(text).then(done).catch(fallback);
-    } else { fallback(); }
-    function fallback(){
-      var ta = document.createElement('textarea');
-      ta.value = text; ta.setAttribute('readonly','');
-      ta.style.position = 'absolute'; ta.style.left = '-9999px';
-      document.body.appendChild(ta); ta.select();
-      try { document.execCommand('copy'); done(); } catch(e){}
-      document.body.removeChild(ta);
-    }
+  document.querySelectorAll('.copy-btn[data-copy]').forEach(function(btn){
+    var hint = btn.querySelector('.copy-hint');
+    btn.addEventListener('click', function(){
+      var text = btn.getAttribute('data-copy') || '';
+      function done(){
+        var label = hint || btn;
+        var prev = label.textContent;
+        label.textContent = 'Copied';
+        btn.classList.add('copied');
+        setTimeout(function(){ label.textContent = prev; btn.classList.remove('copied'); }, 1600);
+      }
+      if (navigator.clipboard && navigator.clipboard.writeText){
+        navigator.clipboard.writeText(text).then(done).catch(fallback);
+      } else { fallback(); }
+      function fallback(){
+        var ta = document.createElement('textarea');
+        ta.value = text; ta.setAttribute('readonly','');
+        ta.style.position = 'absolute'; ta.style.left = '-9999px';
+        document.body.appendChild(ta); ta.select();
+        try { document.execCommand('copy'); done(); } catch(e){}
+        document.body.removeChild(ta);
+      }
+    });
   });
 })();
 </script>

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -120,9 +120,16 @@ h1.title .cold{color:var(--frost);}
 .hero-sub b{color:var(--text);font-weight:500;}
 .cta{margin-top:34px;display:flex;gap:14px;align-items:center;justify-content:center;flex-wrap:wrap;}
 .cmdline{margin:36px auto 0;display:inline-flex;align-items:center;gap:10px;
-  font-family:var(--mono);font-size:14px;color:var(--muted);}
+  font-family:var(--mono);font-size:14px;color:var(--muted);
+  background:none;border:1px solid transparent;border-radius:8px;padding:6px 10px;cursor:pointer;
+  transition:border-color .15s,background .15s;}
+.cmdline:hover{border-color:var(--line);background:rgba(255,255,255,.03);}
 .cmdline .p{color:var(--frost);}
 .cmdline .c{color:var(--text);}
+.cmdline .copy-hint{font-size:11px;color:var(--faint);letter-spacing:.04em;transition:color .15s;}
+.cmdline:hover .copy-hint{color:var(--muted);}
+.cmdline.copied{border-color:rgba(79,209,139,.4);background:rgba(79,209,139,.08);}
+.cmdline.copied .copy-hint{color:#4fd18b;}
 .hero-note,.meta-line{margin-top:16px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
 .btn{font-family:var(--mono);font-size:14px;padding:12px 22px;border-radius:9px;
   display:inline-flex;align-items:center;gap:9px;transition:transform .12s,box-shadow .25s,border-color .15s,background .2s;}


### PR DESCRIPTION
## Summary
- The hero's `.cmdline` showed a bare `coldstart init` fragment with no install context; it now shows the actual runnable command (`npm install -g @cstart/coldstart && coldstart init`).
- That line is now click-to-copy, matching the old static site's install-block copy button.
- Generalized the copy-button script from one hardcoded `#copy-install` id to `document.querySelectorAll('.copy-btn[data-copy]')`, so the hero button and the bottom `#install` terminal's button share a single handler instead of duplicating the logic.

## Test plan
- [x] Verified locally via chrome-devtools-cli: clicked the hero command, confirmed the hint swaps to "Copied" and the success style applies
- [x] Confirmed the existing bottom `#install` terminal's copy button still works under the shared handler
- [ ] Live smoke-check on coldstartmcp.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)