### PR TITLE
site: stamp real <lastmod> dates on sitemap entries

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: the sitemap's <lastmod> comes from each source file's
+          # last commit date, which a shallow clone cannot provide.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/site-astro/astro.config.mjs
+++ b/site-astro/astro.config.mjs
@@ -1,11 +1,80 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
+
+// Map a built route back to the source file it renders from, so <lastmod> can be
+// the file's real last-commit date instead of the build time. Blog posts point at
+// their markdown, not at [slug].astro — editing the template shouldn't restamp
+// every post as "changed".
+function sourceFileForRoute(pathname) {
+  const segments = pathname.split('/').filter(Boolean);
+
+  if (segments[0] === 'blog' && segments.length === 2) {
+    return join('src', 'content', 'blog', `${segments[1]}.md`);
+  }
+
+  const base = join('src', 'pages', ...segments);
+  for (const candidate of [`${base}.astro`, join(base, 'index.astro')]) {
+    if (existsSync(join(projectRoot, candidate))) return candidate;
+  }
+  return null;
+}
+
+// A shallow clone (actions/checkout's default) answers `git log -1` for EVERY file
+// with the single commit it has, so per-file dates come back uniform and wrong
+// rather than empty. Detect that up front and emit no lastmod at all — a wrong
+// lastmod on every URL teaches Google to ignore the field entirely.
+const historyUsable = (() => {
+  try {
+    const shallow = execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (shallow !== 'false') {
+      console.warn('[sitemap] shallow git clone — omitting <lastmod>; set fetch-depth: 0');
+      return false;
+    }
+    return true;
+  } catch {
+    console.warn('[sitemap] no git history available — omitting <lastmod>');
+    return false;
+  }
+})();
+
+// Empty when the file is untracked. Omit lastmod rather than substitute the build
+// date, for the same reason as above.
+function lastCommitDate(relPath) {
+  try {
+    const out = execFileSync('git', ['log', '-1', '--format=%cI', '--', relPath], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
 
 export default defineConfig({
   site: 'https://coldstartmcp.dev',
   integrations: [
     tailwind({ applyBaseStyles: false }),
-    sitemap(),
+    sitemap({
+      serialize(item) {
+        if (!historyUsable) return item;
+        const source = sourceFileForRoute(new URL(item.url).pathname);
+        const committed = source && lastCommitDate(source);
+        if (committed) item.lastmod = committed;
+        return item;
+      },
+    }),
   ],
 });


### PR DESCRIPTION
## What

The generated sitemap carried only `<loc>` for all 16 URLs — no `<lastmod>` anywhere. That's the field Google uses to decide whether a known URL is worth recrawling, and right now `/docs/` plus three blog posts are sitting in *Crawled – currently not indexed* after being rewritten on Aug 8. Google had no signal that anything changed.

Adds a `serialize()` hook to the `@astrojs/sitemap` integration that maps each route back to its source file and stamps that file's last commit date.

## The part worth reviewing

The dates come from git history, which the deploy workflow **did not have**. `actions/checkout` defaults to a shallow clone, and `git log -1` there does *not* fail — it returns the clone's single commit date for every path. The first version of this passed local builds perfectly and would have stamped all 16 URLs with one identical wrong timestamp in CI.

So the fix is two halves that have to travel together:

- `fetch-depth: 0` in `pages.yml` — load-bearing, not an optimisation
- a `git rev-parse --is-shallow-repository` guard in `astro.config.mjs` that emits **no** `lastmod` when history is unusable

A wrong `lastmod` on every URL is worse than none — it teaches Google to ignore the field.

## Verification

| Build | Result |
|---|---|
| Full clone | 16/16 stamped, 5 distinct dates, cross-checked against `git log` |
| Shallow clone | 0 stamped + `[sitemap] shallow git clone — omitting <lastmod>` |

Blog posts resolve to their markdown in `src/content/blog/`, not `[slug].astro`, so editing the post template doesn't restamp all ten posts as changed. Shared chrome (Nav/Footer/Head) likewise doesn't propagate.

Failure mode is safe: if `serialize()` ever threw, the build fails, `deploy-pages` never runs, and the live site is untouched.

Post-deploy check: `curl -s https://coldstartmcp.dev/sitemap-0.xml | grep -c lastmod` → `16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)