### PR TITLE
site: split docs into 4 pages, fix nav consistency, add notebook mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 scripts/probe-output/
 
 # Internal design/research docs — kept locally, not tracked
-docs/
+/docs/
 .coldstart/

--- a/site-astro/src/components/DocsSidebar.astro
+++ b/site-astro/src/components/DocsSidebar.astro
@@ -1,0 +1,68 @@
+---
+interface Props { active: 'getting-started' | 'navigation' | 'notebook' | 'under-the-hood' }
+const { active } = Astro.props;
+
+const groups = [
+  {
+    id: 'getting-started', label: 'Getting started', href: '/docs/',
+    anchors: [
+      { href: '#overview', label: 'Overview' },
+      { href: '#install', label: 'Install & setup' },
+      { href: '#flow', label: 'The intended flow' },
+    ],
+  },
+  {
+    id: 'navigation', label: 'Navigation', href: '/docs/navigation/',
+    anchors: [
+      { href: '#find', label: 'find', code: true },
+      { href: '#gs', label: 'gs', code: true },
+    ],
+  },
+  {
+    id: 'notebook', label: 'Notebook', href: '/docs/notebook/',
+    anchors: [
+      { href: '#notebook', label: 'The notebook, in depth' },
+      { href: '#kb-search', label: 'kb search', code: true },
+      { href: '#kb-lookup', label: 'kb lookup', code: true },
+      { href: '#kb-write', label: 'kb write', code: true },
+      { href: '#kb-commit', label: 'kb commit', code: true },
+      { href: '#kb-view', label: 'kb view', code: true },
+      { href: '#kb-maint', label: 'kb status / lint / repair / render', code: true },
+      { href: '#sharing', label: 'Sharing with a team' },
+    ],
+  },
+  {
+    id: 'under-the-hood', label: 'Under the hood', href: '/docs/under-the-hood/',
+    anchors: [
+      { href: '#freshness', label: 'How the index stays fresh' },
+      { href: '#lifecycle', label: 'Lifecycle commands' },
+      { href: '#mcp', label: 'MCP tools' },
+      { href: '#semantics', label: 'Bring your own semantics' },
+      { href: '#languages', label: 'Supported languages' },
+    ],
+  },
+];
+---
+<aside class="side">
+  <button class="side-toggle" id="sideToggle" type="button" aria-expanded="false" aria-controls="sideList">
+    <span class="chev" aria-hidden="true">&rsaquo;</span> Menu
+  </button>
+  <div class="side-list" id="sideList">
+    {groups.map((g) => (
+      <div class="side-group">
+        <a href={g.href} class={`gh gh-link${active === g.id ? ' active' : ''}`}>{g.label}</a>
+        {active === g.id && (
+          <>
+            {g.anchors.map((a) => (
+              <a href={a.href}>{a.code ? <code>{a.label}</code> : a.label}</a>
+            ))}
+          </>
+        )}
+      </div>
+    ))}
+  </div>
+</aside>
+<style>
+.gh-link { display: block; text-decoration: none; transition: color .12s; background: none; border-left-color: transparent; }
+.gh-link:hover, .gh-link.active { color: var(--frost); opacity: 1; background: none; border-left-color: transparent; }
+</style>

--- a/site-astro/src/components/Nav.astro
+++ b/site-astro/src/components/Nav.astro
@@ -1,7 +1,6 @@
 ---
 interface Props { variant?: 'home' | 'docs' | 'blog' | 'how' }
 const { variant = 'docs' } = Astro.props;
-const installHref = variant === 'home' ? '#install' : '/#install';
 ---
 <div class="progress" id="prog"></div>
 <nav>
@@ -15,10 +14,11 @@ const installHref = variant === 'home' ? '#install' : '/#install';
       <a href="/how-it-works/" class={variant === 'how' ? 'active' : ''}>How it works</a>
       <a href="/docs/" class={variant === 'docs' ? 'active' : ''}>Docs</a>
       <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
-      <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
+      <a href="https://github.com/AkashGoenka/coldstart" class="nav-icon" aria-label="GitHub">
+        <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      </a>
       <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
     </div>
-    <a class="nav-cta" href={installHref}>Install</a>
     <button type="button" class="nav-burger" id="nav-burger" aria-label="Open menu" aria-expanded="false" aria-controls="nav-mobile">
       <span></span><span></span><span></span>
     </button>
@@ -29,9 +29,11 @@ const installHref = variant === 'home' ? '#install' : '/#install';
     <a href="/blog/" class={variant === 'blog' ? 'active' : ''}>Blog</a>
     <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>
     <a href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
-    <a class="nav-cta" href={installHref}>Install →</a>
   </div>
 </nav>
+<style>
+.nav-links a.nav-icon{display:inline-flex;align-items:center;}
+</style>
 <script>
 (function(){
   var prog = document.getElementById('prog');

--- a/site-astro/src/content/blog/why-coldstart-makes-zero-llm-calls.md
+++ b/site-astro/src/content/blog/why-coldstart-makes-zero-llm-calls.md
@@ -62,7 +62,7 @@ The determinism problem is quieter but I think it matters more for a tool an age
 
 Files already declare their own identity. A filename, the segments of its path, the names it exports. Most of the time, the thing you're looking for is named close to what you'd call it, because someone wrote that name for exactly the reason you're now searching for it: so the next person reading the codebase could find it. coldstart ranks files by how many of your query terms they actually cover, using that declared identity plus a real repo-wide grep pass, backed by ripgrep where it's available, git grep where it isn't.
 
-This is a worse tool than embeddings for a genuinely fuzzy conceptual query, one where nothing in your vocabulary overlaps with anything in the file. I don't think that's a gap worth pretending away. If you want that kind of retrieval, point an embedding-based tool at the same repo. coldstart isn't trying to be the same thing done differently, it's trying to be exact where exactness is available, and honest about the rest.
+This is a worse tool than embeddings for a genuinely fuzzy conceptual query, one where nothing in your vocabulary overlaps with anything in the file. I don't think that's a gap worth pretending away. If you want that kind of retrieval, point an embedding-based tool at the same repo. coldstart isn't trying to be the same thing done differently, it's trying to be exact where exactness is available, and honest about the rest. ([More on where that line actually falls.](/vs/vector-rag/))
 
 ## Why the tradeoff wins for the common case
 

--- a/site-astro/src/pages/docs.astro
+++ b/site-astro/src/pages/docs.astro
@@ -3,6 +3,7 @@ import Head from '../layouts/Head.astro';
 import SvgDefs from '../components/SvgDefs.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import DocsSidebar from '../components/DocsSidebar.astro';
 import '../styles/tailwind.css';
 import '../styles/docs.css';
 import '../styles/backdrop.css';
@@ -43,49 +44,13 @@ const techArticleJsonLd = {
 <Nav variant="docs" />
 
 <div class="docs">
-  <aside class="side">
-    <button class="side-toggle" id="sideToggle" type="button" aria-expanded="false" aria-controls="sideList">
-      <span class="chev" aria-hidden="true">&rsaquo;</span> Menu
-    </button>
-    <div class="side-list" id="sideList">
-    <div class="side-group">
-      <div class="gh">Getting started</div>
-      <a href="#overview">Overview</a>
-      <a href="#install">Install &amp; setup</a>
-      <a href="#flow">The intended flow</a>
-    </div>
-    <div class="side-group">
-      <div class="gh">Navigation</div>
-      <a href="#find"><code>find</code></a>
-      <a href="#gs"><code>gs</code></a>
-    </div>
-    <div class="side-group">
-      <div class="gh">Notebook</div>
-      <a href="#notebook">The notebook, in depth</a>
-      <a href="#kb-search"><code>kb search</code></a>
-      <a href="#kb-lookup"><code>kb lookup</code></a>
-      <a href="#kb-write"><code>kb write</code></a>
-      <a href="#kb-commit"><code>kb commit</code></a>
-      <a href="#kb-view"><code>kb view</code></a>
-      <a href="#kb-maint"><code>kb status / lint / repair / render</code></a>
-      <a href="#sharing">Sharing with a team</a>
-    </div>
-    <div class="side-group">
-      <div class="gh">Under the hood</div>
-      <a href="#freshness">How the index stays fresh</a>
-      <a href="#lifecycle">Lifecycle commands</a>
-      <a href="#mcp">MCP tools</a>
-      <a href="#semantics">Bring your own semantics</a>
-      <a href="#languages">Supported languages</a>
-    </div>
-    </div>
-  </aside>
+  <DocsSidebar active="getting-started" />
 
   <main class="content">
     <section id="overview" class="doc-sec">
       <div class="kicker">Documentation</div>
       <h1>coldstart, command by command.</h1>
-      <p class="lead-p">coldstart is one binary with two front doors — a <b>CLI</b> (the fast path for any shell-capable agent) and an <b>MCP server</b> (for no-shell clients), with byte-identical output. This page covers the stable core surface; for exhaustive flags, versioned changes, and internals, see the <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">README and docs on GitHub</a> — the source of truth.</p>
+      <p class="lead-p">coldstart is one binary with two front doors — a <b>CLI</b> (the fast path for any shell-capable agent) and an <b>MCP server</b> (for no-shell clients), with byte-identical output. This page covers the stable core surface; for exhaustive flags, versioned changes, and internals, see the <a href="https://github.com/AkashGoenka/coldstart">README and docs on GitHub</a> — the source of truth.</p>
       <div class="callout"><span class="ct">The shape of it</span>Two operations answer navigation — <code>find</code> (which files?) and <code>gs</code> (what is this file, who uses it?) — and the <code>kb</code> family is the notebook: durable, agent-written notes kept honest by the index. That's the whole surface.</div>
     </section>
 
@@ -104,11 +69,13 @@ const techArticleJsonLd = {
       <div class="flags">
         <div class="flag-row"><span class="fk">--experience cli|mcp</span><span class="fv">The surface to wire. <b>cli</b> is the fast path; <b>mcp</b> also writes an MCP server entry.</span></div>
         <div class="flag-row"><span class="fk">--client NAME</span><span class="fv"><b>claude</b>, <b>cursor</b>, <b>codex</b>, or <b>other</b>. Determines which config files get wired.</span></div>
-        <div class="flag-row"><span class="fk">--commit-notebook</span><span class="fv">Opt in to committing the notebook <code>.raw</code> logs so the team can share it. Private by default — see <a href="#sharing" style="color:var(--frost)">Sharing</a>.</span></div>
+        <div class="flag-row"><span class="fk">--commit-notebook</span><span class="fv">Opt in to committing the notebook <code>.raw</code> logs so the team can share it. Private by default — see <a href="/docs/notebook/#sharing">Sharing</a>.</span></div>
       </div>
-      <p style="margin-top:20px"><b>Upgrading:</b> just <code>npm install -g @cstart/coldstart@latest</code> — that's the whole step. Each project's background keeper stamps its version in its lockfile, so the next <code>find</code>/<code>gs</code> in that repo sees the mismatch, shuts the old process down, and spawns a fresh one from the new binary; nothing to re-run per project. You only need <code>coldstart init</code> again if a node/nvm or npm-prefix change <em>moved</em> the global install and left the wired hook paths dangling — and <code>coldstart status</code> tells you exactly that (it reports the installed version, any keeper still on an older one, and any hook path that no longer resolves).</p>
-      <p style="margin-top:14px"><b>Removing:</b> <code>coldstart unwire</code> reverses <code>init</code> — it strips coldstart's per-repo wiring (hook entries, the <code>coldstart.md</code> import, the <code>AGENTS.md</code> block, the MCP entry, owned files) without touching your own content in shared files. The notebook is kept by default; <code>--purge</code> also deletes it. Run it per project, then <code>npm uninstall -g @cstart/coldstart</code>. Any keepers still running self-reap within about half a minute of the uninstall — they notice their own binary is gone and shut down — so you don't have to hunt down background processes by hand.</p>
-      <p style="margin-top:14px"><b>Codex hook trust:</b> Codex gates hooks behind a trust review, so the notebook/navigation hooks <code>init</code> writes <b>will not fire until you approve them</b> (untrusted hooks are skipped silently) — <code>init</code> cannot pre-trust them (no supported non-interactive path; see <a href="https://github.com/openai/codex/issues/21615" style="color:var(--frost)">openai/codex#21615</a>). When Codex shows <em>"Hooks need review"</em>, choose <em>"Trust all and continue"</em>. If your Codex app doesn't surface that prompt, launch <code>codex</code> from a terminal in the repo — it appears at startup there; trust persists (keyed by each hook's hash) across surfaces. Re-approve after any coldstart update changes a hook. For automated <code>codex exec</code> runs, pass <code>--dangerously-bypass-hook-trust</code> instead. Project trust (<code>trust_level = "trusted"</code> in <code>config.toml</code>) is a separate gate and does <b>not</b> trust hooks.</p>
+      <div class="flags" style="margin-top:20px">
+        <div class="flag-row"><span class="fk">Upgrading</span><span class="fv"><code>npm install -g @cstart/coldstart@latest</code> — keepers detect the version bump and restart themselves. Re-run <code>init</code> only if a node/nvm change moved the global install; <code>coldstart status</code> flags that.</span></div>
+        <div class="flag-row"><span class="fk">Removing</span><span class="fv"><code>coldstart unwire</code> strips the per-repo wiring (notebook kept by default, <code>--purge</code> deletes it), then <code>npm uninstall -g @cstart/coldstart</code>.</span></div>
+        <div class="flag-row"><span class="fk">Codex hook trust</span><span class="fv">Codex requires approving hooks once — choose <em>"Trust all and continue"</em> when prompted, or launch <code>codex</code> from a terminal if it doesn't appear. Automated runs: pass <code>--dangerously-bypass-hook-trust</code>. Details: <a href="https://github.com/openai/codex/issues/21615">openai/codex#21615</a>.</span></div>
+      </div>
     </section>
 
     <section id="flow" class="doc-sec">
@@ -121,295 +88,13 @@ const techArticleJsonLd = {
       </ul>
     </section>
 
-    <div class="grp-head"><div class="kicker">Navigation</div></div>
-
-    <section id="find" class="doc-sec">
-      <div class="cmd">
-        <div class="name"><span class="c">coldstart find</span> <span class="badge">navigation</span></div>
-        <div class="sig">coldstart find &lt;term&gt; [term…] [flags]</div>
-        <div class="desc"><b>Which files are about this?</b> Ranks files by how many of your query terms each covers — filenames, path segments, exported symbols, plus a repo-wide name-reference pass — and shows <em>why</em> each ranked: which terms it defines vs. imports.</div>
-      </div>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart find</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart find</span> auth session cookie</span>
-<span class="gap"></span>
-<span class="ln"><span class="c-frost">src/auth/service.ts</span>  <span class="c-hit">3/3</span> <span class="c-dim">defines</span> auth, session, cookie</span>
-<span class="ln">  <span class="c-ember">Summary</span> <span class="c-dim">[fresh]</span> Signs and verifies session cookies.</span>
-<span class="ln"><span class="c-frost">src/middleware/session.ts</span>  <span class="c-hit">2/3</span> <span class="c-dim">imports</span> session, cookie</span>
-        </div>
-      </div>
-      <p style="margin-top:16px">Pass <b>every salient identifier</b> from your task — the symbol, the domain noun, the rare token you half-remember — not one distilled keyword. <code>find</code> ranks by coverage and shows where the terms cluster, so often that's enough to answer without opening anything. Its reference pass runs on ripgrep, so it competes with raw grep on speed.</p>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">--path GLOB</span><span class="fv">Scope to matching paths. Comma-combine; prefix <code>!</code> to exclude.</span></div>
-        <div class="flag-row"><span class="fk">--tests</span><span class="fv">Include test files (excluded by default).</span></div>
-        <div class="flag-row"><span class="fk">--via</span><span class="fv">Show name-reference relations — where the terms are referenced, not just declared.</span></div>
-        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
-      </div>
-      <div class="callout"><span class="ct">When find says "no indexed file contains any of […]"</span>Those identifiers aren't in the repo. Don't grep spelling variants — trust the negative.</div>
-    </section>
-
-    <section id="gs" class="doc-sec">
-      <div class="cmd">
-        <div class="name"><span class="c">coldstart gs</span> <span class="badge">navigation</span></div>
-        <div class="sig">coldstart gs &lt;file&gt; [flags]</div>
-        <div class="desc"><b>What is this file, and who uses it?</b> Returns the file's top-level symbols (with line ranges), its 1-hop internal imports, who imports it, and per-symbol cross-file callers — in one call. This is the answer to "who calls this?", not a grep.</div>
-      </div>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart gs</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart gs</span> src/auth/service.ts</span>
-<span class="ln"><span class="c-dim">symbols</span>  signCookie <span class="c-dim">L12</span> · verify <span class="c-dim">L34</span> · rotate <span class="c-dim">L61</span></span>
-<span class="ln"><span class="c-dim">callers</span>  verify ← <span class="c-file">middleware/session.ts</span>, <span class="c-file">routes/login.ts</span></span>
-<span class="ln"><span class="c-dim">imported by</span>  4 files</span>
-        </div>
-      </div>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">--symbol a,b</span><span class="fv">Deliver the named method bodies inline — skip a separate Read.</span></div>
-        <div class="flag-row"><span class="fk">--match TERM</span><span class="fv">Filter a god-file to one area. <code>a|b</code> = OR, <code>/regex/</code> = regex.</span></div>
-        <div class="flag-row"><span class="fk">--view V</span><span class="fv">One of <code>symbols</code> / <code>imports</code> / <code>importers</code> / <code>callers</code>. Default returns all.</span></div>
-        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
-      </div>
-      <div class="callout"><span class="ct">Scope</span>Callers are one-hop and file-scoped. Named function/constant calls resolve cross-file; member-expression calls (<code>this.method()</code>, <code>api.method()</code>) don't. Chase further hops by running <code>gs</code> on the caller file.</div>
-    </section>
-
-    <div class="grp-head"><div class="kicker">Notebook</div></div>
-
-    <section id="notebook" class="doc-sec">
-      <h2>The notebook, in depth</h2>
-      <p class="lead-p">A repo-local knowledge base, written and read by agents, living in <code>.coldstart/notebook/</code>. It's the one place semantics belong: authored by the agent that just did the work, kept honest by the index, and recalled when a later task matches. <b>No human writes or grooms it.</b></p>
-
-      <h4 class="subhead">What a note is</h4>
-      <div class="types">
-        <div class="tcard file"><div class="tt">File note</div><p>What a file is for — a single summary, or per-symbol facets for hub files.</p></div>
-        <div class="tcard flow"><div class="tt">Flow note</div><p>A cross-file story: ordered steps and the invariants that hold across them.</p></div>
-        <div class="tcard lesson"><div class="tt">Lesson</div><p>A trap, rule, bug-cause, rationale, or a confirmed <em>absence</em>.</p></div>
-      </div>
-      <p style="margin-top:18px">Every note carries <b>anchors</b> — the concrete file paths and symbols its claims rest on. Anchors are what make a note checkable rather than a floating assertion.</p>
-
-      <h4 class="subhead">Where notes reach the agent</h4>
-      <ul class="tight">
-        <li><b>Summary lines on <code>find</code> results</b> — a past agent's verified overview, right where the file ranks. <span class="pill fresh"><span class="d"></span>fresh</span> means the file is byte-identical to when the summary was verified, so the agent can rely on it without re-reading.</li>
-        <li><b>Recall at prompt time</b> — the key one. A hook wired into Claude Code, Cursor, and Codex fires on every prompt submit: notes whose titles, aliases, or anchors match are <b>injected straight into the agent's context</b> as a compact, hard-capped block <em>before it acts</em> — the agent doesn't choose to search, the note is simply already there. Nothing matches → nothing injected, no noise.</li>
-        <li><b><code>kb search</code> / <code>kb lookup</code></b> — a search engine over the notebook, and an exact-address lookup before editing a file.</li>
-      </ul>
-
-      <h4 class="subhead">Why it can be trusted</h4>
-      <ul class="tight">
-        <li><b>Freshness is mechanical.</b> Every anchor is stamped with a content hash at write time and re-checked against the live file on every read, so a drifted note renders <span class="pill changed"><span class="d"></span>evidence changed</span> instead of passing as fact. <a href="/how-it-works/notebook/" style="color:var(--frost)">What happens when a file changes, moves, or is deleted →</a></li>
-        <li><b>The log is the truth.</b> Notes live in an append-only <code>.raw</code> event log; the Markdown notes are derived and regenerated mechanically. A note is a pure fold of its log.</li>
-        <li><b>Writes go through a gate.</b> A new note's concept is searched against existing notes first — the agent must merge into a match or declare it new. Duplicates are caught at write time.</li>
-        <li><b>Concurrent sessions are safe.</b> Per-note append-only logs, exclusive creation of new ids, lossless union-merge of shared notes, atomic renders — concurrent writers never silently merge or lose a note.</li>
-        <li><b>Corrections happen in-session.</b> An agent that finds a note wrong while the evidence is in context is told to fix or retract it right then.</li>
-      </ul>
-
-      <div class="callout warm"><span class="ct">On token savings</span>Because the next agent recalls a verified note instead of re-deriving it, repeated tasks re-spend far fewer tokens orienting. In head-to-head benchmarks against a no-tool baseline on real applications: <b>−64% tokens on Arches</b> (Python/Django, 27-query sweep, recall +2pp better) and <b>−31% tokens on JMRI</b> (Java, 25-query sweep, recall at parity). Cost scales with turns, not output size — coldstart wins by ending the turn sooner, not by printing less.</div>
-
-      <p style="margin-top:22px"><b>Language-agnostic.</b> The freshness machinery is content-hash based, so the notebook works on any codebase — including languages the navigation index doesn't parse. Where the index does parse, notes additionally get symbol-level freshness.</p>
-
-      <h4 class="subhead">When capture happens</h4>
-      <p>Capture is <b>trigger-timed</b>, not every-turn. The hook keeps per-file evidence of what the session actually read or edited (search hits and passing path mentions never count), scores the uncaptured backlog, and asks for notes at natural boundaries — when a burst of work settles, or the moment a commit lands (manual commits included). Most turns end silently. The ask itself is <b>non-blocking</b>: it arrives with your next prompt as a short worklist of the files the session genuinely worked with, each annotated with its existing note's state — never a wall of instructions after every answer. That worklist (and the write contract that goes with it) is also written durably to <code>.coldstart/notebook/.worklist-&lt;session&gt;-&lt;agent&gt;.md</code>, so a long session can re-read it after the one-shot delivery scrolls away; it trims itself as notes are written and regenerates on the next capture, so a missed file simply reappears rather than being lost. The file is keyed per agent stream — the main agent and each subagent it spawns share one session id but get their own worklist, so a subagent's capture never overwrites the main agent's list.</p>
-      <p style="margin-top:12px">Files whose notes are already fresh don't re-trigger capture, so a warmed-up repo asks less over time. The flip side: a brand-new notebook starts empty and <b>warms with use</b> — the first few real tasks seed the file notes, and "how X works" flow notes appear as sessions actually need those answers. Don't judge recall on day one.</p>
-
-      <h4 class="subhead"><code>/capture-notes</code> — capture on demand</h4>
-      <p>Sometimes <em>you</em> know a moment is worth recording before the score crosses — a hard-won debugging insight, a confirmed absence, a decision that didn't touch many files. <code>/capture-notes</code> fires the <b>same</b> capture flow immediately: same worklist, same checklist, only the trigger threshold is skipped. It never forces a write — the agent still decides what (if anything) is worth a note, and writes nothing if the answer is nothing.</p>
-      <p style="margin-top:12px"><code>coldstart init</code> wires it for your client: <b>Claude Code</b> and <b>Cursor</b> get a <code>/capture-notes</code> slash command; <b>Codex</b> gets a <code>capture-notes</code> skill (invoke with <code>$capture-notes</code>) — Codex's custom prompts are global and deprecated, so a repo-scoped skill is the supported surface there. All three run the same one-liner, so it also works by hand:</p>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">capture on demand</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">node &lt;install&gt;/hooks/kb-elicit.mjs</span> <span class="c-flag">--manual</span>   <span class="c-dim"># prints the capture checklist for this session</span></span>
-        </div>
-      </div>
-      <p style="margin-top:12px">It reads the evidence the capture hook has already accumulated and never writes back to it, so asking for a manual capture can't disturb the automatic one. If the session hasn't done any real work yet, or everything is already captured, it says so and stops.</p>
-
-      <h4 class="subhead"><code>.coldstartignore</code> — files that never get notes</h4>
-      <p><code>coldstart init</code> scaffolds <code>.coldstart/.coldstartignore</code> (gitignore syntax). It's a <b>personal</b> file — kept out of git even when the notebook is shared, because the built-in defaults ship in the tool itself: <code>*.json</code>, lockfiles, <code>dist/</code>/<code>build/</code>/<code>coverage/</code>, minified/map/snapshot files, binaries and images, and <code>.env*</code> (notes are committed; secrets must never enter them). Every collaborator gets that baseline with or without the file; lines you add extend it on your machine. Re-include a default with <code>!</code>:</p>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">.coldstart/.coldstartignore</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-dim"># add your own</span></span>
-<span class="ln">*.generated.ts</span>
-<span class="ln">docs/</span>
-<span class="ln"><span class="c-dim"># re-include a built-in default</span></span>
-<span class="ln">!tsconfig.json</span>
-        </div>
-      </div>
-      <p style="margin-top:12px">Ignored files are filtered at the root — they never appear in a capture worklist and never trigger it. Logic-bearing configs (<code>vite.config.ts</code>, CI workflow YAML, <code>routes.rb</code>) are deliberately <em>not</em> ignored by default: they carry exactly the gotchas notes exist for. <code>kb lint</code> reports any note that anchors an ignored file (possible only via direct <code>kb write</code>).</p>
-    </section>
-
-    <section id="kb-search" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb search</span> <span class="badge">notebook</span></div>
-        <div class="sig">coldstart kb search &lt;terms…&gt; [--max N]</div>
-        <div class="desc">Search the notebook with plain task words, symbols, or file names. Returns ranked notes — the mid-task tool when your vocabulary shifts.</div>
-      </div>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb search</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb search</span> tile save lifecycle</span>
-<span class="gap"></span>
-<span class="ln"><span class="c-ember">tile-save-lifecycle</span>  <span class="c-dim">flow · [fresh]</span></span>
-<span class="ln"><span class="c-ember">src/models.py · Tile</span>  <span class="c-dim">file · [fresh]</span></span>
-        </div>
-      </div>
-    </section>
-
-    <section id="kb-lookup" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb lookup</span> <span class="badge">notebook</span></div>
-        <div class="sig">coldstart kb lookup &lt;path&gt; [symbol]</div>
-        <div class="desc">Everything known at one exact address. Run it before editing a file to pull the note (and per-symbol facets) that apply to exactly that path.</div>
-      </div>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb lookup</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb lookup</span> src/models.py Tile</span>
-        </div>
-      </div>
-    </section>
-
-    <section id="kb-write" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb write</span> <span class="badge">notebook · the gate</span></div>
-        <div class="sig">coldstart kb write &lt;spec.json | array.json | -&gt; [--into &lt;id&gt; | --new]</div>
-        <div class="desc">The write gate. A two-phase, dedup-first path: the note's concept is checked against existing notes before anything is written.</div>
-      </div>
-      <ul class="tight">
-        <li><b>Batch is the capture path.</b> The spec file may be a JSON <b>array</b> of notes, written in one call: well-formed notes land, malformed ones are reported <em>together</em> (a bad note never silences a good one), and the call ends with a coverage line naming any worked file still without a note. A single object still works for a one-off.</li>
-        <li>A single new flow/lesson <b>exits 3</b> with candidate matches. Resolve it with <code>--into &lt;id&gt;</code> (merge into an existing note) or <code>--new</code> (declare it genuinely new).</li>
-        <li>Reads a spec file, or <code>-</code> to stream the spec from stdin.</li>
-        <li>Correct a note that proved wrong in the same session: <code>&#123;"op":"retract","id":"&lt;id&gt;","target":&#123;"kind":"note"&#125;&#125;</code> removes it (or <code>target:&#123;kind:"anchor"|"alias"|…, key:"…"&#125;</code> removes one part) — no need to restate the note's type or path.</li>
-        <li>Freshly-coined ids are created exclusively — a same-moment duplicate becomes two visible notes, never a silent merge.</li>
-      </ul>
-      <div class="callout warm"><span class="ct">Agent-facing</span>This is the command the capture hook drives at the end of a session. You rarely type it by hand.</div>
-    </section>
-
-    <section id="kb-commit" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb commit</span> <span class="badge">notebook · human-only</span></div>
-        <div class="sig">coldstart kb commit</div>
-        <div class="desc">The one sanctioned git path for the notebook. Commits only the <code>.raw</code> logs and skeleton — never your feature code, and notes never ride along in a feature commit.</div>
-      </div>
-      <div class="callout warm"><span class="ct">Never an agent action</span><code>kb commit</code> is CLI/human-only and is <b>not</b> exposed as an MCP tool. Publishing notes to git is a human decision.</div>
-    </section>
-
-    <section id="kb-view" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb view</span> <span class="badge">notebook · human-only</span></div>
-        <div class="sig">coldstart kb view [--no-open]</div>
-        <div class="desc">Generate a single self-contained HTML browser of the whole notebook and open it in your default browser. No server — one file, generated fresh, freshness stamped at generation time. Once generated, the background keeper re-renders it whenever notes change, so a plain browser reload shows the latest — you don't re-run the command.</div>
-      </div>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb view</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb view</span></span>
-<span class="ln"><span class="c-hit">✓</span> <span class="c-dim">kb view: wrote .coldstart/notebook/index.html — opening in browser</span></span>
-        </div>
-      </div>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">--no-open</span><span class="fv">Write <code>index.html</code> but don't launch the browser.</span></div>
-      </div>
-      <div class="callout warm"><span class="ct">For the human</span>Agents use <code>kb search</code> / <code>lookup</code>; this is the view for a person who wants to browse what the agents have been keeping. The generated file self-registers in the notebook's <code>.gitignore</code>. Leave the tab open — the keeper keeps the file current in the background, so a reload is all you ever need after the first generate.</div>
-    </section>
-
-    <section id="kb-maint" class="doc-sec">
-      <div class="cmd">
-        <div class="name warm"><span class="c">coldstart kb status / lint / repair / repair-aliases / render</span> <span class="badge">notebook</span></div>
-      </div>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">kb status</span><span class="fv">Notebook health: note counts and per-note freshness at a glance.</span></div>
-        <div class="flag-row"><span class="fk">kb lint</span><span class="fv">Check the notebook for structural problems (broken anchors, malformed notes).</span></div>
-        <div class="flag-row"><span class="fk">kb repair</span><span class="fv">List the notes that are written but <em>unfindable</em> — missing the fields a note can't be retrieved without (search aliases, anchor symbols, a flow's verified paths). Notes written before those fields were required are correct but unreachable. It prints a worklist and changes nothing: your agent opens each note and the code it names and completes it with an ordinary <code>kb write</code>, because every gap needs a judgement about the code. Nothing to fix → <code>Nothing to repair here.</code> Also available as <code>/repair-notes</code>.</span></div>
-        <div class="flag-row"><span class="fk">kb repair-aliases</span><span class="fv">A different worklist: notes whose <code>identityAliases</code> exist but may no longer describe the file/flow (stale or really symptom words from an earlier write) — not notes missing aliases entirely, that's <code>kb repair</code> above. Shows each note's current aliases alongside what's hidden past the render cap, 10 notes per page, and changes nothing itself. Also available as <code>/repair-aliases</code>.</span></div>
-        <div class="flag-row"><span class="fk">kb render</span><span class="fv">Regenerate the derived Markdown notes from the <code>.raw</code> logs.</span></div>
-        <div class="flag-row"><span class="fk">kb init</span><span class="fv">Notebook-only setup — skeleton + hooks. Redundant if you ran <code>coldstart init</code>, which already does this.</span></div>
-        <div class="flag-row"><span class="fk">kb migrate</span><span class="fv">Upgrade an older notebook's on-disk format.</span></div>
-      </div>
-    </section>
-
-    <section id="sharing" class="doc-sec">
-      <h2>Sharing with a team</h2>
-      <p>The notebook is <b>private by default</b> — <code>.coldstart/</code> is gitignored. Opt in to sharing and the whole team's agents contribute to one growing corpus.</p>
-      <div class="term">
-        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">share the notebook</span></div>
-        <div class="term-body">
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span> <span class="c-flag">--commit-notebook</span>   <span class="c-dim"># make .raw committable</span></span>
-<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb commit</span>              <span class="c-dim"># publish notes to git</span></span>
-        </div>
-      </div>
-      <p style="margin-top:16px">Once committed, the <code>.raw</code> logs travel with the repo and <b>union-merge across branches and machines</b> — parallel branches of notes reconcile without conflicts. Every teammate's agent both reads from and writes to the same notebook, so the corpus grows at the speed of the whole team, not one person.</p>
-      <div class="callout warm"><span class="ct">Bigger notebooks, faster</span>The corpus grows exactly where the codebase gets worked. On a shared repo, that's every engineer's sessions feeding one knowledge base — and because each note stays anchored to the code, growth stays true instead of rotting.</div>
-    </section>
-
-    <div class="grp-head"><div class="kicker">Under the hood</div></div>
-
-    <section id="freshness" class="doc-sec">
-      <h2>How the index stays fresh</h2>
-      <p>coldstart is <b>one keeper, thin readers</b>. A single background keeper watches the repo and keeps an on-disk cache current; the readers (<code>find</code>, <code>gs</code>, the MCP server) are stateless and never build. There is no cache TTL — the index is never discarded for being old, it's kept <em>correct</em>.</p>
-      <div class="diagram">
-        <svg viewBox="0 0 900 300" role="img" aria-label="Architecture: a single keeper watches the repo and saves an on-disk cache; three stateless readers read that cache">
-          <defs><marker id="ah2" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path class="d-arrowhead" d="M0,0 L9,4.5 L0,9 z"/></marker></defs>
-          <rect class="d-box d-frost" x="250" y="20" width="400" height="76" rx="10" stroke-width="2"/>
-          <text class="d-label" x="270" y="50">keeper — coldstart --daemon</text>
-          <text class="d-sub" x="270" y="74">watches repo → patch/rebuild → saves cache · serves nothing</text>
-          <rect class="d-box" x="370" y="130" width="160" height="44" rx="8"/>
-          <text class="d-cmd" x="450" y="157" text-anchor="middle">on-disk cache</text>
-          <path class="d-arrow" d="M450,98 L450,128" marker-end="url(#ah2)"/>
-          <path class="d-arrow" d="M450,176 L180,224" marker-end="url(#ah2)"/>
-          <path class="d-arrow" d="M450,176 L450,224" marker-end="url(#ah2)"/>
-          <path class="d-arrow" d="M450,176 L720,224" marker-end="url(#ah2)"/>
-          <rect class="d-box" x="70" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="175" y="252" text-anchor="middle">coldstart find</text><text class="d-sub" x="175" y="270" text-anchor="middle">reads cache, prints</text>
-          <rect class="d-box" x="345" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="450" y="252" text-anchor="middle">coldstart gs</text><text class="d-sub" x="450" y="270" text-anchor="middle">reads cache, prints</text>
-          <rect class="d-box" x="620" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="725" y="252" text-anchor="middle">MCP server</text><text class="d-sub" x="725" y="270" text-anchor="middle">reads cache, stdio</text>
-        </svg>
-      </div>
+    <section id="next" class="doc-sec">
+      <h2>Where to next</h2>
       <div class="fgrid">
-        <div class="fcard"><div class="fnum">WHILE RUNNING</div><h4>Patched as you type</h4><p>Edits debounce (400 ms), then patch incrementally (~2–5 ms/file) or trigger a background rebuild. Re-saved in atomic generations — a reader never loads a half-written mix.</p></div>
-        <div class="fcard"><div class="fnum">ON START</div><h4>Reconciled, not rebuilt</h4><p>Stat-checks every file against its fingerprint plus a git diff, and patches exactly what changed. A branch switch that used to force a full rebuild is now typically a few seconds.</p></div>
-        <div class="fcard"><div class="fnum">AS A BACKSTOP</div><h4>Linted &amp; audited</h4><p>Every patch is checked against index invariants (a violation auto-rebuilds), and a rotating fingerprint audit after each save catches watcher-missed drift.</p></div>
+        <a class="fcard" href="/docs/navigation/"><div class="fnum">NAVIGATION</div><h4><code>find</code> &amp; <code>gs</code></h4><p>Locate the files for a concept, then drill into one file's shape, callers, and importers.</p></a>
+        <a class="fcard" href="/docs/notebook/"><div class="fnum">NOTEBOOK</div><h4>The <code>kb</code> family</h4><p>Durable, agent-written notes kept honest by the index — search, lookup, write, and share with a team.</p></a>
+        <a class="fcard" href="/docs/under-the-hood/"><div class="fnum">UNDER THE HOOD</div><h4>Freshness, MCP, languages</h4><p>How the index stays current, the lifecycle commands, MCP tool exposure, and the supported-language set.</p></a>
       </div>
-      <div class="callout"><span class="ct">Full internals</span>The exact pipeline (walk → parse → resolve → graph → cache) and per-language resolver notes live in <b>ARCHITECTURE.md</b> on <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">GitHub</a>.</div>
-    </section>
-
-    <section id="lifecycle" class="doc-sec">
-      <h2>Lifecycle commands</h2>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">coldstart status</span><span class="fv">Keepers on this machine: alive? fresh? last patch/rebuild/save? repairs? It also reports install health — the <code>Installed:</code> version, plus a warning if any keeper is still running an <em>older</em> version than the installed binary (run <code>coldstart restart</code>) or if a repo's wired hook paths no longer exist because a node/nvm or npm-prefix change moved the global install (run <code>coldstart init</code> there).</span></div>
-        <div class="flag-row"><span class="fk">coldstart restart</span><span class="fv">Kill the current repo's keeper (respawns on next lookup). <code>--root DIR</code> targets another repo; <code>--all</code> kills every keeper. <code>coldstart stop</code> is a synonym — same kill, and the keeper still respawns the next time a reader (a <code>find</code>/<code>gs</code> or a connected MCP client) needs it, so killing it from <code>ps</code> alone won't keep it down while an editor is querying.</span></div>
-        <div class="flag-row"><span class="fk">coldstart index</span><span class="fv">Build + save the cache once, up front (single-writer prep).</span></div>
-        <div class="flag-row"><span class="fk">coldstart --version</span><span class="fv">Print the installed version and exit (<code>-v</code> works too). <code>coldstart --help</code> / <code>-h</code> prints the command list.</span></div>
-      </div>
-      <div class="callout"><span class="ct">When anything feels stale</span><code>coldstart restart</code> — a fresh keeper reconciles on start, so it comes back <em>correct</em>, not just alive. If an update doesn't seem to have taken effect, run <code>coldstart status</code> first: it tells you whether the keeper is on the old version (restart), a hook path is dangling (re-init), or the install itself didn't update. If something looks structurally wrong, <b>TROUBLESHOOTING.md</b> on GitHub has recovery steps.</div>
-    </section>
-
-    <section id="mcp" class="doc-sec">
-      <h2>MCP tools</h2>
-      <p>For no-shell clients (like Claude Desktop), the same engine is exposed as MCP tools with byte-identical output to the CLI.</p>
-      <div class="flags">
-        <div class="flag-row"><span class="fk">find · gs</span><span class="fv">The two navigation operations.</span></div>
-        <div class="flag-row"><span class="fk">kb_search · kb_lookup</span><span class="fv">Read the notebook.</span></div>
-        <div class="flag-row"><span class="fk">kb_write · kb_status · kb_repair · kb_repair_aliases</span><span class="fv">Write to and inspect the notebook — the MCP server is a writer for <code>kb_write</code>. <code>kb_repair</code> lists notes that are written but unfindable; <code>kb_repair_aliases</code> lists notes whose aliases exist but may no longer be true.</span></div>
-      </div>
-      <div class="callout"><span class="ct">Not exposed</span><code>kb commit</code> and <code>kb view</code> stay CLI/human-only — publishing to git and opening a browser are never agent actions.</div>
-    </section>
-
-    <section id="semantics" class="doc-sec">
-      <h2>Bring your own semantics</h2>
-      <p>coldstart has no embeddings, no generated summaries, no semantic layer computed at index time — <b>on purpose. The semantic layer is the agent.</b> Every consumer is already a frontier model; pre-computing meaning at index time only duplicates that, worse and stale. So the index keeps what's cheap to keep <em>exact</em> — paths, symbols, exports, the import/call graph — and returns <em>why</em> each file ranked. The notebook applies the same rule to memory: it stores and freshness-checks the meaning agents author, and computes none of its own.</p>
-      <div class="callout"><span class="ct">Read the argument</span>The full case is in <b>PHILOSOPHY.md</b> on <a href="https://github.com/AkashGoenka/coldstart" style="color:var(--frost)">GitHub</a>.</div>
-    </section>
-
-    <section id="languages" class="doc-sec">
-      <h2>Supported languages</h2>
-      <p>Tree-sitter for the parsed set; the notebook's content-hash freshness works on all of them — notes on a Swift repo are as trustworthy as notes on a TypeScript one (they just lack symbol-level freshness).</p>
-      <div class="langs">
-        <span class="chip hot">TypeScript</span><span class="chip hot">JavaScript</span><span class="chip hot">JSX / TSX</span>
-        <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
-        <span class="chip hot">Python</span><span class="chip hot">Ruby (Rails)</span><span class="chip hot">Go</span><span class="chip hot">Rust</span>
-        <span class="chip">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
-        <span class="chip">Groovy / Gradle</span><span class="chip">GraphQL</span><span class="chip">YAML</span><span class="chip">TOML</span><span class="chip">XML</span><span class="chip">.env</span>
-      </div>
-      <p style="margin-top:16px;font-size:14px"><b>Not indexed:</b> Swift, Dart — no extension mapping; these files aren't walked or parsed. The notebook still works on them.</p>
     </section>
   </main>
 </div>

--- a/site-astro/src/pages/docs/navigation.astro
+++ b/site-astro/src/pages/docs/navigation.astro
@@ -1,0 +1,156 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import DocsSidebar from '../../components/DocsSidebar.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/backdrop.css';
+
+const techArticleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'find & gs — coldstart navigation reference | coldstart',
+  description: 'Reference for coldstart\'s find and gs: rank candidate files for a concept, then inspect one file\'s symbols, importers, and callers.',
+  url: 'https://coldstartmcp.dev/docs/navigation/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: {
+    '@type': 'Organization',
+    name: 'coldstart'
+  },
+  about: 'Navigation for AI coding agents',
+  proficiencyLevel: 'Beginner'
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title="find & gs — coldstart navigation reference | coldstart"
+    description="Reference for coldstart's find and gs: rank candidate files for a concept, then inspect one file's symbols, importers, and callers."
+    keywords="coldstart find, coldstart gs, code navigation, call graph, import graph, codebase index, AI coding agents"
+    canonicalPath="/docs/navigation/"
+    ogType="article"
+    ogDescription="Reference for coldstart's find and gs: rank candidate files for a concept, then inspect one file's symbols, importers, and callers."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(techArticleJsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="docs-page">
+<SvgDefs />
+<Nav variant="docs" />
+
+<div class="docs">
+  <DocsSidebar active="navigation" />
+
+  <main class="content">
+    <div class="kicker">Navigation</div>
+    <h1>find &amp; gs</h1>
+    <p class="lead-p">Two lookups answer "where does this live?" and "what is this file?" without a model call — rank candidate files for a concept, then inspect one file's symbols, importers, and callers. <a href="/how-it-works/navigation/">Why it's built this way →</a></p>
+
+    <section id="find" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart find</span> <span class="badge">navigation</span></div>
+        <div class="sig">coldstart find &lt;term&gt; [term…] [flags]</div>
+        <div class="desc"><b>Which files are about this?</b> Ranks files by how many of your query terms each covers — filenames, path segments, exported symbols, plus a repo-wide name-reference pass — and shows <em>why</em> each ranked: which terms it defines vs. imports.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart find</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart find</span> auth session cookie</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-frost">src/auth/service.ts</span>  <span class="c-hit">3/3</span> <span class="c-dim">defines</span> auth, session, cookie</span>
+<span class="ln">  <span class="c-ember">Summary</span> <span class="c-dim">[fresh]</span> Signs and verifies session cookies.</span>
+<span class="ln"><span class="c-frost">src/middleware/session.ts</span>  <span class="c-hit">2/3</span> <span class="c-dim">imports</span> session, cookie</span>
+        </div>
+      </div>
+      <p style="margin-top:16px">Pass <b>every salient identifier</b> from your task — the symbol, the domain noun, the rare token you half-remember — not one distilled keyword. <code>find</code> ranks by coverage and shows where the terms cluster, often answering without opening anything. Its reference pass runs on ripgrep, competing with raw grep on speed.</p>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--path GLOB</span><span class="fv">Scope to matching paths. Comma-combine; prefix <code>!</code> to exclude.</span></div>
+        <div class="flag-row"><span class="fk">--tests</span><span class="fv">Include test files (excluded by default).</span></div>
+        <div class="flag-row"><span class="fk">--via</span><span class="fv">Show name-reference relations — where the terms are referenced, not just declared.</span></div>
+        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
+      </div>
+      <div class="callout"><span class="ct">When find says "no indexed file contains any of […]"</span>Those identifiers aren't in the repo. Don't grep spelling variants — trust the negative.</div>
+    </section>
+
+    <section id="gs" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart gs</span> <span class="badge">navigation</span></div>
+        <div class="sig">coldstart gs &lt;file&gt; [flags]</div>
+        <div class="desc"><b>What is this file, and who uses it?</b> Returns the file's top-level symbols (with line ranges), its 1-hop internal imports, who imports it, and per-symbol cross-file callers — in one call. This is the answer to "who calls this?", not a grep.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart gs</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart gs</span> src/auth/service.ts</span>
+<span class="ln"><span class="c-dim">symbols</span>  signCookie <span class="c-dim">L12</span> · verify <span class="c-dim">L34</span> · rotate <span class="c-dim">L61</span></span>
+<span class="ln"><span class="c-dim">callers</span>  verify ← <span class="c-file">middleware/session.ts</span>, <span class="c-file">routes/login.ts</span></span>
+<span class="ln"><span class="c-dim">imported by</span>  4 files</span>
+        </div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--symbol a,b</span><span class="fv">Deliver the named method bodies inline — skip a separate Read.</span></div>
+        <div class="flag-row"><span class="fk">--match TERM</span><span class="fv">Filter a god-file to one area. <code>a|b</code> = OR, <code>/regex/</code> = regex.</span></div>
+        <div class="flag-row"><span class="fk">--view V</span><span class="fv">One of <code>symbols</code> / <code>imports</code> / <code>importers</code> / <code>callers</code>. Default returns all.</span></div>
+        <div class="flag-row"><span class="fk">--json</span><span class="fv">Machine-readable output.</span></div>
+      </div>
+      <div class="callout"><span class="ct">Scope</span>Callers are one-hop and file-scoped. Named function/constant calls resolve cross-file; member-expression calls (<code>this.method()</code>, <code>api.method()</code>) don't. Chase further hops by running <code>gs</code> on the caller file.</div>
+    </section>
+  </main>
+</div>
+
+<hr class="thread" />
+<Footer variant="docs" />
+
+<script>
+  (function () {
+    var links = Array.prototype.slice.call(document.querySelectorAll('.side a[href^="#"]'));
+    if (!links.length || !('IntersectionObserver' in window)) return;
+    var byId = {};
+    links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
+    var visible = new Set();
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) visible.add(e.target.id); else visible.delete(e.target.id);
+      });
+      var top = null, topY = Infinity;
+      visible.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        var y = el.getBoundingClientRect().top;
+        if (y < topY) { topY = y; top = id; }
+      });
+      links.forEach(function (a) { a.classList.remove('active'); });
+      if (top && byId[top]) {
+        byId[top].classList.add('active');
+        var sideEl = byId[top].closest('.side');
+        if (sideEl && sideEl.scrollHeight > sideEl.clientHeight) {
+          byId[top].scrollIntoView({ block: 'nearest' });
+        }
+      }
+    }, { rootMargin: '-70px 0px -70% 0px', threshold: 0 });
+    document.querySelectorAll('.doc-sec').forEach(function (s) { obs.observe(s); });
+  })();
+
+  (function () {
+    var toggle = document.getElementById('sideToggle');
+    var list = document.getElementById('sideList');
+    if (!toggle || !list) return;
+    toggle.addEventListener('click', function () {
+      var open = list.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    list.querySelectorAll('a').forEach(function (a) {
+      a.addEventListener('click', function () {
+        list.classList.remove('open');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/docs/notebook.astro
+++ b/site-astro/src/pages/docs/notebook.astro
@@ -1,0 +1,276 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import DocsSidebar from '../../components/DocsSidebar.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/backdrop.css';
+
+const techArticleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'The kb notebook — coldstart reference | coldstart',
+  description: 'Reference for coldstart\'s kb command family: search, lookup, write, commit, view, and sharing a notebook with a team.',
+  url: 'https://coldstartmcp.dev/docs/notebook/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: {
+    '@type': 'Organization',
+    name: 'coldstart'
+  },
+  about: 'Notebook and memory for AI coding agents',
+  proficiencyLevel: 'Beginner'
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title="The kb notebook — coldstart reference | coldstart"
+    description="Reference for coldstart's kb command family: search, lookup, write, commit, view, and sharing a notebook with a team."
+    keywords="coldstart kb, codebase notebook, agent memory, persistent memory, kb search, kb write, AI coding agents"
+    canonicalPath="/docs/notebook/"
+    ogType="article"
+    ogDescription="Reference for coldstart's kb command family: search, lookup, write, commit, view, and sharing a notebook with a team."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(techArticleJsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="docs-page">
+<SvgDefs />
+<Nav variant="docs" />
+
+<div class="docs">
+  <DocsSidebar active="notebook" />
+
+  <main class="content">
+    <div class="kicker">Notebook</div>
+    <h1>The kb notebook</h1>
+    <p class="lead-p">A repo-local knowledge base written and read by agents — durable notes kept honest by the index, recalled automatically when a later task matches. <a href="/how-it-works/notebook/">Why it's built this way →</a></p>
+
+    <section id="notebook" class="doc-sec">
+      <h2>The notebook, in depth</h2>
+      <p>A repo-local knowledge base, written and read by agents, living in <code>.coldstart/notebook/</code>. It's the one place semantics belong: authored by the agent that just did the work, kept honest by the index, and recalled when a later task matches. <b>No human writes or grooms it.</b></p>
+
+      <h4 class="subhead">What a note is</h4>
+      <div class="types">
+        <div class="tcard file"><div class="tt">File note</div><p>What a file is for — a single summary, or per-symbol facets for hub files.</p></div>
+        <div class="tcard flow"><div class="tt">Flow note</div><p>A cross-file story: ordered steps and the invariants that hold across them.</p></div>
+        <div class="tcard lesson"><div class="tt">Lesson</div><p>A trap, rule, bug-cause, rationale, or a confirmed <em>absence</em>.</p></div>
+      </div>
+      <p style="margin-top:18px">Every note carries <b>anchors</b> — the concrete file paths and symbols its claims rest on. Anchors are what make a note checkable rather than a floating assertion.</p>
+
+      <h4 class="subhead">Where notes reach the agent</h4>
+      <ul class="tight">
+        <li><b>Summary lines on <code>find</code> results</b> — a past agent's verified overview, right where the file ranks. <span class="pill fresh"><span class="d"></span>fresh</span> means the file is byte-identical to when the summary was verified.</li>
+        <li><b>Recall at prompt time</b> — injected straight into the agent's context as a compact block before it acts. Matching notes arrive automatically; nothing matches means nothing injected.</li>
+        <li><b><code>kb search</code> / <code>kb lookup</code></b> — search the notebook and exact-address lookup before editing a file.</li>
+      </ul>
+
+      <h4 class="subhead">Why it can be trusted</h4>
+      <ul class="tight">
+        <li><b>Freshness is mechanical.</b> Every anchor is stamped with a content hash at write time and re-checked on every read. A drifted note renders <span class="pill changed"><span class="d"></span>evidence changed</span> instead of passing as fact.</li>
+        <li><b>The log is the truth.</b> Notes live in an append-only <code>.raw</code> event log; the Markdown notes are derived and regenerated mechanically.</li>
+        <li><b>Writes go through a gate.</b> A new note's concept is searched against existing notes first — duplicates are caught at write time.</li>
+        <li><b>Concurrent sessions are safe.</b> Per-note append-only logs, exclusive creation of new ids, lossless union-merge, atomic renders — concurrent writers never silently merge or lose a note.</li>
+        <li><b>Corrections happen in-session.</b> An agent that finds a note wrong while the evidence is in context fixes or retracts it right then.</li>
+      </ul>
+
+      <div class="callout"><span class="ct">On token savings</span>Because the next agent recalls a verified note instead of re-deriving it, repeated tasks re-spend far fewer tokens orienting. In head-to-head benchmarks on real applications: <b>−64% tokens on Arches</b> (Python/Django, 27-query sweep) and <b>−31% tokens on JMRI</b> (Java, 25-query sweep). Cost scales with turns, not output size.</div>
+
+      <p style="margin-top:22px"><b>Language-agnostic.</b> The freshness machinery is content-hash based, so the notebook works on any codebase — including languages the navigation index doesn't parse.</p>
+
+      <h4 class="subhead">When capture happens</h4>
+      <p>Capture is <b>trigger-timed</b>, not every-turn. The hook keeps evidence of what the session actually read or edited (search hits and path mentions never count), scores the uncaptured backlog, and asks at natural boundaries — when a burst of work settles, or a commit lands. Most turns end silently.</p>
+      <p>The ask itself is <b>non-blocking</b>: it arrives with your next prompt as a short worklist of the files the session worked with, each annotated with its existing note's state. That worklist is also written durably to <code>.coldstart/notebook/.worklist-&lt;session&gt;-&lt;agent&gt;.md</code>, so a long session can re-read it after the one-shot delivery scrolls away.</p>
+      <div class="flags" style="margin-top:16px">
+        <div class="flag-row"><span class="fk">Worklist lifecycle</span><span class="fv">Trims as notes are written, regenerates on the next capture. A missed file simply reappears rather than being lost.</span></div>
+        <div class="flag-row"><span class="fk">Per-agent keying</span><span class="fv">The main agent and each subagent it spawns share one session id but get their own worklist, so a subagent's capture never overwrites the main agent's list.</span></div>
+        <div class="flag-row"><span class="fk">Freshness benefit</span><span class="fv">Files whose notes are already fresh don't re-trigger capture, so a warmed-up repo asks less over time. Brand-new notebooks warm with use.</span></div>
+      </div>
+
+      <h4 class="subhead"><code>/capture-notes</code> — capture on demand</h4>
+      <p>Sometimes you know a moment is worth recording before the automatic score crosses — a hard-won insight, a confirmed absence, a decision that didn't touch many files. <code>/capture-notes</code> fires the capture flow immediately, with the same worklist and gate. It never forces a write.</p>
+      <p style="margin-top:12px"><code>coldstart init</code> wires it for your client: <b>Claude Code</b> and <b>Cursor</b> get a <code>/capture-notes</code> slash command; <b>Codex</b> gets a <code>capture-notes</code> skill. All three run the same one-liner, so it also works by hand:</p>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">capture on demand</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">node &lt;install&gt;/hooks/kb-elicit.mjs</span> <span class="c-flag">--manual</span>   <span class="c-dim"># prints the capture checklist for this session</span></span>
+        </div>
+      </div>
+
+      <h4 class="subhead"><code>.coldstartignore</code> — files that never get notes</h4>
+      <p><code>coldstart init</code> scaffolds <code>.coldstart/.coldstartignore</code> (gitignore syntax). Built-in defaults are <code>*.json</code>, lockfiles, <code>dist/</code>/<code>build/</code>/<code>coverage/</code>, minified files, binaries and images, and <code>.env*</code> (notes are committed; secrets must never enter them). Every collaborator gets that baseline; lines you add extend it on your machine.</p>
+      <div class="term" style="margin-top:14px">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">.coldstart/.coldstartignore</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-dim"># add your own</span></span>
+<span class="ln">*.generated.ts</span>
+<span class="ln">docs/</span>
+<span class="ln"><span class="c-dim"># re-include a built-in default</span></span>
+<span class="ln">!tsconfig.json</span>
+        </div>
+      </div>
+      <p style="margin-top:12px">Ignored files are filtered at the root — they never appear in a capture worklist. Logic-bearing configs (<code>vite.config.ts</code>, CI workflows, <code>routes.rb</code>) are deliberately <em>not</em> ignored by default: they carry exactly the gotchas notes exist for.</p>
+    </section>
+
+    <section id="kb-search" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb search</span> <span class="badge">notebook</span></div>
+        <div class="sig">coldstart kb search &lt;terms…&gt; [--max N]</div>
+        <div class="desc">Search the notebook with plain task words, symbols, or file names. Returns ranked notes — the mid-task tool when your vocabulary shifts.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb search</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb search</span> tile save lifecycle</span>
+<span class="gap"></span>
+<span class="ln"><span class="c-ember">tile-save-lifecycle</span>  <span class="c-dim">flow · [fresh]</span></span>
+<span class="ln"><span class="c-ember">src/models.py · Tile</span>  <span class="c-dim">file · [fresh]</span></span>
+        </div>
+      </div>
+    </section>
+
+    <section id="kb-lookup" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb lookup</span> <span class="badge">notebook</span></div>
+        <div class="sig">coldstart kb lookup &lt;path&gt; [symbol]</div>
+        <div class="desc">Everything known at one exact address. Run it before editing a file to pull the note (and per-symbol facets) that apply to exactly that path.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb lookup</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb lookup</span> src/models.py Tile</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="kb-write" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb write</span> <span class="badge">notebook · the gate</span></div>
+        <div class="sig">coldstart kb write &lt;spec.json | array.json | -&gt; [--into &lt;id&gt; | --new]</div>
+        <div class="desc">The write gate. A two-phase, dedup-first path: the note's concept is checked against existing notes before anything is written.</div>
+      </div>
+      <ul class="tight">
+        <li><b>Batch is the capture path.</b> The spec file may be a JSON array of notes, written in one call: well-formed notes land, malformed ones are reported together, and the call ends naming any worked file still without a note.</li>
+        <li>A single new flow/lesson exits 3 with candidate matches. Resolve it with <code>--into &lt;id&gt;</code> (merge) or <code>--new</code> (declare it new).</li>
+        <li>Reads a spec file, or <code>-</code> to stream from stdin.</li>
+        <li>Correct a note: <code>&#123;"op":"retract","id":"&lt;id&gt;","target":&#123;"kind":"note"&#125;&#125;</code> removes it, or target one part with <code>target:&#123;kind:"anchor"|"alias"…, key:"…"&#125;</code>.</li>
+        <li>Freshly-coined ids are created exclusively — a same-moment duplicate becomes two notes, never a silent merge.</li>
+      </ul>
+      <div class="callout"><span class="ct">Agent-facing</span>This is the command the capture hook drives. You rarely type it by hand.</div>
+    </section>
+
+    <section id="kb-commit" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb commit</span> <span class="badge">notebook · human-only</span></div>
+        <div class="sig">coldstart kb commit</div>
+        <div class="desc">The one sanctioned git path for the notebook. Commits only the <code>.raw</code> logs and skeleton — never your feature code, and notes never ride along in a feature commit.</div>
+      </div>
+      <div class="callout"><span class="ct">Never an agent action</span><code>kb commit</code> is CLI/human-only and is <b>not</b> exposed as an MCP tool. Publishing notes to git is a human decision.</div>
+    </section>
+
+    <section id="kb-view" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb view</span> <span class="badge">notebook · human-only</span></div>
+        <div class="sig">coldstart kb view [--no-open]</div>
+        <div class="desc">Generate a single self-contained HTML browser of the whole notebook and open it in your default browser. No server — one file, freshness stamped at generation time.</div>
+      </div>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">coldstart kb view</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb view</span></span>
+<span class="ln"><span class="c-hit">✓</span> <span class="c-dim">kb view: wrote .coldstart/notebook/index.html — opening in browser</span></span>
+        </div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">--no-open</span><span class="fv">Write <code>index.html</code> but don't launch the browser.</span></div>
+      </div>
+      <p style="margin-top:18px">Once generated, the keeper re-renders it whenever notes change, so a browser reload shows the latest — you don't re-run the command.</p>
+    </section>
+
+    <section id="kb-maint" class="doc-sec">
+      <div class="cmd">
+        <div class="name"><span class="c">coldstart kb status / lint / repair / repair-aliases / render</span> <span class="badge">notebook</span></div>
+      </div>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">kb status</span><span class="fv">Notebook health: note counts and per-note freshness at a glance.</span></div>
+        <div class="flag-row"><span class="fk">kb lint</span><span class="fv">Check the notebook for structural problems (broken anchors, malformed notes).</span></div>
+        <div class="flag-row"><span class="fk">kb repair</span><span class="fv">List the notes that are written but unfindable — missing fields a note can't be retrieved without (search aliases, anchor symbols, a flow's verified paths). It prints a worklist and changes nothing: your agent opens each note and the code it names and completes it with an ordinary <code>kb write</code>.</span></div>
+        <div class="flag-row"><span class="fk">kb repair-aliases</span><span class="fv">Notes whose <code>identityAliases</code> may no longer describe the file/flow (stale words from an earlier write) — not notes missing aliases entirely. Shows each note's current aliases, 10 per page, and changes nothing itself.</span></div>
+        <div class="flag-row"><span class="fk">kb render</span><span class="fv">Regenerate the derived Markdown notes from the <code>.raw</code> logs.</span></div>
+        <div class="flag-row"><span class="fk">kb init</span><span class="fv">Notebook-only setup. Redundant if you ran <code>coldstart init</code>, which already does this.</span></div>
+        <div class="flag-row"><span class="fk">kb migrate</span><span class="fv">Upgrade an older notebook's on-disk format.</span></div>
+      </div>
+    </section>
+
+    <section id="sharing" class="doc-sec">
+      <h2>Sharing with a team</h2>
+      <p>The notebook is <b>private by default</b> — <code>.coldstart/</code> is gitignored. Opt in to sharing and the whole team's agents contribute to one growing corpus.</p>
+      <div class="term">
+        <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="title">share the notebook</span></div>
+        <div class="term-body">
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart init</span> <span class="c-flag">--commit-notebook</span>   <span class="c-dim"># make .raw committable</span></span>
+<span class="ln"><span class="c-prompt">$</span> <span class="c-cmd">coldstart kb commit</span>              <span class="c-dim"># publish notes to git</span></span>
+        </div>
+      </div>
+      <p style="margin-top:16px">Once committed, the <code>.raw</code> logs travel with the repo and <b>union-merge across branches and machines</b> — parallel branches of notes reconcile without conflicts. Every teammate's agent both reads from and writes to the same notebook, so the corpus grows at the speed of the whole team.</p>
+      <div class="callout"><span class="ct">Bigger notebooks, faster</span>The corpus grows exactly where the codebase gets worked. On a shared repo, that's every engineer's sessions feeding one knowledge base — and because each note stays anchored to the code, growth stays true instead of rotting.</div>
+    </section>
+  </main>
+</div>
+
+<hr class="thread" />
+<Footer variant="docs" />
+
+<script>
+  (function () {
+    var links = Array.prototype.slice.call(document.querySelectorAll('.side a[href^="#"]'));
+    if (!links.length || !('IntersectionObserver' in window)) return;
+    var byId = {};
+    links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
+    var visible = new Set();
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) visible.add(e.target.id); else visible.delete(e.target.id);
+      });
+      var top = null, topY = Infinity;
+      visible.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        var y = el.getBoundingClientRect().top;
+        if (y < topY) { topY = y; top = id; }
+      });
+      links.forEach(function (a) { a.classList.remove('active'); });
+      if (top && byId[top]) {
+        byId[top].classList.add('active');
+        var sideEl = byId[top].closest('.side');
+        if (sideEl && sideEl.scrollHeight > sideEl.clientHeight) {
+          byId[top].scrollIntoView({ block: 'nearest' });
+        }
+      }
+    }, { rootMargin: '-70px 0px -70% 0px', threshold: 0 });
+    document.querySelectorAll('.doc-sec').forEach(function (s) { obs.observe(s); });
+  })();
+
+  (function () {
+    var toggle = document.getElementById('sideToggle');
+    var list = document.getElementById('sideList');
+    if (!toggle || !list) return;
+    toggle.addEventListener('click', function () {
+      var open = list.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    list.querySelectorAll('a').forEach(function (a) {
+      a.addEventListener('click', function () {
+        list.classList.remove('open');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/docs/under-the-hood.astro
+++ b/site-astro/src/pages/docs/under-the-hood.astro
@@ -1,0 +1,175 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import DocsSidebar from '../../components/DocsSidebar.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/backdrop.css';
+
+const techArticleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Under the hood — index freshness & MCP tools | coldstart',
+  description: 'How coldstart\'s index stays fresh, lifecycle commands, MCP tool exposure, bring-your-own-semantics, and the supported-language set.',
+  url: 'https://coldstartmcp.dev/docs/under-the-hood/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: {
+    '@type': 'Organization',
+    name: 'coldstart'
+  },
+  about: 'Codebase memory for AI coding agents',
+  proficiencyLevel: 'Beginner'
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title="Under the hood — index freshness & MCP tools | coldstart"
+    description="How coldstart's index stays fresh, lifecycle commands, MCP tool exposure, bring-your-own-semantics, and the supported-language set."
+    keywords="coldstart architecture, index freshness, MCP tools, tree-sitter languages, codebase index internals"
+    canonicalPath="/docs/under-the-hood/"
+    ogType="article"
+    ogDescription="How coldstart's index stays fresh, lifecycle commands, MCP tool exposure, bring-your-own-semantics, and the supported-language set."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(techArticleJsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="docs-page">
+<SvgDefs />
+<Nav variant="docs" />
+
+<div class="docs">
+  <DocsSidebar active="under-the-hood" />
+
+  <main class="content">
+    <div class="kicker">Under the hood</div>
+    <h1>How it stays current</h1>
+    <p class="lead-p">One background keeper watches the repo and patches an on-disk cache; readers never build. No cache TTL — the index is never discarded for being old, it's kept correct.</p>
+
+    <section id="freshness" class="doc-sec">
+      <h2>How the index stays fresh</h2>
+      <p>coldstart is <b>one keeper, thin readers</b>. A single background keeper watches the repo and keeps an on-disk cache current; the readers (<code>find</code>, <code>gs</code>, the MCP server) are stateless and never build. There is no cache TTL — the index is never discarded for being old, it's kept <em>correct</em>.</p>
+      <div class="diagram">
+        <svg viewBox="0 0 900 300" role="img" aria-label="Architecture: a single keeper watches the repo and saves an on-disk cache; three stateless readers read that cache">
+          <defs><marker id="ah2" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path class="d-arrowhead" d="M0,0 L9,4.5 L0,9 z"/></marker></defs>
+          <rect class="d-box d-frost" x="250" y="20" width="400" height="76" rx="10" stroke-width="2"/>
+          <text class="d-label" x="270" y="50">keeper — coldstart --daemon</text>
+          <text class="d-sub" x="270" y="74">watches repo → patch/rebuild → saves cache · serves nothing</text>
+          <rect class="d-box" x="370" y="130" width="160" height="44" rx="8"/>
+          <text class="d-cmd" x="450" y="157" text-anchor="middle">on-disk cache</text>
+          <path class="d-arrow" d="M450,98 L450,128" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L180,224" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L450,224" marker-end="url(#ah2)"/>
+          <path class="d-arrow" d="M450,176 L720,224" marker-end="url(#ah2)"/>
+          <rect class="d-box" x="70" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="175" y="252" text-anchor="middle">coldstart find</text><text class="d-sub" x="175" y="270" text-anchor="middle">reads cache, prints</text>
+          <rect class="d-box" x="345" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="450" y="252" text-anchor="middle">coldstart gs</text><text class="d-sub" x="450" y="270" text-anchor="middle">reads cache, prints</text>
+          <rect class="d-box" x="620" y="230" width="210" height="50" rx="8"/><text class="d-cmd" x="725" y="252" text-anchor="middle">MCP server</text><text class="d-sub" x="725" y="270" text-anchor="middle">reads cache, stdio</text>
+        </svg>
+      </div>
+      <div class="fgrid">
+        <div class="fcard"><div class="fnum">WHILE RUNNING</div><h4>Patched as you type</h4><p>Edits debounce (400 ms), then patch incrementally (~2–5 ms/file) or trigger a background rebuild. Re-saved in atomic generations — a reader never loads a half-written mix.</p></div>
+        <div class="fcard"><div class="fnum">ON START</div><h4>Reconciled, not rebuilt</h4><p>Stat-checks every file against its fingerprint plus a git diff, and patches exactly what changed. A branch switch that used to force a full rebuild is now typically a few seconds.</p></div>
+        <div class="fcard"><div class="fnum">AS A BACKSTOP</div><h4>Linted &amp; audited</h4><p>Every patch is checked against index invariants (a violation auto-rebuilds), and a rotating fingerprint audit after each save catches watcher-missed drift.</p></div>
+      </div>
+      <div class="callout"><span class="ct">Full internals</span>The exact pipeline (walk → parse → resolve → graph → cache) and per-language resolver notes live in <b>ARCHITECTURE.md</b> on <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>.</div>
+    </section>
+
+    <section id="lifecycle" class="doc-sec">
+      <h2>Lifecycle commands</h2>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">coldstart status</span><span class="fv">Keepers on this machine: alive? fresh? last operations? It also reports install health — if any keeper is running an older version than the installed binary, run <code>coldstart restart</code>; if a repo's wired hook paths no longer exist (node/nvm change), run <code>coldstart init</code> there.</span></div>
+        <div class="flag-row"><span class="fk">coldstart restart</span><span class="fv">Kill the current repo's keeper (respawns on next lookup). <code>--root DIR</code> targets another repo; <code>--all</code> kills every keeper. A fresh keeper reconciles on start, so it comes back correct, not just alive.</span></div>
+        <div class="flag-row"><span class="fk">coldstart index</span><span class="fv">Build + save the cache once, up front (single-writer prep).</span></div>
+        <div class="flag-row"><span class="fk">coldstart --version</span><span class="fv">Print the installed version and exit (<code>-v</code> works too).</span></div>
+      </div>
+      <div class="callout"><span class="ct">When anything feels stale</span>Run <code>coldstart restart</code> first. If an update doesn't seem to have taken effect, <code>coldstart status</code> tells you whether the keeper is on the old version (restart it), a hook path is dangling (re-run init), or the install didn't update. <b>TROUBLESHOOTING.md</b> on GitHub has recovery steps.</div>
+    </section>
+
+    <section id="mcp" class="doc-sec">
+      <h2>MCP tools</h2>
+      <p>For no-shell clients (like Claude Desktop), the same engine is exposed as MCP tools with byte-identical output to the CLI.</p>
+      <div class="flags">
+        <div class="flag-row"><span class="fk">find · gs</span><span class="fv">The two navigation operations.</span></div>
+        <div class="flag-row"><span class="fk">kb_search · kb_lookup</span><span class="fv">Read the notebook.</span></div>
+        <div class="flag-row"><span class="fk">kb_write · kb_status · kb_repair · kb_repair_aliases</span><span class="fv">Write to and inspect the notebook. <code>kb_repair</code> lists notes that are written but unfindable; <code>kb_repair_aliases</code> lists notes whose aliases may no longer be true.</span></div>
+      </div>
+      <div class="callout"><span class="ct">Not exposed</span><code>kb commit</code> and <code>kb view</code> stay CLI/human-only — publishing to git and opening a browser are never agent actions.</div>
+    </section>
+
+    <section id="semantics" class="doc-sec">
+      <h2>Bring your own semantics</h2>
+      <p>coldstart has no embeddings, no generated summaries, no semantic layer computed at index time — <b>on purpose. The semantic layer is the agent.</b> The index keeps what's cheap to keep exact — paths, symbols, exports, the import/call graph — and returns why each file ranked. The notebook applies the same rule to memory: it stores and freshness-checks the meaning agents author, and computes none of its own.</p>
+      <div class="callout"><span class="ct">Read the argument</span>The full case is in <b>PHILOSOPHY.md</b> on <a href="https://github.com/AkashGoenka/coldstart">GitHub</a>, or see how this plays out against <a href="/vs/vector-rag/">vector RAG specifically</a>.</div>
+    </section>
+
+    <section id="languages" class="doc-sec">
+      <h2>Supported languages</h2>
+      <p>Tree-sitter for the parsed set; the notebook's content-hash freshness works on all of them — notes on a Swift repo are as trustworthy as notes on a TypeScript one (they just lack symbol-level freshness).</p>
+      <div class="langs">
+        <span class="chip">TypeScript</span><span class="chip">JavaScript</span><span class="chip">JSX / TSX</span>
+        <span class="chip">Vue</span><span class="chip">Svelte</span><span class="chip">Astro</span><span class="chip">AngularJS</span>
+        <span class="chip">Python</span><span class="chip">Ruby (Rails)</span><span class="chip">Go</span><span class="chip">Rust</span>
+        <span class="chip">Java</span><span class="chip">Kotlin</span><span class="chip">C#</span><span class="chip">PHP (Laravel)</span><span class="chip">C++</span>
+        <span class="chip">Groovy / Gradle</span><span class="chip">GraphQL</span><span class="chip">YAML</span><span class="chip">TOML</span><span class="chip">XML</span><span class="chip">.env</span>
+      </div>
+      <p style="margin-top:16px;font-size:14px"><b>Not indexed:</b> Swift, Dart — no extension mapping; these files aren't walked or parsed. The notebook still works on them.</p>
+    </section>
+  </main>
+</div>
+
+<hr class="thread" />
+<Footer variant="docs" />
+
+<script>
+  (function () {
+    var links = Array.prototype.slice.call(document.querySelectorAll('.side a[href^="#"]'));
+    if (!links.length || !('IntersectionObserver' in window)) return;
+    var byId = {};
+    links.forEach(function (a) { byId[a.getAttribute('href').slice(1)] = a; });
+    var visible = new Set();
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) visible.add(e.target.id); else visible.delete(e.target.id);
+      });
+      var top = null, topY = Infinity;
+      visible.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        var y = el.getBoundingClientRect().top;
+        if (y < topY) { topY = y; top = id; }
+      });
+      links.forEach(function (a) { a.classList.remove('active'); });
+      if (top && byId[top]) {
+        byId[top].classList.add('active');
+        var sideEl = byId[top].closest('.side');
+        if (sideEl && sideEl.scrollHeight > sideEl.clientHeight) {
+          byId[top].scrollIntoView({ block: 'nearest' });
+        }
+      }
+    }, { rootMargin: '-70px 0px -70% 0px', threshold: 0 });
+    document.querySelectorAll('.doc-sec').forEach(function (s) { obs.observe(s); });
+  })();
+
+  (function () {
+    var toggle = document.getElementById('sideToggle');
+    var list = document.getElementById('sideList');
+    if (!toggle || !list) return;
+    toggle.addEventListener('click', function () {
+      var open = list.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    list.querySelectorAll('a').forEach(function (a) {
+      a.addEventListener('click', function () {
+        list.classList.remove('open');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/pages/how-it-works/index.astro
+++ b/site-astro/src/pages/how-it-works/index.astro
@@ -203,6 +203,7 @@ const jsonLd = {
       </div>
       <div class="how-next">
         <a class="primary" href="/docs/">Read the docs</a>
+        <a class="ghost" href="/vs/vector-rag/">coldstart vs vector RAG →</a>
         <a class="ghost" href="/blog/">Engineering blog →</a>
       </div>
     </div>

--- a/site-astro/src/pages/how-it-works/notebook.astro
+++ b/site-astro/src/pages/how-it-works/notebook.astro
@@ -59,6 +59,52 @@ const jsonLd = {
   </div>
 </header>
 
+<!-- ===================== NOTEBOOK MOCK ===================== -->
+<section class="how-sec" style="padding-top:0">
+  <div class="wrap">
+    <figure class="nb-mock rv">
+      <div class="nbm-top">
+        <div class="nbm-brand"><span class="nbm-kick">Coldstart Notebook</span><span class="nbm-name"><i class="nbm-dot"></i>coldstart</span></div>
+        <div class="nbm-stats">
+          <span><b>80</b> notes</span>
+          <span><b>7</b> links</span>
+          <span class="nbm-bar"><i></i></span>
+          <span class="nbm-fresh">50% fresh</span>
+        </div>
+      </div>
+      <div class="nbm-body">
+        <div class="nbm-side">
+          <div class="nbm-search">Search title, alias, path, symbol…</div>
+          <div class="nbm-file">raw-log.ts</div>
+          <div class="nbm-file">repair.ts</div>
+          <div class="nbm-file">search.ts</div>
+          <div class="nbm-file active">tools.ts</div>
+          <div class="nbm-file">cli.ts</div>
+          <div class="nbm-file">index-manager.ts</div>
+        </div>
+        <div class="nbm-main">
+          <div class="nbm-crumb">FILE · SINGLE</div>
+          <h3 class="nbm-title">src/server/tools.ts</h3>
+          <div class="nbm-meta"><span class="nbm-pill">fresh</span> 1 anchor · 2 edits</div>
+          <div class="nbm-anchors">
+            <div class="nbm-anchor-head">anchors — verified code addresses</div>
+            <div class="nbm-anchor-row">
+              <code>src/server/<b>tools.ts</b></code>
+              <span class="nbm-pill">fresh</span>
+            </div>
+            <div class="nbm-syms"><span>handleGetStructure</span><span>findFileByPath</span></div>
+          </div>
+          <div class="nbm-note-head">note</div>
+          <p class="nbm-note">handleGetStructure builds the gs symbol page for one file. Uses findFileByPath
+            to look up the file: returns [fileId, IndexedFile] if found, null if not indexed —
+            distinguishing "not in index" from "indexed but zero symbols."</p>
+        </div>
+      </div>
+      <figcaption>coldstart's own notebook — one note, opened with <code>kb view</code>.</figcaption>
+    </figure>
+  </div>
+</section>
+
 <!-- ===================== THE LOOP ===================== -->
 <section class="how-sec">
   <div class="wrap">

--- a/site-astro/src/pages/index.astro
+++ b/site-astro/src/pages/index.astro
@@ -85,19 +85,28 @@ const faqJsonLd = {
 <Nav variant="home" />
 
 <!-- ===================== HERO ===================== -->
-<header class="hero">
+<header class="hero" id="install">
   <div class="wrap hero-in">
     <div class="kicker">Codebase memory — what your agents learned, kept for the next session</div>
-    <h1 class="title">Your agent relearns your codebase from <span class="cold">scratch</span> — every session.</h1>
+    <h1 class="title">Your agent relearns your codebase<br>from <span class="cold">scratch</span> — every<br>session.</h1>
     <p class="hero-sub">coldstart gives it <b>persistent memory of your codebase</b> — a notebook it writes itself, so what one session figures out, the next already knows — plus an exact index to <b>find the right file without three wrong reads</b>. No embeddings, no API key: it runs on the model you already pay for.</p>
+
+    <div class="term install-term">
+      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">your-project</span><button type="button" class="copy-btn" id="copy-install" data-copy="npm install -g @cstart/coldstart&#10;coldstart init" aria-label="Copy install commands">Copy</button></div>
+      <div class="term-body">
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">npm install -g @cstart/coldstart</span></span>
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">cd</span> your-project</span>
+<span class="gap"></span>
+<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">coldstart init</span>   <span class="p-dim"># coldstart.md + client wiring + notebook + hooks</span></span>
+<span class="gap"></span>
+<span class="l"><span class="p-hit">✓</span> <span class="p-dim">index warming in the background — your first lookup is instant.</span></span>
+      </div>
+    </div>
+
     <div class="cta">
-      <a class="btn btn-primary" href="#install">Install →</a>
+      <a class="btn btn-primary" href="/docs/">Read the docs →</a>
       <a class="btn btn-ghost" href="/blog/">Read the blog</a>
     </div>
-    <button type="button" class="cmdline copy-btn" data-copy="npm install -g @cstart/coldstart && coldstart init" aria-label="Copy install command">
-      <span class="p">$</span> <span class="c">npm install -g @cstart/coldstart &amp;&amp; coldstart init</span>
-      <span class="copy-hint">Copy</span>
-    </button>
     <p class="meta-line">MIT · Node 18+ · runs offline · no embeddings, no API key</p>
   </div>
 </header>
@@ -267,35 +276,17 @@ const faqJsonLd = {
         </details>
       ))}
     </div>
-  </div>
-</section>
-
-<!-- ===================== INSTALL ===================== -->
-<section id="install" class="install">
-  <div class="wrap">
-    <div class="rise">
-      <div class="eyebrow">Get started</div>
-      <h2>Two commands to warm the repo.</h2>
-      <p class="lead">Works best with <b>Claude Code</b>, <b>Codex</b>, and <b>Cursor</b> — all get the fast CLI path <em style="font-style:italic;color:var(--text)">and</em> the notebook capture/recall hooks, wired automatically by <code style="font-family:var(--mono)">init</code>.</p>
-    </div>
-    <div class="term install-term rise">
-      <div class="term-bar"><span class="tl"></span><span class="tl"></span><span class="tl"></span><span class="term-title">your-project</span><button type="button" class="copy-btn" id="copy-install" data-copy="npm install -g @cstart/coldstart&#10;coldstart init" aria-label="Copy install commands">Copy</button></div>
-      <div class="term-body">
-<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">npm install -g @cstart/coldstart</span></span>
-<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">cd</span> your-project</span>
-<span class="gap"></span>
-<span class="l"><span class="p-prompt">$</span> <span class="p-cmd">coldstart init</span>   <span class="p-dim"># coldstart.md + client wiring + notebook + hooks</span></span>
-<span class="gap"></span>
-<span class="l"><span class="p-hit">✓</span> <span class="p-dim">index warming in the background — your first lookup is instant.</span></span>
+    <div class="faq-close rise">
+      <div class="faq-close-links">
+        <a class="btn btn-ghost btn-icon" href="https://github.com/AkashGoenka/coldstart" aria-label="GitHub">
+          <svg width="17" height="17" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+        <a class="btn btn-ghost btn-icon" href="https://www.npmjs.com/package/@cstart/coldstart" aria-label="npm">
+          <svg width="46" height="15" viewBox="0 0 780 250" aria-hidden="true"><path fill="currentColor" d="M0 0v200h100V50h50v150h50V0H0zM240 0v250h100v-50h100V0H240zm150 50h50v100h-50V50zM480 0v200h100V50h50v150h50V50h50v150h50V0H480z"/></svg>
+        </a>
       </div>
+      <p class="install-langs">20+ languages via Tree-sitter — TypeScript, Python, Go, Rust, Java, Ruby, PHP, C#, C++, and more.</p>
     </div>
-    <div class="cta rise">
-      <a class="btn btn-primary" href="/docs/">Read the docs →</a>
-      <a class="btn btn-ghost" href="/blog/">Read the blog</a>
-      <a class="btn btn-ghost" href="https://github.com/AkashGoenka/coldstart">GitHub</a>
-      <a class="btn btn-ghost" href="https://www.npmjs.com/package/@cstart/coldstart">npm</a>
-    </div>
-    <p class="install-langs rise">20+ languages via Tree-sitter — TypeScript, Python, Go, Rust, Java, Ruby, PHP, C#, C++, and more.</p>
   </div>
 </section>
 

--- a/site-astro/src/pages/vs/vector-rag.astro
+++ b/site-astro/src/pages/vs/vector-rag.astro
@@ -1,0 +1,312 @@
+---
+import Head from '../../layouts/Head.astro';
+import SvgDefs from '../../components/SvgDefs.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import '../../styles/tailwind.css';
+import '../../styles/docs.css';
+import '../../styles/how.css';
+import '../../styles/backdrop.css';
+
+const title = 'coldstart vs vector RAG for codebase memory | coldstart';
+const description =
+  'Code already has ground truth — imports, symbol definitions, a call graph. RAG approximates that structure with embeddings and a similarity score. Here is what that approximation costs, and where it still wins.';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'coldstart vs vector RAG for codebase memory',
+  description,
+  url: 'https://coldstartmcp.dev/vs/vector-rag/',
+  author: { '@type': 'Person', name: 'Akash Goenka' },
+  publisher: { '@type': 'Organization', name: 'coldstart' },
+  about: 'Codebase memory for AI coding agents',
+  proficiencyLevel: 'Beginner',
+};
+---
+<html lang="en">
+<head>
+  <Head
+    title={title}
+    description={description}
+    keywords="RAG vs AST, vector search for code, embeddings for code search, codebase memory, semantic code search, AI coding agent architecture, retrieval augmented generation, code index without embeddings"
+    canonicalPath="/vs/vector-rag/"
+    ogType="article"
+    ogTitle="coldstart vs vector RAG for codebase memory"
+    ogDescription="Code already has ground truth. RAG approximates it with embeddings and a similarity score. Here is what that approximation costs, and where it still wins."
+    themeColor="#070a11"
+  />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+</head>
+<body class="how-page">
+<SvgDefs />
+<Nav variant="how" />
+
+<!-- ===================== HERO ===================== -->
+<header class="how-hero">
+  <div class="wrap">
+    <div class="how-eyebrow">coldstart vs vector RAG</div>
+    <h1>Code isn't a document. Stop <em>searching</em> it like one.</h1>
+    <p class="lead">
+      RAG earned its place doing something real: finding the passage that means what you mean without
+      using your words. Applied to a codebase, it's approximating something that's <b>already exact</b>
+      — imports, symbol definitions, a call graph the parser can compute for free. Here's what that
+      approximation costs, and the one place it's still the right tool.
+    </p>
+    <a class="how-back" href="/">← back to the overview</a>
+  </div>
+</header>
+
+<!-- ===================== THE TWO PIPELINES ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>One of these is computed. The other is guessed.</h2>
+      <p>
+        A call graph isn't a fuzzy concept living somewhere in embedding space — it's a fact the
+        language already states. <code>import</code>, a function call, a class reference: the parser
+        reads the answer directly. RAG doesn't get to read it directly. It chunks the text, embeds the
+        chunks, and asks a vector store which ones <i>sound</i> related.
+      </p>
+    </div>
+
+    <div class="temp-fig">
+      <div class="temp-seam"></div>
+
+      <div class="temp-col cold">
+        <div class="temp-kick">Structural — coldstart</div>
+        <h3>What the parser already knows</h3>
+        <p>
+          Tree-sitter reads the file once. Imports, exports, symbol definitions, and every call site
+          resolve to a real edge — not a guess about what's related.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">imports resolved exactly, not inferred</div>
+          <div class="temp-item">call graph built from real references</div>
+          <div class="temp-item">a changed file repatches in milliseconds</div>
+          <div class="temp-item">zero model calls, zero API key</div>
+          <div class="temp-item">the same query returns the same rank, always</div>
+        </div>
+      </div>
+
+      <div class="temp-col warm">
+        <div class="temp-kick">Semantic — vector RAG</div>
+        <h3>What embeddings approximate</h3>
+        <p>
+          Every file is chunked, embedded, and pushed into a vector store. A query becomes another
+          embedding, compared by cosine distance to everything already indexed.
+        </p>
+        <div class="temp-items">
+          <div class="temp-item">a vector store to run, pay for, and keep online</div>
+          <div class="temp-item">chunk boundaries that don't know where a symbol ends</div>
+          <div class="temp-item">re-embedding needed on every edit, so it's batched</div>
+          <div class="temp-item">an embed call plus an ANN search, every lookup</div>
+          <div class="temp-item">a similarity score, not a fact you can check</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="temp-verdict rv">
+      <b>Neither of these is the "advanced" one.</b> RAG is the right call when there's no structure to
+      exploit — prose, tickets, a wiki, anything where your words and the target's words can legitimately
+      differ. Source code is the opposite case: it already declares its own structure, in a form a parser
+      reads deterministically. Approximating a fact you can compute is a trade, not an upgrade.
+    </div>
+  </div>
+</section>
+
+<!-- ===================== WHAT THE APPROXIMATION COSTS ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>Four costs that show up on real repos, not benchmarks.</h2>
+      <p>
+        None of these are exotic failure modes. They're the ordinary behavior of cosine similarity over
+        a corpus that keeps changing under it — which a coding session does, by definition, on nearly
+        every turn.
+      </p>
+    </div>
+
+    <div class="state-grid">
+      <div class="state warn rv">
+        <div class="state-when">Between a save and a rebuild</div>
+        <div class="state-tag">stale window</div>
+        <h3>The index answers about code that's gone</h3>
+        <p>
+          Re-embedding on every save is too expensive at agent-editing frequency, so it gets batched.
+          Until that batch runs, the index is still describing the file's previous version — with no
+          signal telling you it's out of date.
+        </p>
+      </div>
+
+      <div class="state move rv rv-d1">
+        <div class="state-when">As the repo grows</div>
+        <div class="state-tag">rank drift</div>
+        <h3>Yesterday's top result isn't today's</h3>
+        <p>
+          Cosine similarity gives no stability guarantee. Add ten unrelated files anywhere in the repo
+          and a query that used to surface the right file at rank one can drift to rank four — with
+          nothing about the query or the target having changed.
+        </p>
+      </div>
+
+      <div class="state gone rv rv-d2">
+        <div class="state-when">At chunk boundaries</div>
+        <div class="state-tag">split symbols</div>
+        <h3>A function cut in half, and returned as neither half</h3>
+        <p>
+          Fixed-size chunking doesn't know where a symbol starts or ends. A function that straddles a
+          chunk boundary gets embedded as two unrelated fragments, and a query for it can retrieve
+          either fragment without the context that makes it mean anything.
+        </p>
+      </div>
+
+      <div class="state warn rv rv-d3">
+        <div class="state-when">On every single lookup</div>
+        <div class="state-tag">recurring cost</div>
+        <h3>Paid again for a question already answered once</h3>
+        <p>
+          An embed call plus an ANN search happen on every query an agent makes — often dozens per
+          session. A parser answers "who imports this file" once, patches in milliseconds when the file
+          changes, and never has to ask an API for the answer again.
+        </p>
+      </div>
+    </div>
+
+    <div class="state-note rv">
+      <span class="mk">→</span>
+      <span>
+        None of this makes embeddings the wrong tool, full stop — it makes them a poor fit for a corpus
+        that already has ground truth. <b>If your codebase's vocabulary is genuinely inconsistent</b> —
+        legacy code where names don't match concepts, or you're searching for "the thing that does X"
+        with no shared words at all — that's a real RAG win coldstart doesn't claim. Its own
+        <code>find</code> covers a slice of that with a repo-wide grep-recall pass, not a semantic one.
+      </span>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== THE NOTEBOOK, ON TOP ===================== -->
+<section class="how-sec">
+  <div class="wrap">
+    <div class="how-sec-head rv">
+      <h2>A structural index answers <i>where</i>. Not <i>why it matters</i>.</h2>
+      <p>
+        That gap is real, and it's the one place teams reach for RAG a second time — embedding past
+        conversations, summaries, or decisions as "agent memory." Which quietly re-imports both problems
+        above, at higher stakes: now the stale, drifting thing isn't describing a file, it's describing a
+        decision someone trusted.
+      </p>
+    </div>
+
+    <div class="loop-list">
+      <div class="beat rv">
+        <div class="beat-n">01</div>
+        <div>
+          <h3>The index is a fact about the repo right now.</h3>
+          <p>
+            It can be rebuilt from the source at any moment, so a wrong entry is just a bug — never a
+            standing risk. That's true whether it's built by a parser or a vector store.
+          </p>
+        </div>
+      </div>
+      <div class="beat warm rv">
+        <div class="beat-n">02</div>
+        <div>
+          <h3>A memory is a claim someone made, not a fact you can recompute.</h3>
+          <p>
+            The reasoning behind it is gone the moment the session ends. An embedding of that claim
+            doesn't fix that — it just makes the claim searchable while it silently goes stale.
+          </p>
+        </div>
+      </div>
+      <div class="beat warm rv">
+        <div class="beat-n">03</div>
+        <div>
+          <h3>So the notebook keeps the same discipline as the index, applied one layer up.</h3>
+          <p>
+            Every note is pinned to a fingerprint of the exact files it's about, and re-checked against
+            them on every read. <code>[fresh]</code>, or it says so — the same determinism the index
+            gives you for "where," extended to "why."
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="loop-close rv">
+      <b>That's the actual comparison.</b> It isn't coldstart-the-parser against RAG-the-search-engine —
+      it's an index and a notebook that both stay honest about their own staleness, against a similarity
+      score that has no way to tell you it's wrong.
+      <a href="/how-it-works/notebook/">How the notebook works →</a>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== CLOSE ===================== -->
+<section class="how-close">
+  <div class="wrap">
+    <div class="rv">
+      <h2>No vector store to stand up. No embedding bill.</h2>
+      <p>
+        One index, kept current in the background, plus notes that check themselves. Two commands and
+        it starts working on whatever repo you're in.
+      </p>
+      <div class="how-cmds has-copy">
+        <button type="button" class="copy-btn" data-copy="npm install -g @cstart/coldstart&#10;coldstart init" aria-label="Copy install commands">Copy</button>
+        npm install -g @cstart/coldstart<br><span>coldstart init</span>
+      </div>
+      <div class="how-next">
+        <a class="primary" href="/docs/">Read the docs</a>
+        <a class="ghost" href="/blog/why-coldstart-makes-zero-llm-calls/">Why coldstart makes zero LLM calls →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<Footer variant="how" />
+
+<script>
+  (function () {
+    document.querySelectorAll('.copy-btn[data-copy]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var text = btn.getAttribute('data-copy') || '';
+        function done() {
+          btn.classList.add('copied');
+          btn.textContent = 'Copied';
+          setTimeout(function () { btn.classList.remove('copied'); btn.textContent = 'Copy'; }, 1600);
+        }
+        if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {});
+          return;
+        }
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); done(); } catch (e) {}
+        document.body.removeChild(ta);
+      });
+    });
+  })();
+
+  (function () {
+    var els = document.querySelectorAll('.rv, .ring-fig, .temp-fig');
+    if (!('IntersectionObserver' in window)) {
+      els.forEach(function (el) { el.classList.add('in'); });
+      return;
+    }
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
+    els.forEach(function (el) { io.observe(el); });
+  })();
+</script>
+</body>
+</html>

--- a/site-astro/src/styles/docs.css
+++ b/site-astro/src/styles/docs.css
@@ -57,46 +57,42 @@ code { font-family: var(--mono); }
 /* ---- NAV (shared chrome — same max-width/padding as landing.css so the
    bar doesn't visibly resize between home, docs, and blog) ---- */
 nav {
-  position: sticky; top: 0; z-index: 30;
-  background: color-mix(in srgb, var(--bg) 80%, transparent);
-  backdrop-filter: blur(10px);
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--line);
 }
-.nav-in { display: flex; align-items: center; gap: 20px; height: 60px; max-width: 1120px; margin: 0 auto; padding: 0 28px; }
+.nav-in { display: flex; align-items: center; gap: 28px; height: 64px; max-width: 1120px; margin: 0 auto; padding: 0 28px; }
 .brand { font-family: var(--display); font-weight: 500; font-size: 19px; letter-spacing: -.01em; display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
-.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, var(--ember-bright), var(--frost)); box-shadow: 0 0 10px color-mix(in srgb, var(--frost) 50%, transparent); }
+.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 34% 30%, var(--ember), var(--frost)); box-shadow: 0 0 12px color-mix(in srgb, var(--frost) 60%, transparent); }
 .brand .mark { flex: none; }
 .mark { fill: none; }
 .fl { stroke-width: 2.1; stroke-linecap: round; }
 .s2 .fl { stroke: url(#warm); }
 .core { stroke: none; }
 .nav-spacer { flex: 1; }
-.nav-links { display: flex; gap: 22px; font-size: 14px; }
+.nav-links { display: flex; gap: 26px; font-size: 14px; }
 .nav-links a { position: relative; padding-bottom: 4px; color: var(--muted); text-decoration: none; transition: color .15s; }
 .nav-links a:hover { color: var(--ink); }
 .nav-links a.active { color: var(--frost); }
 .nav-links a.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -4px; height: 2px; border-radius: 1px; background: var(--frost); }
-.nav-cta { font-family: var(--mono); font-size: 13.5px; text-decoration: none; padding: 9px 18px; border-radius: 6px; background: var(--frost); color: #04121a; font-weight: 600; transition: opacity .15s; }
-.nav-cta:hover { opacity: .88; }
 .nav-burger { display: none; flex: none; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer; padding: 0; align-items: center; justify-content: center; flex-direction: column; }
 .nav-burger span { display: block; width: 15px; height: 1.5px; background: var(--ink); border-radius: 2px; }
 .nav-burger span + span { margin-top: 3px; }
 .nav-mobile {
-  display: none; flex-direction: column; gap: 2px; padding: 10px 24px 16px;
-  position: fixed; top: 60px; left: 0; right: 0; z-index: 29;
-  max-height: calc(100vh - 60px); overflow-y: auto;
+  display: none; flex-direction: column; gap: 2px; padding: 10px 28px 16px;
+  position: fixed; top: 64px; left: 0; right: 0; z-index: 49;
+  max-height: calc(100vh - 64px); overflow-y: auto;
   background: color-mix(in srgb, var(--bg) 96%, transparent);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
   border-top: 1px solid var(--line);
 }
 .nav-mobile.open { display: flex; }
 .nav-mobile a { font-family: var(--mono); font-size: 14.5px; color: var(--muted); text-decoration: none; padding: 10px 0; border-bottom: 1px solid color-mix(in srgb, var(--line) 70%, transparent); }
 .nav-mobile a:last-child { border-bottom: 0; }
 .nav-mobile a:hover { color: var(--ink); }
-.nav-mobile .nav-cta { display: inline-block; margin-top: 8px; text-align: center; color: #04121a; }
-.nav-mobile .nav-cta:hover { color: #04121a; }
 @media (max-width: 860px) {
-  .nav-links, .nav-in .nav-cta { display: none; }
+  .nav-links { display: none; }
   .nav-burger { display: flex; }
 }
 
@@ -110,13 +106,13 @@ nav {
 .term-bar .tl:nth-child(1) { background: #ff5f57; }
 .term-bar .tl:nth-child(2) { background: #febc2e; }
 .term-bar .tl:nth-child(3) { background: #28c840; }
-.term-bar .title { margin-left: 10px; font-family: var(--mono); font-size: 12px; color: #5d6b83; }
+.term-bar .title { margin-left: 10px; font-family: var(--mono); font-size: 12px; color: #7a8aa3; }
 .term-body { padding: 20px 22px 26px; font-family: var(--mono); font-size: 13.5px; line-height: 1.75; color: var(--term-ink); overflow-x: auto; }
-.term-body .ln { white-space: pre; }
+.term-body .ln { white-space: pre; display: block; }
 .c-prompt { color: #4fd18b; }
 .c-cmd { color: #eef3fb; }
 .c-flag { color: #ffb267; }
-.c-dim { color: #5d6b83; }
+.c-dim { color: #7a8aa3; }
 .c-frost { color: #6fd3ef; }
 .c-ember { color: #ffb267; }
 .c-file { color: #c3d0e2; }
@@ -134,7 +130,6 @@ nav {
 /* ---- LANGS ---- */
 .langs { display: flex; flex-wrap: wrap; gap: 9px; }
 .chip { font-family: var(--mono); font-size: 12.5px; padding: 5px 11px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); background: var(--surface-2); }
-.chip.hot { color: var(--frost); border-color: color-mix(in srgb, var(--frost) 40%, var(--line)); }
 .doc-sec .langs { margin-top: 20px; gap: 8px; }
 
 /* ---- pills (freshness) ---- */
@@ -165,7 +160,8 @@ nav {
 /* ---- FRESHNESS / feature cards ---- */
 .fgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
 @media (max-width: 820px) { .fgrid { grid-template-columns: 1fr; } }
-.fcard { border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; background: var(--surface); }
+.fcard { display: block; border: 1px solid var(--line); border-radius: var(--radius); padding: 24px; background: var(--surface); text-decoration: none; transition: border-color .15s, transform .15s; }
+a.fcard:hover { border-color: color-mix(in srgb, var(--frost) 45%, var(--line)); transform: translateY(-2px); }
 .fcard .fnum { font-family: var(--mono); font-size: 12px; color: var(--frost); letter-spacing: .1em; }
 .fcard h4 { font-family: var(--mono); font-size: 16px; margin: 10px 0 8px; letter-spacing: -.01em; }
 .fcard p { font-size: 14.5px; color: var(--muted); }
@@ -198,7 +194,7 @@ footer { border-top: 1px solid var(--line); padding: 48px 0; }
 .docs { max-width: 1200px; margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px 1fr; gap: 56px; align-items: start; }
 @media (max-width: 860px) { .docs { grid-template-columns: 1fr; gap: 0; } }
 
-.side { position: sticky; top: 60px; align-self: start; max-height: calc(100vh - 60px); overflow-y: auto; padding: 34px 0 60px; }
+.side { position: sticky; top: 64px; align-self: start; max-height: calc(100vh - 64px); overflow-y: auto; padding: 34px 0 60px; }
 @media (max-width: 860px) { .side { position: static; max-height: none; border-bottom: 1px solid var(--line); padding: 8px 0; } }
 
 .side-toggle { display: none; }
@@ -231,6 +227,8 @@ footer { border-top: 1px solid var(--line); padding: 48px 0; }
 .content h1 { font-family: var(--display); font-weight: 500; font-size: clamp(30px, 5vw, 40px); letter-spacing: -.01em; line-height: 1.1; }
 .content h2 { font-family: var(--display); font-weight: 500; font-size: clamp(21px, 3vw, 26px); letter-spacing: -.01em; }
 .content > p, .doc-sec > p, .prose p { color: var(--muted); font-size: 16px; margin-top: 14px; }
+.content p a, .doc-sec p a, .prose p a, .doc-sec li a { color: var(--frost); text-decoration: underline; text-decoration-color: color-mix(in srgb, var(--frost) 35%, transparent); text-underline-offset: 2px; }
+.content p a:hover, .doc-sec p a:hover, .prose p a:hover, .doc-sec li a:hover { text-decoration-color: currentColor; }
 .prose p + p { margin-top: 12px; }
 .lead-p { font-size: 18px !important; color: var(--muted); margin-top: 18px; }
 .content b, .prose b { color: var(--ink); font-weight: 600; }
@@ -240,25 +238,22 @@ p code, li code, .prose code { font-size: 13.5px; background: var(--surface-2); 
 .cmd { margin-top: 8px; }
 .cmd .name { font-family: var(--mono); font-size: 24px; font-weight: 700; letter-spacing: -.02em; display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 .cmd .name .c { color: var(--frost); }
-.cmd .name.warm .c { color: var(--ember); }
 .cmd .name .badge { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; align-self: center; }
 .cmd .sig { font-family: var(--mono); font-size: 14px; color: var(--muted); margin-top: 8px; }
 .cmd .desc { margin-top: 12px; color: var(--muted); font-size: 15.5px; }
 .cmd .desc b { color: var(--ink); }
 
-.flags { margin-top: 18px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
-.flag-row { display: grid; grid-template-columns: 190px 1fr; gap: 16px; padding: 11px 16px; border-top: 1px solid var(--line); font-size: 14px; }
-.flag-row:first-child { border-top: 0; }
+.flags { margin-top: 18px; }
+.flag-row { display: grid; grid-template-columns: 190px 1fr; gap: 16px; padding: 10px 0; border-top: 1px solid var(--line); font-size: 14px; }
+.flag-row:first-child { border-top: 0; padding-top: 0; }
 .flag-row .fk { font-family: var(--mono); font-size: 12.5px; color: var(--frost); }
 .flag-row .fv { color: var(--muted); }
 .flag-row .fv b { color: var(--ink); }
 @media (max-width: 560px) { .flag-row { grid-template-columns: 1fr; gap: 4px; } }
 
-.callout { margin-top: 20px; border: 1px solid var(--line); border-left: 3px solid var(--frost); background: var(--surface-2); border-radius: 8px; padding: 14px 18px; font-size: 14.5px; color: var(--muted); }
-.callout.warm { border-left-color: var(--ember); }
+.callout { margin-top: 20px; border-left: 2px solid var(--frost); padding: 2px 0 2px 16px; font-size: 14.5px; color: var(--muted); }
 .callout b { color: var(--ink); }
 .callout .ct { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--frost); display: block; margin-bottom: 6px; }
-.callout.warm .ct { color: var(--ember); }
 
 .types { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; margin-top: 20px; }
 @media (max-width: 680px) { .types { grid-template-columns: 1fr; } }
@@ -301,7 +296,7 @@ body.essay-page {
   --ink: #eef3fb;
   --prose: #c9d3e2;       /* 12.8:1 — was #8b9ab2 at 6.9:1 */
   --muted: #8b9ab2;
-  --faint: #6b7789;
+  --faint: #7a8aa3;
   --line: #1e2735;
   --line-soft: #182029;
   --frost: #4fbfe0;

--- a/site-astro/src/styles/how.css
+++ b/site-astro/src/styles/how.css
@@ -12,7 +12,7 @@ body.how-page {
   --paper: #e5d9bd;
   --paper-ink: #2a2620;
   --paper-line: #c7b790;
-  --faint: #5d6b83;
+  --faint: #7a8aa3;
   --ember-dim: #a86a35;
 }
 
@@ -177,6 +177,60 @@ body.how-page {
 .how-aside { margin-top: 40px; padding-top: 30px; border-top: 1px solid var(--line); max-width: 680px; }
 .how-aside h3 { font-family: var(--display); font-weight: 400; font-size: 21px; letter-spacing: -.01em; margin-bottom: 10px; }
 .how-aside p { color: var(--muted); font-size: 15.5px; }
+
+/* ============================================================
+   NOTEBOOK MOCK — a built (not screenshotted) recreation of `kb view`
+   ============================================================ */
+.nb-mock { margin: 0; }
+.nb-mock figcaption { margin-top: 14px; font-size: 13.5px; color: var(--muted); text-align: center; }
+.nb-mock figcaption code { color: var(--frost); }
+
+.nbm-top {
+  display: flex; align-items: center; justify-content: space-between; gap: 20px;
+  padding: 16px 22px; border: 1px solid var(--line); border-bottom: none;
+  border-radius: 14px 14px 0 0; background: var(--surface);
+}
+.nbm-brand { display: flex; flex-direction: column; gap: 2px; }
+.nbm-kick { font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); }
+.nbm-name { font-family: var(--display); font-size: 16px; display: flex; align-items: center; gap: 8px; }
+.nbm-dot { width: 8px; height: 8px; border-radius: 50%; background: radial-gradient(circle at 34% 30%, var(--ember), var(--frost)); }
+.nbm-stats { display: flex; align-items: center; gap: 16px; font-size: 12.5px; color: var(--muted); }
+.nbm-stats b { color: var(--ink); font-size: 14px; }
+.nbm-bar { width: 60px; height: 5px; border-radius: 3px; background: var(--line); overflow: hidden; display: inline-block; }
+.nbm-bar i { display: block; width: 50%; height: 100%; background: linear-gradient(90deg, var(--ok), var(--ember)); }
+.nbm-fresh { color: var(--ink); }
+
+.nbm-body {
+  display: grid; grid-template-columns: 200px 1fr;
+  border: 1px solid var(--line); border-radius: 0 0 14px 14px; overflow: hidden;
+  box-shadow: 0 20px 60px -20px rgba(0,0,0,.5);
+}
+.nbm-side { background: var(--surface); border-right: 1px solid var(--line); padding: 14px 10px; }
+.nbm-search {
+  font-size: 12px; color: var(--muted); border: 1px solid var(--line); border-radius: 7px;
+  padding: 7px 10px; margin-bottom: 12px; background: var(--surface-2);
+}
+.nbm-file { font-family: var(--mono); font-size: 12.5px; color: var(--muted); padding: 6px 10px; border-radius: 6px; }
+.nbm-file.active { color: var(--frost); background: color-mix(in srgb, var(--frost) 10%, transparent); }
+
+.nbm-main { padding: 26px 30px 30px; background: var(--bg); }
+.nbm-crumb { font-family: var(--mono); font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--frost); margin-bottom: 8px; }
+.nbm-title { font-family: var(--mono); font-size: 20px; font-weight: 600; color: var(--ink); margin-bottom: 8px; }
+.nbm-meta { font-size: 12.5px; color: var(--muted); display: flex; align-items: center; gap: 8px; margin-bottom: 22px; }
+.nbm-pill { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--ok); background: var(--ok-bg); border-radius: 999px; padding: 2px 9px; }
+.nbm-anchors { border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; margin-bottom: 22px; background: var(--surface-2); }
+.nbm-anchor-head { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
+.nbm-anchor-row { display: flex; align-items: center; justify-content: space-between; font-size: 14px; margin-bottom: 12px; }
+.nbm-anchor-row code b { color: var(--frost); }
+.nbm-syms { display: flex; gap: 8px; flex-wrap: wrap; }
+.nbm-syms span { font-family: var(--mono); font-size: 12px; color: var(--ink); background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 4px 9px; }
+.nbm-note-head { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); margin-bottom: 8px; }
+.nbm-note { font-size: 14.5px; line-height: 1.65; color: var(--ink); max-width: 68ch; }
+
+@media (max-width: 640px) {
+  .nbm-side { display: none; }
+  .nbm-body { grid-template-columns: 1fr; }
+}
 
 /* ============================================================
    SIGNATURE 2 — the temperature seam (navigation page)

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -10,7 +10,7 @@
   --warm-ground:#12100e;
   --text:#e7eef8;
   --muted:#8b9ab2;
-  --faint:#5d6b83;
+  --faint:#7a8aa3;
   --frost:#4fbfe0;
   --frost-dim:#2f89a8;
   --ember:#ef9448;
@@ -67,9 +67,6 @@ nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
 .nav-links a:hover{color:var(--text);}
 .nav-links a.active{color:var(--frost);}
 .nav-links a.active::after{content:"";position:absolute;left:0;right:0;bottom:-4px;height:2px;border-radius:1px;background:var(--frost);}
-.nav-cta{font-family:var(--mono);font-size:13.5px;padding:9px 18px;border-radius:6px;
-  background:var(--frost);color:#04121a;font-weight:600;transition:opacity .15s;}
-.nav-cta:hover{opacity:.88;}
 .nav-burger{display:none;flex:none;width:34px;height:34px;border:1px solid var(--line);border-radius:8px;
   background:transparent;cursor:pointer;padding:0;align-items:center;justify-content:center;flex-direction:column;}
 .nav-burger span{display:block;width:15px;height:1.5px;background:var(--text);border-radius:2px;}
@@ -87,15 +84,13 @@ nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
   border-bottom:1px solid color-mix(in srgb,var(--line) 70%,transparent);}
 .nav-mobile a:last-child{border-bottom:0;}
 .nav-mobile a:hover{color:var(--text);}
-.nav-mobile .nav-cta{display:inline-block;margin-top:8px;text-align:center;color:#04121a;}
-.nav-mobile .nav-cta:hover{color:#04121a;}
 @media(max-width:820px){
-  .nav-links,.nav-in .nav-cta{display:none;}
+  .nav-links{display:none;}
   .nav-burger{display:flex;}
 }
 
 /* ---------- shared section scaffold ---------- */
-section{padding:104px 0;position:relative;}
+section{padding:76px 0;position:relative;}
 .eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
   color:var(--frost);margin-bottom:22px;}
 .eyebrow.warm{color:var(--ember);}
@@ -111,15 +106,15 @@ h2{font-family:var(--display);font-weight:500;font-size:clamp(28px,4vw,42px);
 .rise.in{opacity:1;transform:none;}
 
 /* ---------- HERO ---------- */
-.hero{padding:88px 0 72px;position:relative;overflow:hidden;text-align:center;}
+.hero{padding:44px 0 64px;position:relative;overflow:hidden;text-align:center;}
 .hero::before{content:"";position:absolute;inset:0;z-index:-1;
   background:
     radial-gradient(70% 55% at 50% -10%,color-mix(in srgb,var(--frost) 13%,transparent),transparent 60%);}
-.hero-in{max-width:760px;margin:0 auto;}
+.hero-in{max-width:920px;margin:0 auto;}
 .kicker{font-family:var(--mono);font-size:13px;letter-spacing:.1em;text-transform:uppercase;
-  color:var(--faint);margin-bottom:24px;}
+  color:var(--faint);margin-bottom:20px;}
 h1.title{font-family:var(--display);font-weight:500;margin:0 auto;
-  font-size:clamp(34px,5.4vw,58px);line-height:1.14;letter-spacing:-.01em;max-width:16ch;text-wrap:balance;}
+  font-size:clamp(28px,4.4vw,44px);line-height:1.2;letter-spacing:-.01em;max-width:36ch;}
 h1.title .cold{color:var(--frost);}
 .hero-sub{margin:26px auto 0;font-size:clamp(16px,2vw,18px);color:var(--muted);max-width:50ch;line-height:1.65;}
 .hero-sub b{color:var(--text);font-weight:500;}
@@ -142,6 +137,8 @@ h1.title .cold{color:var(--frost);}
 .btn-primary:hover{transform:translateY(-1px);box-shadow:0 12px 30px -8px color-mix(in srgb,var(--frost) 55%,transparent);}
 .btn-ghost{color:var(--text);border:1px solid var(--line);}
 .btn-ghost:hover{border-color:var(--frost);}
+.btn-icon{padding:12px 18px;color:var(--muted);}
+.btn-icon:hover{color:var(--text);}
 .hero-note{font-family:var(--mono);font-size:12px;color:var(--faint);}
 
 /* ---------- TERMINAL ---------- */
@@ -152,7 +149,7 @@ h1.title .cold{color:var(--frost);}
   border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.015);}
 .tl{width:11px;height:11px;border-radius:50%;}
 .tl:nth-child(1){background:#ff5f57;}.tl:nth-child(2){background:#febc2e;}.tl:nth-child(3){background:#28c840;}
-.term-title{margin-left:10px;font-family:var(--mono);font-size:11.5px;color:#5d6b83;}
+.term-title{margin-left:10px;font-family:var(--mono);font-size:11.5px;color:#7a8aa3;}
 .copy-btn{margin-left:auto;font-family:var(--mono);font-size:11px;color:#8aa0bd;cursor:pointer;
   background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:6px;
   padding:4px 10px;transition:color .15s,background .15s,border-color .15s;}
@@ -162,7 +159,7 @@ h1.title .cold{color:var(--frost);}
   color:#c3d0e2;overflow-x:auto;}
 .term-body .l{white-space:pre;display:block;}
 .p-prompt{color:#4fd18b;}.p-cmd{color:#eef3fb;}.p-flag{color:var(--ember);}
-.p-dim{color:#5d6b83;}.p-frost{color:#6fd3ef;}.p-ember{color:#ffb267;}
+.p-dim{color:#7a8aa3;}.p-frost{color:#6fd3ef;}.p-ember{color:#ffb267;}
 .p-hit{color:#4fd18b;}.p-file{color:#c3d0e2;}
 .term-body .gap{display:block;height:9px;}
 /* typing reveal */
@@ -175,11 +172,9 @@ h1.title .cold{color:var(--frost);}
 /* ---------- NAVIGATION SECTION (the index) ---------- */
 .navsec{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
 .navsec > .wrap > .rise:first-child,
-.phil > .wrap > .rise:first-child,
-.install > .wrap > .rise:first-child{max-width:720px;margin-left:auto;margin-right:auto;text-align:center;}
+.phil > .wrap > .rise:first-child{max-width:720px;margin-left:auto;margin-right:auto;text-align:center;}
 .navsec > .wrap > .rise:first-child .lead,
-.phil > .wrap > .rise:first-child .lead,
-.install > .wrap > .rise:first-child .lead{margin-left:auto;margin-right:auto;}
+.phil > .wrap > .rise:first-child .lead{margin-left:auto;margin-right:auto;}
 
 /* hand-drawn comparison: wandering grep path vs. a straight two-hop find→gs path */
 .flow-figure{margin-top:48px;}
@@ -371,7 +366,7 @@ h1.title .cold{color:var(--frost);}
 .article-card p{margin-top:12px;color:var(--muted);font-size:14.5px;}
 
 /* ---------- FAQ ---------- */
-.faq{background:var(--ink-1);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.faq{background:var(--ink-1);border-top:1px solid var(--line);}
 .faq > .wrap > .rise:first-child{max-width:720px;margin-left:auto;margin-right:auto;text-align:center;}
 .faq > .wrap > .rise:first-child .lead{margin-left:auto;margin-right:auto;}
 .faq-list{display:flex;flex-direction:column;gap:0;margin-top:48px;max-width:720px;margin-left:auto;margin-right:auto;}
@@ -389,10 +384,11 @@ h1.title .cold{color:var(--frost);}
   border:1px solid var(--line);border-radius:4px;padding:1px 5px;}
 @media(max-width:640px){.faq-item{padding:20px;}.faq-q{font-size:15.5px;}.faq-a{font-size:14px;}}
 
-/* ---------- INSTALL ---------- */
-.install-term{max-width:760px;margin:44px auto 0;}
-.install .cta{justify-content:center;margin-top:30px;}
-.install-langs{margin-top:26px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
+/* ---------- INSTALL (in hero) / FAQ CLOSE ---------- */
+.install-term{max-width:760px;margin:36px auto 0;text-align:left;}
+.faq-close{margin-top:52px;text-align:center;}
+.faq-close-links{display:flex;gap:14px;justify-content:center;}
+.install-langs{margin-top:22px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
 
 /* ---------- FOOTER ---------- */
 footer{border-top:1px solid var(--line);padding:50px 0;}


### PR DESCRIPTION
## Summary
Response to a friend's review pass on the marketing site.

- Split the single `/docs/` page into `/docs/`, `/docs/navigation/`, `/docs/notebook/`, `/docs/under-the-hood/` — nextjs.org-style progressive-disclosure sidebar, content trimmed, single accent color, de-boxed UI.
- Fixed header inconsistency between landing and docs pages (nav CSS had drifted: 60px vs 64px height, different gap/z-index).
- Fixed docs sidebar's active group header double-boxing bug.
- Removed arbitrary "hot" color tier on supported-language chips.
- Reverted npm nav link to plain text; fixed a terminal-block line-collapse rendering bug.
- Added a hand-built HTML/CSS recreation of the notebook's `kb view` UI to `/how-it-works/notebook/` (not a screenshot — matches the site's existing built-UI pattern).
- Landing hero copy tightened; new `/vs/vector-rag/` comparison page.
- Fixed `.gitignore`: an unanchored `docs/` pattern (meant for the repo-root internal-docs folder) was silently excluding `site-astro/src/pages/docs/` from git.

## Test plan
- [x] `npm run build` — 20 pages, no errors
- [x] Screenshot-verified desktop: home, `/docs/`, `/docs/navigation/`, `/docs/notebook/`, `/docs/under-the-hood/`, `/how-it-works/notebook/`
- [x] Screenshot-verified mobile (390×844): home, `/docs/` + mobile menu, `/docs/under-the-hood/` languages, `/how-it-works/notebook/` notebook mock (sidebar correctly hides below 640px)
- [x] Broken-anchor-link audit across the whole site after the docs split

🤖 Generated with [Claude Code](https://claude.com/claude-code)