### PR TITLE
site: how-it-works pages for the notebook loop and the index

### DIFF
--- a/site-astro/src/components/Footer.astro
+++ b/site-astro/src/components/Footer.astro
@@ -1,10 +1,11 @@
 ---
-interface Props { variant?: 'home' | 'docs' | 'blog' }
+interface Props { variant?: 'home' | 'docs' | 'blog' | 'how' }
 const { variant = 'docs' } = Astro.props;
 const taglines = {
   home: 'codebase memory for coding agents · MIT',
   docs: 'docs · MIT',
   blog: 'blog · MIT',
+  how: 'how it works · MIT',
 };
 const tagline = taglines[variant];
 ---

--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -1,5 +1,5 @@
 ---
-interface Props { variant?: 'home' | 'docs' | 'blog' }
+interface Props { variant?: 'home' | 'docs' | 'blog' | 'how' }
 const { variant = 'docs' } = Astro.props;
 const installHref = variant === 'home' ? '#install' : '/#install';
 ---

--- a/site-astro/src/pages/docs.astro
+++ b/site-astro/src/pages/docs.astro
@@ -196,7 +196,7 @@ const techArticleJsonLd = {
 
       <h4 class="subhead">Why it can be trusted</h4>
       <ul class="tight">
-        <li><b>Freshness is mechanical.</b> Every anchor is stamped with a content hash at write time; the index re-checks it as the code changes. A drifted note renders <span class="pill changed"><span class="d"></span>evidence changed</span> and the guidance says re-verify — stale knowledge degrades into a labeled hypothesis, not a confident lie.</li>
+        <li><b>Freshness is mechanical.</b> Every anchor is stamped with a content hash at write time and re-checked against the live file on every read, so a drifted note renders <span class="pill changed"><span class="d"></span>evidence changed</span> instead of passing as fact. <a href="/how-it-works/notebook/" style="color:var(--frost)">What happens when a file changes, moves, or is deleted →</a></li>
         <li><b>The log is the truth.</b> Notes live in an append-only <code>.raw</code> event log; the Markdown notes are derived and regenerated mechanically. A note is a pure fold of its log.</li>
         <li><b>Writes go through a gate.</b> A new note's concept is searched against existing notes first — the agent must merge into a match or declare it new. Duplicates are caught at write time.</li>
         <li><b>Concurrent sessions are safe.</b> Per-note append-only logs, exclusive creation of new ids, lossless union-merge of shared notes, atomic renders — concurrent writers never silently merge or lose a note.</li>

--- a/site-astro/src/pages/how-it-works/navigation.astro
+++ b/site-astro/src/pages/how-it-works/navigation.astro
@@ -1,0 +1,236 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/how.css';
+import '../../styles/backdrop.css';
+
+const title = 'How the navigation layer works — an exact map, no embeddings | coldstart';
+const description =
+  'How coldstart answers "where does this live?" without a model call: a small exact map of paths, symbols, imports and calls, kept current in the background, queried with two lookups — find and gs.';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'How the coldstart navigation layer works',
+  description,
+  url: 'https://coldstartmcp.dev/how-it-works/navigation/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: { '@type': 'Organization', name: 'coldstart' },
+  about: 'Code navigation for AI coding agents',
+  proficiencyLevel: 'Beginner',
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title={title}
+    description={description}
+    keywords="code navigation, codebase index, find files, call graph, import graph, no embeddings, AI coding agents, coldstart, find, gs"
+    canonicalPath="/how-it-works/navigation/"
+    ogType="article"
+    ogTitle="How the navigation layer works — an exact map, no embeddings"
+    ogDescription="A small exact map of paths, symbols, imports and calls, kept current in the background, queried with two lookups. No embeddings, no API key, no waiting."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="how-page">
+<SvgDefs />
+<Nav variant="how" />
+
+<!-- ===================== HERO ===================== -->
+<header class="how-hero">
+  <div class="wrap">
+    <div class="how-eyebrow">The navigation layer · how it works</div>
+    <h1>Finding the right file shouldn't cost a <span class="cold">model call.</span></h1>
+    <p class="lead">
+      coldstart keeps a small, exact map of your repository — what exists, what it's called, and
+      what points at what — and answers <b>"where does this live?"</b> straight from that map. No
+      embeddings, no network, no waiting for a reply.
+    </p>
+    <a class="how-back" href="/#flow">← back to the navigation layer</a>
+  </div>
+</header>
+
+<!-- ===================== THE TEMPERATURE LINE ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Two kinds of question. Only one is worth answering in advance.</h2>
+      <p>
+        Everything coldstart does follows from where it draws this line — and the line is the whole
+        design.
+      </p>
+    </div>
+
+    <!-- SIGNATURE FIGURE: the seam between what's kept exact and what's left to the model -->
+    <div class="temp-fig">
+      <div class="temp-seam" aria-hidden="true"></div>
+
+      <div class="temp-col cold">
+        <div class="temp-kick">Kept exact</div>
+        <h3>Facts with one right answer</h3>
+        <p>
+          These don't depend on what you're working on, so they're cheap to store and instant to
+          look up. coldstart keeps them, and keeps them current.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">what files exist</div>
+          <div class="temp-item">what they're named</div>
+          <div class="temp-item">what each one declares</div>
+          <div class="temp-item">what imports what</div>
+          <div class="temp-item">what calls what</div>
+        </div>
+      </div>
+
+      <div class="temp-col warm">
+        <div class="temp-kick">Left to the model</div>
+        <h3>Answers that depend on the task</h3>
+        <p>
+          These need judgement about the job in hand — and the thing asking is already a frontier
+          model. Deciding meaning ahead of time just makes a worse, staler copy of it.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">what this code means</div>
+          <div class="temp-item">whether it's the right approach</div>
+          <div class="temp-item">which of these actually matters here</div>
+          <div class="temp-item">what to change</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="temp-verdict rv">
+      That's why there's no vector database, no generated summaries, and no API key to paste.
+      <b>The semantic layer is the agent.</b> coldstart's job is to put the right files in front of
+      it, exactly and instantly, and then stay out of the way.
+    </div>
+  </div>
+</section>
+
+<!-- ===================== THE TWO LOOKUPS ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Two lookups instead of a search party.</h2>
+      <p>
+        The usual failure mode isn't that an agent can't read code — it's that it opens three wrong
+        files first. The map turns that into one narrowing question, then one confirming one.
+      </p>
+    </div>
+
+    <div class="zoom">
+      <div class="zpan rv">
+        <div class="zpan-k">The map</div>
+        <div class="zpan-t">Everything, by name</div>
+        <div class="zbody">
+          every file path<br>
+          every symbol it declares<br>
+          every export<br>
+          <span class="hit">every import edge</span><br>
+          <span class="hit">every call edge</span>
+        </div>
+        <div class="zpan-foot">
+          Built once when you install, then patched in the background as you type. There's no index
+          command in your workflow.
+        </div>
+      </div>
+
+      <div class="zpan rv rv-d1">
+        <div class="zpan-k">Lookup one</div>
+        <div class="zpan-t"><code>find</code> — which files is this about?</div>
+        <div class="zbody">
+          <span class="hit">▸ src/auth/session.ts</span> <span class="dim">[3/3]</span><br>
+          <span class="dim">&nbsp;&nbsp;defines</span> signCookie, verify<br>
+          <span class="hit">▸ src/routes/login.ts</span> <span class="dim">[2/3]</span><br>
+          <span class="dim">&nbsp;&nbsp;imports</span> signCookie<br>
+          <span class="hit">▸ src/middleware/auth.ts</span> <span class="dim">[2/3]</span><br>
+          <span class="dim">&nbsp;&nbsp;imports</span> verify
+        </div>
+        <div class="zpan-foot">
+          You throw in every identifier you half-remember. It ranks files by how many of them are
+          really there — and says whether each file <i>defines</i> the term or only <i>imports</i>
+          it, so the top result is usually the answer.
+        </div>
+      </div>
+
+      <div class="zpan rv rv-d2">
+        <div class="zpan-k">Lookup two</div>
+        <div class="zpan-t"><code>gs</code> — what is this file, and who uses it?</div>
+        <div class="zbody">
+          <span class="warm">src/auth/session.ts</span><br>
+          &nbsp;&nbsp;signCookie<span class="dim">&nbsp;&nbsp;&nbsp;&nbsp;12–38</span><br>
+          &nbsp;&nbsp;verify<span class="dim">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;40–71</span><br>
+          &nbsp;&nbsp;rotateSecret<span class="dim">&nbsp;&nbsp;73–96</span><br>
+          <span class="dim">imported by</span><br>
+          &nbsp;&nbsp;routes/login.ts<br>
+          &nbsp;&nbsp;middleware/auth.ts
+        </div>
+        <div class="zpan-foot">
+          One file's shape: its symbols with line ranges, who imports it, who calls each one. This
+          is the real answer to "who uses this?" — not a grep for a name you might be spelling
+          differently.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== ALWAYS CURRENT ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Current without being thought about.</h2>
+      <p>
+        A background process watches the repository and patches the map as you edit, so an agent
+        querying it sees the code you have right now, not the code you had at install time.
+        Switching branches reconciles in a few seconds. You never re-run anything, and there's
+        nothing to keep in sync by hand.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== CLOSE ===================== -->
+<section class="how-close">
+  <div class="wrap">
+    <div class="rv">
+      <h2>It works from the first lookup.</h2>
+      <p>
+        Unlike memory, navigation needs no warm-up — the map is built at install and useful
+        immediately.
+      </p>
+      <div class="how-cmds">npm install -g @cstart/coldstart<br><span>coldstart init</span></div>
+      <div class="how-next">
+        <a class="primary" href="/docs/">Read the docs</a>
+        <a class="ghost" href="/how-it-works/notebook/">How the notebook works →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<Footer variant="how" />
+
+<script>
+  (function () {
+    var els = document.querySelectorAll('.rv, .ring-fig, .temp-fig');
+    if (!('IntersectionObserver' in window)) {
+      els.forEach(function (el) { el.classList.add('in'); });
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
+    els.forEach(function (el) { io.observe(el); });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/how-it-works/notebook.astro
+++ b/site-astro/src/pages/how-it-works/notebook.astro
@@ -1,0 +1,310 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/how.css';
+import '../../styles/backdrop.css';
+
+const title = 'How the notebook works — codebase memory that checks itself | coldstart';
+const description =
+  'The notebook loop, explained: an agent writes down what it learned, the note is anchored to the exact code it came from, and that code is re-checked on every read — so a note that goes stale says so instead of lying.';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'How the coldstart notebook works',
+  description,
+  url: 'https://coldstartmcp.dev/how-it-works/notebook/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: { '@type': 'Organization', name: 'coldstart' },
+  about: 'Codebase memory for AI coding agents',
+  proficiencyLevel: 'Beginner',
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title={title}
+    description={description}
+    keywords="codebase memory, notebook, agent memory, stale notes, note freshness, content hash, persistent memory, AI coding agents, coldstart"
+    canonicalPath="/how-it-works/notebook/"
+    ogType="article"
+    ogTitle="How the notebook works — codebase memory that checks itself"
+    ogDescription="An agent writes down what it learned. The note is anchored to the exact code it came from, and re-checked on every read — so a stale note says so instead of lying."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="how-page">
+<SvgDefs />
+<Nav variant="how" />
+
+<!-- ===================== HERO ===================== -->
+<header class="how-hero">
+  <div class="wrap">
+    <div class="how-eyebrow warm">The notebook · how it works</div>
+    <h1>One agent works it out. The next one <em>doesn't have to.</em></h1>
+    <p class="lead">
+      That only holds if the note is still true. So here is the whole loop — how a note gets
+      written, what ties it to the code it came from, and <b>exactly what happens to it when that
+      code changes underneath.</b>
+    </p>
+    <a class="how-back" href="/#notebook">← back to the notebook</a>
+  </div>
+</header>
+
+<!-- ===================== THE LOOP ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Four things happen, in a circle.</h2>
+      <p>
+        None of them is a chore you have to remember. An agent writes what it learned, the note is
+        pinned to the evidence, the evidence is re-checked on every read, and the note comes back
+        when it's relevant.
+      </p>
+    </div>
+
+    <!-- SIGNATURE FIGURE: the ring -->
+    <div class="ring-fig">
+      <svg class="ring-svg" viewBox="106 62 548 476" role="img" aria-labelledby="ringTitle ringDesc">
+        <title id="ringTitle">The notebook loop</title>
+        <desc id="ringDesc">
+          A closed cycle of four stations — learn, anchor, check, recall — drawn around a note card
+          stamped as verified. The note produced by one task is checked and handed to the next.
+        </desc>
+        <defs>
+          <linearGradient id="loopGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#4fbfe0"/>
+            <stop offset="50%" stop-color="#8fa2b8"/>
+            <stop offset="100%" stop-color="#ef9448"/>
+          </linearGradient>
+        </defs>
+
+        <circle class="ring-track" cx="380" cy="300" r="170"/>
+        <circle class="ring-draw" cx="380" cy="300" r="170" pathLength="1000" filter="url(#rough)"/>
+
+        <g class="ring-chev" filter="url(#rough)">
+          <path d="M-7,-7 L0,0 L-7,7" transform="translate(500.2,179.8) rotate(45)"/>
+          <path d="M-7,-7 L0,0 L-7,7" transform="translate(500.2,420.2) rotate(135)"/>
+          <path d="M-7,-7 L0,0 L-7,7" transform="translate(259.8,420.2) rotate(225)"/>
+          <path d="M-7,-7 L0,0 L-7,7" transform="translate(259.8,179.8) rotate(315)"/>
+        </g>
+
+        <!-- the note in the middle: what the loop is protecting -->
+        <g class="ring-card">
+          <rect class="paper" x="284" y="240" width="192" height="120" rx="4"/>
+          <text class="t" x="298" y="268">src/models.py · Tile</text>
+          <line class="rule" x1="298" y1="288" x2="396" y2="288"/>
+          <line class="rule" x1="298" y1="308" x2="378" y2="308"/>
+          <line class="rule" x1="298" y1="328" x2="392" y2="328"/>
+          <g transform="rotate(-11 428 306)">
+            <g filter="url(#rough)">
+              <circle class="stamp" cx="428" cy="306" r="31"/>
+              <circle class="stamp" cx="428" cy="306" r="25"/>
+            </g>
+            <text class="stamp-t" x="428" y="311" text-anchor="middle">FRESH</text>
+          </g>
+        </g>
+
+        <g class="ring-node s1">
+          <circle cx="380" cy="130" r="26"/>
+          <text class="n" x="380" y="135" text-anchor="middle">01</text>
+          <text class="lbl" x="380" y="88" text-anchor="middle">LEARN</text>
+        </g>
+        <g class="ring-node s2">
+          <circle cx="550" cy="300" r="26"/>
+          <text class="n" x="550" y="305" text-anchor="middle">02</text>
+          <text class="lbl" x="588" y="305" text-anchor="start">ANCHOR</text>
+        </g>
+        <g class="ring-node s3 warm">
+          <circle cx="380" cy="470" r="26"/>
+          <text class="n" x="380" y="475" text-anchor="middle">03</text>
+          <text class="lbl" x="380" y="524" text-anchor="middle">CHECK</text>
+        </g>
+        <g class="ring-node s4 warm">
+          <circle cx="210" cy="300" r="26"/>
+          <text class="n" x="210" y="305" text-anchor="middle">04</text>
+          <text class="lbl" x="172" y="305" text-anchor="end">RECALL</text>
+        </g>
+      </svg>
+    </div>
+
+    <div class="loop-list">
+      <div class="beat rv">
+        <div class="beat-n">01</div>
+        <div>
+          <h3>An agent finishes a real task, and writes down what it cost to understand.</h3>
+          <p>
+            Not what the code <i>is</i> — you can read that. The part worth keeping is what wasn't
+            written anywhere: that this function is the only safe write path, that these two files
+            always change together, that the helper you'd expect to exist doesn't.
+          </p>
+        </div>
+      </div>
+      <div class="beat rv">
+        <div class="beat-n">02</div>
+        <div>
+          <h3>The note is pinned to the exact code it came from.</h3>
+          <p>
+            It names the files and symbols it's about, and records <b>a fingerprint of each one as
+            it looked at that moment.</b> A note is never a floating opinion — it's a claim with an
+            address and a snapshot of what it was true about.
+          </p>
+        </div>
+      </div>
+      <div class="beat warm rv">
+        <div class="beat-n">03</div>
+        <div>
+          <h3>Every read re-takes the fingerprint.</h3>
+          <p>
+            Nothing is trusted from memory. Before a note is shown to anyone, the files it points at
+            are read <b>as they are right now</b> and compared against the snapshot. That one
+            comparison is the entire freshness system — there is nothing else to configure, and no
+            expiry date to guess at.
+          </p>
+        </div>
+      </div>
+      <div class="beat warm rv">
+        <div class="beat-n">04</div>
+        <div>
+          <h3>The note comes back on its own, before anyone starts searching.</h3>
+          <p>
+            When a later prompt is about that code, the note is handed to the agent up front —
+            carrying the result of the check with it, so the agent knows how far to trust it before
+            it acts on it.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="loop-close rv">
+      And the agent that just used a note is the one best placed to fix it — it has the files open.
+      A note that turns out to be wrong gets corrected in that same session, which is step one
+      again. <b>There's no maintenance step, because the maintenance is the loop.</b>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== WHEN THE CODE MOVES ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>A note about code is a note about a moving target.</h2>
+      <p>
+        So: what happens when the file changes, gets renamed, or disappears entirely? The
+        fingerprint from step two is what makes that answer mechanical instead of hopeful. Four
+        outcomes, re-decided from scratch every time the note is read.
+      </p>
+    </div>
+
+    <div class="state-grid">
+      <div class="state ok rv">
+        <div class="state-when">The file is untouched</div>
+        <div class="state-tag">[fresh]</div>
+        <h3>Nothing to re-check</h3>
+        <p>
+          Byte-for-byte what it was when the note was written. An agent can act on it without
+          opening the file at all — which is the whole point.
+        </p>
+      </div>
+
+      <div class="state warn rv rv-d1">
+        <div class="state-when">The file changed</div>
+        <div class="state-tag">[evidence changed]</div>
+        <h3>Demoted to a hypothesis</h3>
+        <p>
+          The note still appears — it's probably still mostly right — but labelled, with an
+          instruction to re-verify it against the file first. It never quietly keeps its authority
+          after the ground moved.
+        </p>
+      </div>
+
+      <div class="state move rv rv-d2">
+        <div class="state-when">The file was renamed or moved</div>
+        <div class="state-tag">[moved → src/new/path.py]</div>
+        <h3>The note follows the file</h3>
+        <p>
+          A rename isn't a deletion. If the content at the new path still matches the fingerprint,
+          the note travels with it — a refactor that shuffles your tree doesn't cost you the
+          notebook.
+        </p>
+      </div>
+
+      <div class="state gone rv rv-d3">
+        <div class="state-when">The file is gone</div>
+        <div class="state-tag">[anchor missing]</div>
+        <h3>The note goes quiet</h3>
+        <p>
+          Deleted — or simply not on this branch. A note whose files have all vanished stops
+          presenting itself as a description of live code, and returns by itself when the files do.
+          Switching branches rewrites nothing.
+        </p>
+      </div>
+    </div>
+
+    <div class="state-note rv">
+      <span class="mk">→</span>
+      <span>
+        Notice what's <i>not</i> in that list: a judgement call. <b>Every one of these is a
+        comparison, not an opinion</b> — which is why it can run on every read, in any language,
+        without a model call and without slowing anything down. A note never silently rots here. It
+        loses confidence out loud.
+      </span>
+    </div>
+
+    <div class="how-aside rv">
+      <h3>One repo, one corpus</h3>
+      <p>
+        The notebook is plain files in your repository. Commit it and the whole team's agents read
+        and write the same body of knowledge — two people writing about the same file on different
+        branches both keep their notes, and the merge combines them instead of picking a winner.
+        Private by default; sharing is opt-in.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== CLOSE ===================== -->
+<section class="how-close">
+  <div class="wrap">
+    <div class="rv">
+      <h2>It starts empty and warms with use.</h2>
+      <p>
+        The first few real tasks seed the notes. Nothing to import, nothing to write by hand — two
+        commands and the loop starts turning.
+      </p>
+      <div class="how-cmds">npm install -g @cstart/coldstart<br><span>coldstart init</span></div>
+      <div class="how-next">
+        <a class="primary" href="/docs/">Read the docs</a>
+        <a class="ghost" href="/how-it-works/navigation/">How the navigation layer works →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<Footer variant="how" />
+
+<script>
+  (function () {
+    var els = document.querySelectorAll('.rv, .ring-fig, .temp-fig');
+    if (!('IntersectionObserver' in window)) {
+      els.forEach(function (el) { el.classList.add('in'); });
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
+    els.forEach(function (el) { io.observe(el); });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/index.astro
+++ b/site-astro/src/pages/index.astro
@@ -156,7 +156,7 @@ const faqJsonLd = {
       <p>Commit the notebook to your repo and the whole team feeds one corpus — union-merged across branches, no conflicts. Private by default; opt in with <code>coldstart init --commit-notebook</code>.</p>
     </div>
 
-    <a class="how-link warm" href="/how-it-works/notebook/">How the notebook loop works <span class="ar" aria-hidden="true">→</span></a>
+    <a class="how-link warm" href="/how-it-works/notebook/">How the notebook works <span class="ar" aria-hidden="true">→</span></a>
   </div>
 </section>
 

--- a/site-astro/src/pages/index.astro
+++ b/site-astro/src/pages/index.astro
@@ -44,6 +44,10 @@ const faqs = [
     q: 'What is the coldstart notebook?',
     a: 'The notebook is a durable set of notes the agent writes itself while it works, so what one session figures out about your codebase the next session already knows. Notes are anchored to real files and symbols and kept honest by the index, so they are flagged when the code they describe changes.',
   },
+  {
+    q: 'What happens to a note when the code changes, or the file is renamed or deleted?',
+    a: 'Every note records a fingerprint of the exact files it describes, and that fingerprint is re-checked against the live file every time the note is read. If nothing changed, the note reads `[fresh]` and can be used without re-opening the file. If the file changed, it is labelled `[evidence changed]` and the agent is told to re-verify before relying on it. If the file was renamed or moved, the note follows it as long as the content still matches. If the file is gone — deleted, or simply not on the branch you are on — the note goes quiet, and comes back by itself if the files do. None of this is a judgement call, so it runs on every read, in any language, with no model call.',
+  },
 ];
 
 const faqJsonLd = {
@@ -151,6 +155,8 @@ const faqJsonLd = {
       <span class="kk">Shared, it compounds</span>
       <p>Commit the notebook to your repo and the whole team feeds one corpus — union-merged across branches, no conflicts. Private by default; opt in with <code>coldstart init --commit-notebook</code>.</p>
     </div>
+
+    <a class="how-link warm" href="/how-it-works/notebook/">How the notebook loop works <span class="ar" aria-hidden="true">→</span></a>
   </div>
 </section>
 
@@ -228,6 +234,8 @@ const faqJsonLd = {
       <span class="kk">Measured, not promised</span>
       <p><b>−64% tokens on Arches</b> (Python/Django), <b>−31% on JMRI</b> (Java) — head-to-head against a no-tool baseline on real applications, recall equal or better in both. <a href="/blog/why-most-token-savings-tools-lie/">How we measured it →</a></p>
     </div>
+
+    <a class="how-link" href="/how-it-works/navigation/">How the index works <span class="ar" aria-hidden="true">→</span></a>
   </div>
 </section>
 

--- a/site-astro/src/styles/how.css
+++ b/site-astro/src/styles/how.css
@@ -1,0 +1,297 @@
+/* ============================================================
+   coldstart — how-it-works pages (notebook + navigation)
+   Rides docs.css for tokens and nav/footer chrome. Everything
+   here is scoped under body.how-page so it can never leak into
+   docs or blog, which share that stylesheet.
+
+   temperature = concept, same as the rest of the site:
+   frost = the cold exact index, ember = the warm memory.
+   ============================================================ */
+
+body.how-page {
+  --paper: #e5d9bd;
+  --paper-ink: #2a2620;
+  --paper-line: #c7b790;
+  --faint: #5d6b83;
+  --ember-dim: #a86a35;
+}
+
+/* ---------- shared scroll reveal ---------- */
+.how-page .rv { opacity: 0; transform: translateY(14px); transition: opacity .6s ease, transform .6s cubic-bezier(.2, .7, .3, 1); }
+.how-page .rv.in { opacity: 1; transform: none; }
+.how-page .rv-d1 { transition-delay: .08s; }
+.how-page .rv-d2 { transition-delay: .16s; }
+.how-page .rv-d3 { transition-delay: .24s; }
+
+/* ---------- hero ---------- */
+/* ONE content column for the whole page — hero, sections and close share the
+   same left edge. Measure is limited per-element, never by re-narrowing .wrap,
+   which is what put three different left margins down the page. */
+.how-page .wrap { max-width: 940px; }
+
+.how-hero { padding: 76px 0 8px; }
+.how-hero h1, .how-hero .lead { max-width: 780px; }
+/* matches .kicker in docs.css — the site's one label convention, no leading rule */
+.how-eyebrow {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--frost); margin-bottom: 16px;
+}
+.how-eyebrow.warm { color: var(--ember); }
+.how-hero h1 {
+  font-family: var(--display); font-weight: 400;
+  font-size: clamp(34px, 5.4vw, 56px); line-height: 1.1;
+  letter-spacing: -.02em; margin-bottom: 22px;
+}
+.how-hero h1 em { font-style: italic; color: var(--ember); }
+.how-hero h1 .cold { color: var(--frost); font-style: normal; }
+.how-lead { font-size: clamp(17px, 2vw, 19.5px); color: var(--muted); max-width: 640px; }
+.how-lead b { color: var(--ink); font-weight: 500; }
+
+.how-back {
+  display: inline-flex; align-items: center; gap: 8px; margin-top: 34px;
+  font-family: var(--mono); font-size: 12.5px; color: var(--faint);
+  text-decoration: none; transition: color .15s;
+}
+.how-back:hover { color: var(--frost); }
+
+/* ---------- section frame ---------- */
+.how-sec { padding: 58px 0; border-top: 1px solid var(--line); margin-top: 34px; }
+.how-sec:first-of-type { margin-top: 30px; }
+.how-sec-head { max-width: 680px; margin-bottom: 44px; }
+.how-sec-head:last-child { margin-bottom: 0; }
+.how-sec-head h2 {
+  font-family: var(--display); font-weight: 400;
+  font-size: clamp(26px, 3.4vw, 36px); line-height: 1.18;
+  letter-spacing: -.015em; margin-bottom: 16px;
+}
+.how-sec-head p { color: var(--muted); font-size: 16.5px; }
+.how-sec-head p b { color: var(--ink); font-weight: 500; }
+
+/* ============================================================
+   SIGNATURE 1 — the loop ring (notebook page)
+   ============================================================ */
+.ring-fig { display: flex; justify-content: center; margin: 0 auto 54px; max-width: 660px; }
+.ring-svg { width: 100%; height: auto; overflow: visible; }
+
+.ring-track { stroke: var(--line); stroke-width: 1.5; fill: none; }
+.ring-draw {
+  stroke: url(#loopGrad); stroke-width: 2.4; fill: none; stroke-linecap: round;
+  stroke-dasharray: 1000; stroke-dashoffset: 1000;
+  transition: stroke-dashoffset 1.9s cubic-bezier(.35, .1, .25, 1);
+}
+.ring-fig.in .ring-draw { stroke-dashoffset: 0; }
+
+.ring-node circle { fill: var(--bg); stroke: var(--frost); stroke-width: 1.8; }
+.ring-node.warm circle { stroke: var(--ember); }
+.ring-node text.n { font-family: var(--mono); font-size: 13px; font-weight: 700; fill: var(--frost); }
+.ring-node.warm text.n { fill: var(--ember); }
+.ring-node text.lbl {
+  font-family: var(--mono); font-size: 14px; font-weight: 500; fill: var(--ink);
+  letter-spacing: .04em;
+}
+.ring-node { opacity: 0; transition: opacity .5s ease; }
+.ring-fig.in .ring-node { opacity: 1; }
+.ring-fig.in .ring-node.s1 { transition-delay: .25s; }
+.ring-fig.in .ring-node.s2 { transition-delay: .70s; }
+.ring-fig.in .ring-node.s3 { transition-delay: 1.15s; }
+.ring-fig.in .ring-node.s4 { transition-delay: 1.60s; }
+
+.ring-chev { stroke: var(--faint); stroke-width: 1.6; fill: none; stroke-linecap: round; stroke-linejoin: round; opacity: 0; transition: opacity .5s ease .9s; }
+.ring-fig.in .ring-chev { opacity: .75; }
+
+.ring-card { opacity: 0; transform: scale(.94); transform-origin: 380px 300px; transition: opacity .6s ease 1.9s, transform .6s cubic-bezier(.2, .8, .3, 1) 1.9s; }
+.ring-fig.in .ring-card { opacity: 1; transform: none; }
+.ring-card .paper { fill: var(--paper); }
+.ring-card .rule { stroke: var(--paper-line); stroke-width: 1.2; }
+.ring-card .t { font-family: var(--mono); font-size: 11.5px; fill: var(--paper-ink); }
+.ring-card .stamp { fill: none; stroke: var(--ember-dim); stroke-width: 2.2; }
+.ring-card .stamp-t { font-family: var(--mono); font-size: 13px; font-weight: 700; fill: var(--ember-dim); letter-spacing: .06em; }
+
+/* the four beats, spelled out under the ring */
+.loop-list { display: grid; gap: 2px; counter-reset: beat; }
+.beat {
+  display: grid; grid-template-columns: 54px 1fr; gap: 20px;
+  padding: 26px 0; border-top: 1px solid var(--line);
+}
+.beat:last-child { border-bottom: 1px solid var(--line); }
+.beat-n {
+  font-family: var(--mono); font-size: 12px; font-weight: 700;
+  color: var(--frost); padding-top: 3px; letter-spacing: .06em;
+}
+.beat.warm .beat-n { color: var(--ember); }
+.beat h3 { font-family: var(--sans); font-size: 17px; font-weight: 600; margin-bottom: 8px; }
+.beat p { color: var(--muted); font-size: 15.5px; }
+.beat p b { color: var(--ink); font-weight: 500; }
+.beat code {
+  font-size: 13px; background: var(--surface); border: 1px solid var(--line);
+  border-radius: 5px; padding: 1px 6px; color: var(--frost);
+}
+
+.loop-close {
+  margin-top: 34px; padding: 22px 26px; border-radius: 12px;
+  border: 1px solid var(--line-warm); background: linear-gradient(180deg, rgba(239, 148, 72, .06), transparent);
+  font-size: 16px; color: var(--muted);
+}
+.loop-close b { color: var(--ember); font-weight: 500; }
+
+/* ============================================================
+   the four states — what happens when the code moves
+   ============================================================ */
+.state-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+.state {
+  border: 1px solid var(--line); border-radius: 12px; padding: 22px 24px 24px;
+  background: var(--surface-2); position: relative; overflow: hidden;
+}
+.state::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
+  background: var(--accent, var(--faint));
+}
+.state.ok { --accent: var(--ok); }
+.state.warn { --accent: var(--ember); }
+.state.move { --accent: var(--frost); }
+.state.gone { --accent: var(--faint); }
+
+.state-when {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--faint); margin-bottom: 14px;
+}
+.state-tag {
+  display: inline-block; font-family: var(--mono); font-size: 13px;
+  padding: 5px 11px; border-radius: 6px; margin-bottom: 14px;
+  color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  word-break: break-word;
+}
+.state h3 { font-size: 16px; font-weight: 600; margin-bottom: 8px; }
+.state p { color: var(--muted); font-size: 15px; }
+
+.state-note {
+  margin-top: 26px; display: flex; gap: 16px; align-items: flex-start;
+  padding: 20px 24px; border: 1px dashed var(--line); border-radius: 12px;
+  color: var(--muted); font-size: 15.5px;
+}
+.state-note .mk { font-family: var(--mono); color: var(--frost); flex: none; font-size: 13px; padding-top: 2px; }
+.state-note b { color: var(--ink); font-weight: 500; }
+
+/* a secondary point that doesn't earn a whole section */
+.how-aside { margin-top: 40px; padding-top: 30px; border-top: 1px solid var(--line); max-width: 680px; }
+.how-aside h3 { font-family: var(--display); font-weight: 400; font-size: 21px; letter-spacing: -.01em; margin-bottom: 10px; }
+.how-aside p { color: var(--muted); font-size: 15.5px; }
+
+/* ============================================================
+   SIGNATURE 2 — the temperature seam (navigation page)
+   ============================================================ */
+.temp-fig {
+  position: relative; display: grid; grid-template-columns: 1fr 1fr;
+  gap: 0; margin-bottom: 34px; align-items: stretch;
+  border: 1px solid var(--line); border-radius: 14px; overflow: hidden;
+}
+.temp-col { padding: 28px 30px 30px; display: flex; flex-direction: column; }
+.temp-col.cold { background: linear-gradient(160deg, color-mix(in srgb, var(--frost) 6%, transparent), transparent 62%); }
+.temp-col.warm { background: linear-gradient(200deg, color-mix(in srgb, var(--ember) 6%, transparent), transparent 62%); }
+.temp-kick {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em;
+  text-transform: uppercase; margin-bottom: 6px;
+}
+.temp-col.cold .temp-kick { color: var(--frost); }
+.temp-col.warm .temp-kick { color: var(--ember); }
+.temp-col h3 { font-family: var(--display); font-weight: 400; font-size: 22px; margin-bottom: 8px; letter-spacing: -.01em; }
+.temp-col > p { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
+.temp-items { display: grid; gap: 9px; align-content: start; }
+.temp-item {
+  font-family: var(--mono); font-size: 13.5px; padding: 10px 14px; border-radius: 8px;
+  border: 1px solid var(--line); background: var(--surface-2); color: var(--ink);
+  opacity: 0; transform: translateX(-8px); transition: opacity .45s ease, transform .45s ease;
+}
+.temp-col.warm .temp-item { transform: translateX(8px); border-color: var(--line-warm); }
+.temp-fig.in .temp-item { opacity: 1; transform: none; }
+.temp-fig.in .temp-item:nth-child(1) { transition-delay: .10s; }
+.temp-fig.in .temp-item:nth-child(2) { transition-delay: .20s; }
+.temp-fig.in .temp-item:nth-child(3) { transition-delay: .30s; }
+.temp-fig.in .temp-item:nth-child(4) { transition-delay: .40s; }
+.temp-fig.in .temp-item:nth-child(5) { transition-delay: .50s; }
+
+/* the line the whole design is drawn on — one crisp hairline, frost to ember,
+   wiped in on scroll. A rough/wavy stroke at this scale read as a scratch. */
+.temp-seam {
+  position: absolute; left: 50%; top: 0; bottom: 0; width: 1px;
+  transform: translateX(-50%); pointer-events: none;
+  background: linear-gradient(180deg, var(--frost), var(--ember));
+  transform-origin: top; scale: 1 0;
+  transition: scale 1.1s cubic-bezier(.35, .1, .25, 1);
+}
+.temp-fig.in .temp-seam { scale: 1 1; }
+
+.temp-verdict {
+  padding: 22px 26px; border-radius: 12px; border: 1px solid var(--line);
+  background: var(--surface-2); font-size: 16px; color: var(--muted);
+}
+.temp-verdict b { color: var(--ink); font-weight: 500; }
+
+/* ============================================================
+   the zoom strip — repo → find → gs
+   ============================================================ */
+.zoom { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; align-items: stretch; }
+.zpan {
+  border: 1px solid var(--line); border-radius: 12px; background: var(--term-bg);
+  padding: 18px 20px 20px; display: flex; flex-direction: column;
+}
+.zpan-k {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--faint); margin-bottom: 4px;
+}
+.zpan-t { font-size: 15px; font-weight: 600; margin-bottom: 14px; }
+.zbody { font-family: var(--mono); font-size: 12.5px; line-height: 1.85; color: var(--term-ink); }
+.zbody .dim { color: var(--faint); }
+.zbody .hit { color: var(--frost); }
+.zbody .warm { color: var(--ember); }
+.zpan-foot { margin-top: auto; padding-top: 16px; color: var(--muted); font-size: 14px; }
+
+/* ---------- closing CTA ---------- */
+.how-close { padding: 66px 0 90px; border-top: 1px solid var(--line); margin-top: 34px; }
+.how-close p, .how-close .how-cmds { max-width: 680px; }
+.how-close h2 { font-family: var(--display); font-weight: 400; font-size: clamp(26px, 3.4vw, 34px); margin-bottom: 14px; letter-spacing: -.015em; }
+.how-close p { color: var(--muted); font-size: 16.5px; margin-bottom: 28px; }
+.how-cmds {
+  font-family: var(--mono); font-size: 14px; background: var(--term-bg);
+  border: 1px solid var(--line); border-radius: 10px; padding: 18px 22px;
+  color: var(--term-ink); margin-bottom: 28px; overflow-x: auto;
+}
+.how-cmds span { color: var(--frost); }
+.how-next { display: flex; gap: 12px; flex-wrap: wrap; }
+.how-next a {
+  font-family: var(--mono); font-size: 13.5px; padding: 11px 20px; border-radius: 8px;
+  text-decoration: none; transition: opacity .15s, border-color .15s, color .15s;
+}
+.how-next a.primary { background: var(--frost); color: #04121a; font-weight: 600; }
+.how-next a.primary:hover { opacity: .88; }
+.how-next a.ghost { border: 1px solid var(--line); color: var(--muted); }
+.how-next a.ghost:hover { color: var(--ink); border-color: var(--frost); }
+
+/* ---------- responsive ---------- */
+@media (max-width: 820px) {
+  .how-hero { padding-top: 52px; }
+  .how-sec { padding: 56px 0; margin-top: 44px; }
+  .state-grid { grid-template-columns: 1fr; }
+  .zoom { grid-template-columns: 1fr; }
+  .temp-fig { grid-template-columns: 1fr; gap: 8px; }
+  .temp-col, .temp-col.cold, .temp-col.warm { padding: 24px 22px; }
+  .temp-col.warm { border-top: 1px solid var(--line-warm); }
+  .temp-seam { display: none; }
+  .temp-col.warm .temp-item, .temp-col.cold .temp-item { transform: translateY(8px); }
+  .temp-fig.in .temp-item { transform: none; }
+  .beat { grid-template-columns: 40px 1fr; gap: 14px; }
+}
+
+/* ---------- motion opt-out ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .how-page .rv,
+  .how-page .rv.in { opacity: 1; transform: none; transition: none; }
+  .ring-draw, .ring-fig.in .ring-draw { stroke-dashoffset: 0; transition: none; }
+  .ring-node, .ring-chev, .ring-card,
+  .ring-fig.in .ring-node, .ring-fig.in .ring-chev, .ring-fig.in .ring-card {
+    opacity: 1; transform: none; transition: none;
+  }
+  .temp-item, .temp-fig.in .temp-item { opacity: 1; transform: none; transition: none; }
+  .temp-seam path, .temp-fig.in .temp-seam path { stroke-dashoffset: 0; transition: none; }
+}

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -224,9 +224,8 @@ h1.title .cold{color:var(--frost);}
 
 /* the exhibit: what step three actually produces, pulled out and shown */
 .nb-exhibit{margin:44px auto 0;max-width:560px;width:100%;text-align:left;}
-.nb-exhibit-label{display:flex;align-items:center;gap:11px;margin-bottom:18px;
+.nb-exhibit-label{display:flex;align-items:center;margin-bottom:18px;
   font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--faint);}
-.nb-exhibit-label::before{content:"";width:26px;height:1px;background:var(--ember-dim);flex:none;}
 
 /* note card — paper, not chrome: it's a page from the notebook, not another dark panel */
 .card{border:1px solid var(--paper-line);border-radius:4px;background:var(--paper);color:var(--paper-ink);
@@ -418,3 +417,24 @@ footer{border-top:1px solid var(--line);padding:50px 0;}
   .cursor{display:none;}
 }
 :focus-visible{outline:2px solid var(--frost);outline-offset:2px;border-radius:4px;}
+
+/* ---------- how-it-works entry points (below notebook + navigation) ----------
+   A small centred link-button, not a panel: it's a side door out of the section,
+   so it must read as clickable without competing with the section's own content. */
+/* Raised, not recessed: on a dark ground a darker fill reads as a hole, so the
+   affordance comes from a slight lift + border. Tinted per section so it sits
+   correctly on both the warm (notebook) and cool (index) grounds. */
+.how-link{
+  display:flex;align-items:center;gap:9px;width:max-content;margin:34px auto 0;
+  padding:9px 17px;border:1px solid var(--line);border-radius:999px;
+  background:rgba(255,255,255,.045);
+  font-family:var(--mono);font-size:13px;color:var(--muted);text-decoration:none;
+  transition:color .16s,border-color .16s,background .16s;
+}
+.how-link.warm{border-color:var(--line-warm);background:rgba(255,214,170,.055);}
+.how-link:hover{color:var(--text);background:rgba(255,255,255,.085);border-color:var(--frost);}
+.how-link.warm:hover{background:rgba(255,214,170,.1);border-color:var(--ember);}
+.how-link .ar{flex:none;transition:transform .16s,color .16s;}
+.how-link:hover .ar{transform:translateX(3px);color:var(--frost);}
+.how-link.warm:hover .ar{color:var(--ember);}
+.how-link:focus-visible{outline:2px solid var(--frost);outline-offset:3px;}

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -421,19 +421,32 @@ footer{border-top:1px solid var(--line);padding:50px 0;}
 /* ---------- how-it-works entry points (below notebook + navigation) ----------
    A small centred link-button, not a panel: it's a side door out of the section,
    so it must read as clickable without competing with the section's own content. */
-/* Raised, not recessed: on a dark ground a darker fill reads as a hole, so the
-   affordance comes from a slight lift + border. Tinted per section so it sits
-   correctly on both the warm (notebook) and cool (index) grounds. */
+/* Solid dark chip at rest, lifting on hover. The fill is OPAQUE and darker than
+   the section ground it sits on (warm variant darker than --warm-ground, cool
+   darker than --ink-1) so it reads as a distinct control rather than an outline;
+   full-strength text keeps it from looking faded. Hover raises the fill and warms
+   the border — a real state change, not a wash. */
 .how-link{
   display:flex;align-items:center;gap:9px;width:max-content;margin:34px auto 0;
-  padding:9px 17px;border:1px solid var(--line);border-radius:999px;
-  background:rgba(255,255,255,.045);
-  font-family:var(--mono);font-size:13px;color:var(--muted);text-decoration:none;
+  padding:10px 19px;border-radius:999px;
+  border:1px solid color-mix(in srgb,var(--frost) 32%,transparent);
+  background:color-mix(in srgb,var(--frost) 13%,var(--void));
+  box-shadow:0 1px 0 rgba(255,255,255,.05) inset, 0 6px 18px -10px rgba(0,0,0,.9);
+  font-family:var(--mono);font-size:13px;color:#b7e6f5;text-decoration:none;
   transition:color .16s,border-color .16s,background .16s;
 }
-.how-link.warm{border-color:var(--line-warm);background:rgba(255,214,170,.055);}
-.how-link:hover{color:var(--text);background:rgba(255,255,255,.085);border-color:var(--frost);}
-.how-link.warm:hover{background:rgba(255,214,170,.1);border-color:var(--ember);}
+.how-link:hover{
+  background:color-mix(in srgb,var(--frost) 22%,var(--void));
+  border-color:color-mix(in srgb,var(--frost) 62%,transparent);color:#fff;
+}
+.how-link.warm{
+  border-color:color-mix(in srgb,var(--ember) 34%,transparent);
+  background:color-mix(in srgb,var(--ember) 14%,#0b0806);color:#ffcfa4;
+}
+.how-link.warm:hover{
+  background:color-mix(in srgb,var(--ember) 23%,#0b0806);
+  border-color:color-mix(in srgb,var(--ember) 64%,transparent);color:#fff;
+}
 .how-link .ar{flex:none;transition:transform .16s,color .16s;}
 .how-link:hover .ar{transform:translateX(3px);color:var(--frost);}
 .how-link.warm:hover .ar{color:var(--ember);}


### PR DESCRIPTION
## Why

The site never said what happens to a note when the code it describes changes. The entire freshness story was **one sentence** on the home page — "the background keeper flags it the moment the code moves" — plus one bullet in the docs.

That left the question people actually ask unanswered: *what about a rename, or a deleted file?* The behaviour for those cases already exists and is good (`stampAnchors` in `src/kb/freshness.ts` resolves five states, including following a byte-identical file to its new path), but none of it was public.

A cold read of the live home page — an agent given the page and no product context — rated the write → store → keep-accurate → inject-back loop **6/10**, and named staleness as the missing link: *"'Flags it' → then what? It's like saying 'the smoke detector alerts you when there's smoke' without saying what you should do about it."*

## What

Two concept-level pages. Car-engine altitude — what the pieces do and why they connect, not the internals.

**`/how-it-works/notebook/`** — the loop as four beats (learn → anchor → check → recall) around a drawn-on-scroll ring, then the four outcomes when the code moves:

| Situation | Shows as | Meaning |
|---|---|---|
| Untouched | `[fresh]` | Use it without re-opening the file |
| Changed | `[evidence changed]` | Demoted to a hypothesis, re-verify first |
| Renamed / moved | `[moved → new/path]` | Content still matches, note follows the file |
| Gone | `[anchor missing]` | Note goes quiet; returns on its own if the files do |

**`/how-it-works/navigation/`** — what the index keeps exact vs what it leaves to the model, then `find` / `gs`.

### Also

- Home page: a small centred link into each page, below the notebook and navigation sections
- Home page: a sixth FAQ covering the staleness question
- Docs: thinned the freshness bullet, which now links to the notebook page
- `landing.css`: dropped the decorative rule before `.nb-exhibit-label`
- `Nav`/`Footer`: a `how` variant, so neither Docs nor Blog highlights on these pages

## Verification

Rendered in a browser rather than reviewed as CSS — which caught three things reading the markup would not have: an illegible stamp on the ring's note card, a seam that read as a stray scratch, and a file grid that looked like a loading skeleton.

- 1440px and 390px: no horizontal overflow on either page
- Left edges measured — all seven content blocks land on one column
- Ring symmetry measured: left/right gaps 15/15, top/bottom 14/12, ring centre = card centre = column centre
- FAQ: 6 `FAQPage` entries, **every question present in the rendered body** (the past defect this FAQ block exists to fix), backticks stripped from the JSON-LD
- `npm run build` clean

**Not verified:** the `prefers-reduced-motion` block covers every animated selector by inspection, but the devtools CLI has no toggle for it, so it was not exercised in a browser.

## Follow-up, not in this PR

No nav entry — these are reachable from the home page and the docs only. Per discussion, a Resources dropdown grouping guides is the better home for them once there are more pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)