### PR TITLE
site: add /how-it-works/ section index

### DIFF
--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -12,6 +12,7 @@ const installHref = variant === 'home' ? '#install' : '/#install';
     </a>
     <span class="nav-spacer"></span>
     <div class="nav-links">
+      <a href="/how-it-works/" class={variant === 'how' ? 'active' : ''}>How it works</a>
       <a href="/docs/" class={variant === 'docs' ? 'active' : ''}>Docs</a>
       <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
       <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
@@ -23,6 +24,7 @@ const installHref = variant === 'home' ? '#install' : '/#install';
     </button>
   </div>
   <div class="nav-mobile" id="nav-mobile">
+    <a href="/how-it-works/" class={variant === 'how' ? 'active' : ''}>How it works</a>
     <a href="/docs/" class={variant === 'docs' ? 'active' : ''}>Docs</a>
     <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
     <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>

--- a/site-astro/src/pages/how-it-works/index.astro
+++ b/site-astro/src/pages/how-it-works/index.astro
@@ -1,0 +1,257 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/how.css';
+import '../../styles/backdrop.css';
+
+const title = 'How coldstart works — codebase memory for AI coding agents | coldstart';
+const description =
+  'How coldstart gives a coding agent memory of your codebase: durable notes anchored to the code they came from and re-checked on every read, over an exact index of paths, symbols and calls. Two layers, explained end to end.';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'How coldstart works',
+  description,
+  url: 'https://coldstartmcp.dev/how-it-works/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: { '@type': 'Organization', name: 'coldstart' },
+  about: 'Codebase memory for AI coding agents',
+  proficiencyLevel: 'Beginner',
+  hasPart: [
+    {
+      '@type': 'TechArticle',
+      headline: 'How the coldstart notebook works',
+      url: 'https://coldstartmcp.dev/how-it-works/notebook/',
+    },
+    {
+      '@type': 'TechArticle',
+      headline: 'How the coldstart navigation layer works',
+      url: 'https://coldstartmcp.dev/how-it-works/navigation/',
+    },
+  ],
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title={title}
+    description={description}
+    keywords="codebase memory, how it works, agent memory, codebase index, note freshness, no embeddings, AI coding agents, coldstart"
+    canonicalPath="/how-it-works/"
+    ogType="article"
+    ogTitle="How coldstart works — codebase memory for AI coding agents"
+    ogDescription="Durable notes anchored to the code they came from and re-checked on every read, over an exact index of paths, symbols and calls. Two layers, explained end to end."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="how-page how-index">
+<SvgDefs />
+<Nav variant="how" />
+
+<!-- ===================== HERO ===================== -->
+<header class="how-hero">
+  <div class="wrap">
+    <div class="how-eyebrow">How it works</div>
+    <h1>An agent that has <em>been here before</em> shouldn't start from <span class="cold">nothing.</span></h1>
+    <p class="lead">
+      coldstart is <b>codebase memory</b>: what an agent worked out about your code, written down at
+      the moment it worked it out, and checked against the code again every time it's read. Underneath
+      it sits an exact index, so an agent can still find the file no one has left a note on.
+    </p>
+    <a class="how-back" href="/">← back to the overview</a>
+  </div>
+</header>
+
+<!-- ===================== THE TWO LAYERS ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Two layers, and only one of them is memory.</h2>
+      <p>
+        The index is a fact about the repository as it exists right now. The notebook is a fact about
+        what someone <b>learned</b> here that reading the file wouldn't tell you. They're built
+        differently because they expire differently.
+      </p>
+    </div>
+
+    <div class="temp-fig">
+      <div class="temp-seam"></div>
+
+      <!-- the whole panel is the link: the thing that explains IS the thing you click,
+           so there is no separate button to aim at -->
+      <a class="temp-col warm how-card" href="/how-it-works/notebook/">
+        <div class="temp-kick">The notebook</div>
+        <h3>Memory of this codebase</h3>
+        <p>
+          Notes written by the agent that did the reading — anchored to a file, often a symbol, and
+          stamped against the exact bytes it verified.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">written during the task, not after</div>
+          <div class="temp-item">addressed to a file and symbol</div>
+          <div class="temp-item">re-surfaced when the next agent needs it</div>
+          <div class="temp-item">re-checked on every read</div>
+          <div class="temp-item">says [fresh] or flags itself stale</div>
+        </div>
+        <span class="how-card-go">How the notebook works <span class="ar" aria-hidden="true">→</span></span>
+      </a>
+
+      <a class="temp-col cold how-card" href="/how-it-works/navigation/">
+        <div class="temp-kick">The navigation layer</div>
+        <h3>An exact map, no embeddings</h3>
+        <p>
+          Paths, symbol names, imports and calls, parsed and kept current in the background. Queried
+          with two lookups, answered without a model call.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">find — which files match these terms</div>
+          <div class="temp-item">gs — one file's shape and its callers</div>
+          <div class="temp-item">ranked on checkable evidence</div>
+          <div class="temp-item">no embeddings, no API key</div>
+          <div class="temp-item">useful from the first lookup</div>
+        </div>
+        <span class="how-card-go">How navigation works <span class="ar" aria-hidden="true">→</span></span>
+      </a>
+    </div>
+
+    <div class="temp-verdict rv">
+      <b>Why they can't share a design.</b> The index can be rebuilt from the repository at any
+      moment, so it is never wrong for long — a wrong entry is a bug. A note can't be rebuilt from
+      anything; the reasoning that produced it is gone the moment the session ends. So a note that
+      goes wrong stays wrong, silently, and gets acted on as fact. That asymmetry is the whole reason
+      the notebook carries freshness machinery and the index doesn't need any.
+    </div>
+
+  </div>
+</section>
+
+<!-- ===================== THE HANDOFF ===================== -->
+<!-- the one thing neither child page can show: each covers its own layer, so the
+     point where they hand off to each other only exists here -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>The index is how the memory gets found.</h2>
+      <p>
+        They aren't alternatives you pick between. Notes are addressed to files, so <b>the index is
+        what retrieves them</b> — one lookup returns the ranked files and whatever is already known
+        about those same files, together.
+      </p>
+    </div>
+
+    <div class="flow-tiles rv">
+      <div class="flow-tile">
+        <div class="k">On the code</div>
+        <h3>The ranking comes first</h3>
+        <p>
+          Filenames, path segments, exported symbols and a repo-wide reference scan — <code>find</code>
+          ranks each file by how many of your terms it covers, and shows the evidence for the
+          ranking. This runs whether or not a single note exists.
+        </p>
+      </div>
+
+      <div class="flow-tile warm">
+        <div class="k">Same result</div>
+        <h3>The note rides along</h3>
+        <p>
+          Any ranked file that has one carries a <code>Summary:</code> line against the result
+          itself, right where you're deciding whether to open it. Marked <code>[fresh]</code>, the
+          file is byte-identical to when it was verified.
+        </p>
+      </div>
+
+      <div class="flow-tile">
+        <div class="k">Your call</div>
+        <h3>The next move is yours</h3>
+        <p>
+          Open the file with <code>gs</code> if the note made it interesting. Open the note itself
+          for per-symbol detail and the flows through it. Or go straight to the code — most files
+          have no note, and the ranking alone was enough.
+        </p>
+      </div>
+    </div>
+
+    <div class="loop-close rv">
+      <b>Which is why the memory has to be addressed to code.</b> A note anchored to a file is
+      reachable by the same lookup that finds the file. A note filed under a topic or a similarity
+      score is something you'd have to go and search for separately — and an agent mid-task won't.
+    </div>
+  </div>
+</section>
+
+<!-- ===================== CLOSE ===================== -->
+<section class="how-close">
+  <div class="wrap">
+    <div class="rv">
+      <h2>Both layers install in one command.</h2>
+      <p>
+        <code>init</code> writes the agent guidance, wires your client, and builds the index. The
+        notebook starts empty and fills itself as agents work.
+      </p>
+      <div class="how-cmds has-copy">
+        <button type="button" class="copy-btn" data-copy="npm install -g @cstart/coldstart&#10;coldstart init" aria-label="Copy install commands">Copy</button>
+        npm install -g @cstart/coldstart<br><span>coldstart init</span>
+      </div>
+      <div class="how-next">
+        <a class="primary" href="/docs/">Read the docs</a>
+        <a class="ghost" href="/blog/">Engineering blog →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<Footer variant="how" />
+
+<script>
+  // same contract as the homepage copy buttons: data-copy holds the literal text,
+  // clipboard API with an execCommand fallback for non-secure contexts
+  (function () {
+    document.querySelectorAll('.copy-btn[data-copy]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var text = btn.getAttribute('data-copy') || '';
+        function done() {
+          btn.classList.add('copied');
+          btn.textContent = 'Copied';
+          setTimeout(function () { btn.classList.remove('copied'); btn.textContent = 'Copy'; }, 1600);
+        }
+        if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {});
+          return;
+        }
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); done(); } catch (e) {}
+        document.body.removeChild(ta);
+      });
+    });
+  })();
+
+  (function () {
+    var els = document.querySelectorAll('.rv, .ring-fig, .temp-fig');
+    if (!('IntersectionObserver' in window)) {
+      els.forEach(function (el) { el.classList.add('in'); });
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
+    els.forEach(function (el) { io.observe(el); });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/how-it-works/navigation.astro
+++ b/site-astro/src/pages/how-it-works/navigation.astro
@@ -55,7 +55,7 @@ const jsonLd = {
       what points at what — and answers <b>"where does this live?"</b> straight from that map. No
       embeddings, no network, no waiting for a reply.
     </p>
-    <a class="how-back" href="/#flow">← back to the navigation layer</a>
+    <a class="how-back" href="/how-it-works/">← how it works</a>
   </div>
 </header>
 

--- a/site-astro/src/pages/how-it-works/notebook.astro
+++ b/site-astro/src/pages/how-it-works/notebook.astro
@@ -55,7 +55,7 @@ const jsonLd = {
       written, what ties it to the code it came from, and <b>exactly what happens to it when that
       code changes underneath.</b>
     </p>
-    <a class="how-back" href="/#notebook">← back to the notebook</a>
+    <a class="how-back" href="/how-it-works/">← how it works</a>
   </div>
 </header>
 

--- a/site-astro/src/styles/how.css
+++ b/site-astro/src/styles/how.css
@@ -247,6 +247,73 @@ body.how-page {
 .zbody .warm { color: var(--ember); }
 .zpan-foot { margin-top: auto; padding-top: 16px; color: var(--muted); font-size: 14px; }
 
+/* ============================================================
+   INDEX PAGE — reuses the temperature seam as the two-layer
+   chooser. Scoped to .how-index so the child pages' own use of
+   .temp-fig is untouched.
+   ============================================================ */
+/* Each column is an <a>, not a panel with a button in it. text-decoration and
+   colour have to be reset because .temp-col was never a link. */
+.how-index .how-card { text-decoration: none; color: inherit; position: relative; transition: background .2s; }
+.how-index .how-card.warm:hover { background: linear-gradient(160deg, color-mix(in srgb, var(--ember) 11%, transparent), transparent 68%); }
+.how-index .how-card.cold:hover { background: linear-gradient(160deg, color-mix(in srgb, var(--frost) 11%, transparent), transparent 68%); }
+
+/* Card footer. The hairline is what stops the label reading as text that floats
+   after the list; margin-top:auto pins it to a shared baseline across columns
+   even when one has more content than the other. */
+.how-card-go {
+  margin-top: auto; padding-top: 20px;
+  border-top: 1px solid var(--line);
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  font-family: var(--mono); font-size: 12.5px; color: var(--faint);
+  transition: color .2s, border-color .2s;
+}
+.how-card-go .ar { font-size: 14px; transition: transform .2s; }
+.how-index .how-card:hover .how-card-go .ar { transform: translateX(4px); }
+.how-index .how-card.warm:hover .how-card-go { color: var(--ember); border-top-color: var(--line-warm); }
+.how-index .how-card.cold:hover .how-card-go { color: var(--frost); border-top-color: color-mix(in srgb, var(--frost) 35%, transparent); }
+/* keyboard parity with hover — the card is a real tab stop */
+.how-index .how-card:focus-visible { outline: 2px solid var(--frost); outline-offset: -2px; }
+
+/* Three tiles instead of a hairline-ruled list: same bordered-card language as
+   .state (notebook page) and .zpan (navigation page), with the left accent bar
+   carrying the temperature — frost for the index steps, ember for the note. */
+.how-index .flow-tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.how-index .flow-tile {
+  border: 1px solid var(--line); border-radius: 12px; background: var(--surface-2);
+  padding: 24px 24px 26px; position: relative; overflow: hidden;
+}
+.how-index .flow-tile::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--frost);
+}
+.how-index .flow-tile.warm { border-color: var(--line-warm); }
+.how-index .flow-tile.warm::before { background: var(--ember); }
+.how-index .flow-tile .k {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--faint); margin-bottom: 14px;
+}
+.how-index .flow-tile h3 { font-family: var(--sans); font-size: 16px; font-weight: 600; margin-bottom: 10px; }
+.how-index .flow-tile p { color: var(--muted); font-size: 15px; }
+.how-index .flow-tile code {
+  font-size: 13px; background: var(--surface); border: 1px solid var(--line);
+  border-radius: 5px; padding: 1px 6px; color: var(--frost);
+}
+.how-index .loop-close { margin-top: 22px; }
+@media (max-width: 820px) {
+  .how-index .flow-tiles { grid-template-columns: 1fr; }
+}
+
+.how-index .temp-verdict { margin-top: 30px; }
+.how-index .temp-verdict i { font-style: italic; color: var(--ink); }
+/* warm reads first here, so it leads on desktop and stacks first on mobile */
+.how-index .temp-fig { align-items: stretch; }
+/* the stacked divider belongs on whichever column is SECOND — here that's cold,
+   not warm, so the base rule would draw it against the figure's own top border */
+@media (max-width: 820px) {
+  .how-index .temp-col.warm { border-top: 0; }
+  .how-index .temp-col.cold { border-top: 1px solid var(--line); }
+}
+
 /* ---------- closing CTA ---------- */
 .how-close { padding: 66px 0 90px; border-top: 1px solid var(--line); margin-top: 34px; }
 .how-close p, .how-close .how-cmds { max-width: 680px; }
@@ -258,6 +325,19 @@ body.how-page {
   color: var(--term-ink); margin-bottom: 28px; overflow-x: auto;
 }
 .how-cmds span { color: var(--frost); }
+/* copy button — how pages ride docs.css, not landing.css, so .copy-btn has to be
+   redeclared here rather than inherited from the homepage */
+.how-page .how-cmds.has-copy { position: relative; padding-right: 84px; }
+.how-page .copy-btn {
+  position: absolute; top: 12px; right: 12px;
+  font-family: var(--mono); font-size: 11px; color: #8aa0bd; cursor: pointer;
+  background: rgba(255, 255, 255, .04); border: 1px solid var(--line);
+  border-radius: 6px; padding: 5px 10px;
+  transition: color .15s, background .15s, border-color .15s;
+}
+.how-page .copy-btn:hover { color: #eef3fb; background: rgba(255, 255, 255, .08); border-color: rgba(255, 255, 255, .16); }
+.how-page .copy-btn.copied { color: #4fd18b; border-color: rgba(79, 209, 139, .4); background: rgba(79, 209, 139, .08); }
+
 .how-next { display: flex; gap: 12px; flex-wrap: wrap; }
 .how-next a {
   font-family: var(--mono); font-size: 13.5px; padding: 11px 20px; border-radius: 8px;


### PR DESCRIPTION
`/how-it-works/` 404'd — only the two child pages existed, and nothing linked to a section landing page because there wasn't one.

## Why the page earns its place

Each child page covers a single layer, and the homepage presents the two sequentially. **The point where they meet exists nowhere else on the site.** Two sections carry that:

- a side-by-side comparison of the two layers, which the homepage structurally can't give (it presents them one after the other)
- how a single `find` lookup returns ranked files *together with* the notes attached to those same files — the notebook lane is path-keyed, so the index is what retrieves the memory

## Changes

- **New** `src/pages/how-it-works/index.astro` — `TechArticle` JSON-LD with `hasPart` pointing at both children
- **Nav** — `How it works` as the first link, desktop and mobile. The homepage's per-section deep links to the children are left alone, so the two entry paths don't compete: Nav for "explain this from the top", homepage section for "more on *this*"
- **Interaction** — the two-layer figure is one `<a>` per column rather than a panel with a button in it, with a bordered footer carrying the affordance
- **Child pages** — back-links now point at the section index instead of homepage anchors (one line each)
- All new CSS is scoped under `.how-index`; the child pages' own use of `.temp-fig` / `.beat` is untouched

## Deliberately not on the homepage

The comparison card presents the two layers as visually co-equal, which is exactly the framing #144 removed from the category slots. The homepage stays memory-led with navigation second.

## Verification

- `npm run build` clean, 16 pages; `sitemap-0.xml` picks up all three `/how-it-works/` routes
- Rendered and checked at 1440px, 1000px (nav crowding with the fifth link — no crowding, `npm` stays), and 390px
- Left/right edges measured rather than eyeballed: section lead and tile bodies both `274–954`; all three tile headings 26px tall with bodies starting at the same y
- Copy button functionally tested — fires, shows `Copied`, reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)