### PR TITLE
site: purge Cloudflare cache after each Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,3 +44,9 @@ jobs:
           path: site-astro/dist
       - id: deployment
         uses: actions/deploy-pages@v4
+      - name: Purge Cloudflare cache
+        run: |
+          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'


### PR DESCRIPTION
## Summary
- Cloudflare now caches HTML at the edge (was `DYNAMIC` on every request before this change's companion Cache Rule)
- Adds a purge step after `deploy-pages` so each deploy invalidates the edge cache immediately instead of waiting on the 1-day edge TTL
- Requires `CF_ZONE_ID` and `CF_API_TOKEN` repo secrets (already configured)

## Test plan
- [x] Verified Cache Rule (Hostname equals coldstartmcp.dev) flips `cf-cache-status` MISS → HIT
- [ ] Confirm this workflow step runs green on merge and purges successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)