### PR TITLE
Fix mobile navigation and landing-page layout

### DIFF
--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -38,9 +38,10 @@ const installHref = variant === 'home' ? '#install' : '/#install';
   btn.addEventListener('click', function(){
     var open = menu.classList.toggle('open');
     btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    btn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
   });
   menu.querySelectorAll('a').forEach(function(a){
-    a.addEventListener('click', function(){ menu.classList.remove('open'); btn.setAttribute('aria-expanded','false'); });
+    a.addEventListener('click', function(){ menu.classList.remove('open'); btn.setAttribute('aria-expanded','false'); btn.setAttribute('aria-label','Open menu'); });
   });
 })();
 </script>

--- a/site-astro/src/styles/docs.css
+++ b/site-astro/src/styles/docs.css
@@ -70,7 +70,7 @@ nav {
 .nav-links a.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -4px; height: 2px; border-radius: 1px; background: var(--frost); }
 .nav-cta { font-family: var(--mono); font-size: 13.5px; text-decoration: none; padding: 9px 18px; border-radius: 6px; background: var(--frost); color: #04121a; font-weight: 600; transition: opacity .15s; }
 .nav-cta:hover { opacity: .88; }
-.nav-burger { display: none; flex: none; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer; padding: 0; align-items: center; justify-content: center; }
+.nav-burger { display: none; flex: none; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer; padding: 0; align-items: center; justify-content: center; flex-direction: column; }
 .nav-burger span { display: block; width: 15px; height: 1.5px; background: var(--ink); border-radius: 2px; }
 .nav-burger span + span { margin-top: 3px; }
 .nav-mobile { display: none; flex-direction: column; gap: 2px; padding: 10px 24px 16px; border-top: 1px solid var(--line); }

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -71,7 +71,7 @@ nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
   background:var(--frost);color:#04121a;font-weight:600;transition:opacity .15s;}
 .nav-cta:hover{opacity:.88;}
 .nav-burger{display:none;flex:none;width:34px;height:34px;border:1px solid var(--line);border-radius:8px;
-  background:transparent;cursor:pointer;padding:0;align-items:center;justify-content:center;}
+  background:transparent;cursor:pointer;padding:0;align-items:center;justify-content:center;flex-direction:column;}
 .nav-burger span{display:block;width:15px;height:1.5px;background:var(--text);border-radius:2px;}
 .nav-burger span+span{margin-top:3px;}
 .nav-mobile{display:none;flex-direction:column;gap:2px;padding:10px 28px 16px;border-top:1px solid var(--line);}
@@ -96,12 +96,14 @@ h2{font-family:var(--display);font-weight:500;font-size:clamp(28px,4vw,42px);
 .lead{margin-top:20px;font-size:clamp(16px,2vw,19px);color:var(--muted);max-width:60ch;}
 .lead b,.lead strong{color:var(--text);font-weight:600;}
 
-/* reveal on scroll */
-.rise{opacity:0;transform:translateY(22px);transition:opacity .7s ease,transform .7s ease;}
+/* Content must remain present when the page is captured, printed, or restored
+   from scroll position. The old hidden-by-default reveal made whole sections
+   look empty until an IntersectionObserver happened to run. */
+.rise{opacity:1;transform:none;}
 .rise.in{opacity:1;transform:none;}
 
 /* ---------- HERO ---------- */
-.hero{padding:128px 0 100px;position:relative;overflow:hidden;text-align:center;}
+.hero{padding:88px 0 72px;position:relative;overflow:hidden;text-align:center;}
 .hero::before{content:"";position:absolute;inset:0;z-index:-1;
   background:
     radial-gradient(70% 55% at 50% -10%,color-mix(in srgb,var(--frost) 13%,transparent),transparent 60%);}
@@ -169,6 +171,12 @@ h1.title .cold{color:var(--frost);}
 
 /* ---------- NAVIGATION SECTION (the index) ---------- */
 .navsec{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.navsec > .wrap > .rise:first-child,
+.phil > .wrap > .rise:first-child,
+.install > .wrap > .rise:first-child{max-width:720px;margin-left:auto;margin-right:auto;text-align:center;}
+.navsec > .wrap > .rise:first-child .lead,
+.phil > .wrap > .rise:first-child .lead,
+.install > .wrap > .rise:first-child .lead{margin-left:auto;margin-right:auto;}
 
 /* hand-drawn comparison: wandering grep path vs. a straight two-hop find→gs path */
 .flow-figure{margin-top:48px;}
@@ -361,8 +369,8 @@ h1.title .cold{color:var(--frost);}
 .article-card p{margin-top:12px;color:var(--muted);font-size:14.5px;}
 
 /* ---------- INSTALL ---------- */
-.install-term{max-width:760px;margin-top:44px;}
-.install .cta{justify-content:flex-start;margin-top:30px;}
+.install-term{max-width:760px;margin:44px auto 0;}
+.install .cta{justify-content:center;margin-top:30px;}
 .install-langs{margin-top:26px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
 
 /* ---------- FOOTER ---------- */


### PR DESCRIPTION
## What changed
- Fix the mobile hamburger icon by stacking its three bars vertically.
- Update the menu button label as it opens and closes for accessibility.
- Reduce hero vertical padding so the CTA is not pushed below the viewport.
- Center the major landing-page section introductions and install content.
- Keep revealed content visible for reliable full-page captures and restored scroll states.

## Root cause
The hamburger button used flex layout without `flex-direction: column`, causing the bars to render horizontally. The landing page also used oversized hero spacing and inconsistent intro alignment.

## Validation
- `npm run build` passes.
- Verified the rendered local page at `http://localhost:4321/`.
- Verified SSH authentication to GitHub and pushed the branch.