### PR TITLE
fix(windows): hide consoles from daemon child_process calls

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -176,8 +176,7 @@ export function wireClaudeKbHooks(cwd: string): 'created' | 'updated' | { error:
 function notebookRawTracked(cwd: string): boolean {
   try {
     const listed = execFileSync('git', ['ls-files', '.coldstart/notebook/.raw'], {
-      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
-    });
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true });
     return listed.trim().length > 0;
   } catch {
     return false; // not a git repo, or git unavailable — treat as untracked

--- a/src/kb/commit.ts
+++ b/src/kb/commit.ts
@@ -31,7 +31,7 @@ export interface KbCommitResult {
 }
 
 function git(root: string, args: string[]): string {
-  return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
 }
 
 export function kbCommit(root: string, message?: string): KbCommitResult {

--- a/src/kb/git.ts
+++ b/src/kb/git.ts
@@ -18,8 +18,7 @@ export function gitHeadSha(root: string): string | undefined {
       cwd: root,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 3000,
-    }).trim();
+      timeout: 3000, windowsHide: true }).trim();
     return /^[0-9a-f]{40}/.test(out) ? out.slice(0, 12) : undefined;
   } catch {
     return undefined;

--- a/src/kb/view.ts
+++ b/src/kb/view.ts
@@ -112,7 +112,7 @@ function openInBrowser(file: string): void {
     : process.platform === 'win32' ? { bin: 'cmd', args: ['/c', 'start', '', file] }
     : { bin: 'xdg-open', args: [file] };
   try {
-    const child = execFile(cmd.bin, cmd.args, () => {});
+    const child = execFile(cmd.bin, cmd.args, { windowsHide: true }, () => {});
     child.unref();
   } catch { /* ignore — the path is printed regardless */ }
 }

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -43,7 +43,7 @@ export async function ensureKeeper(finalRoot: string): Promise<void> {
       const child = spawn(
         process.execPath,
         [entry, '--root', finalRoot, '--daemon', '--quiet'],
-        { detached: true, stdio: 'ignore' },
+        { detached: true, stdio: 'ignore', windowsHide: true },
       );
       child.unref();
     } finally {

--- a/src/server/find.ts
+++ b/src/server/find.ts
@@ -51,7 +51,7 @@ const SCAN_CONCURRENCY = 4;
 
 function probe(bin: string, args: string[], cwd: string, requireSuccess = false): boolean {
   try {
-    execFileSync(bin, args, { cwd, stdio: 'ignore', timeout: 4000 });
+    execFileSync(bin, args, { cwd, stdio: 'ignore', timeout: 4000, windowsHide: true });
     return true;
   } catch (e: unknown) {
     if (requireSuccess) return false;
@@ -225,6 +225,7 @@ function listFilesExternal(searcher: Exclude<Searcher, { kind: 'node' }>, root: 
         cwd: root,
         encoding: 'utf8',
         maxBuffer: 64 * 1024 * 1024,
+        windowsHide: true,
         ...(argv0 ? { argv0 } : {}),
       },
       (err, stdout) => {

--- a/src/server/searcher.ts
+++ b/src/server/searcher.ts
@@ -40,6 +40,7 @@ function isRipgrep(bin: string, argv0?: string): boolean {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 4000,
+      windowsHide: true,
       ...(argv0 ? { argv0 } : {}),
     });
     return out.startsWith('ripgrep');


### PR DESCRIPTION
## Summary
- Pass `windowsHide: true` on keeper self-relaunch, git, ripgrep probe/search, init, and notebook viewer spawns.
- Prevents flashing console / Windows Terminal windows while the detached daemon indexes.

Closes #149