### PR TITLE
fix(init): quote hook command paths — every hook is silently dead on Windows

### DIFF
--- a/hooks/capture-payload.mjs
+++ b/hooks/capture-payload.mjs
@@ -142,6 +142,9 @@ function writeDurableWorklist(root, sid, aid, entries) {
  * with its own `.coldstart/checklist.md`. Placeholders {{WORKLIST}}, {{CLI}},
  * {{ROOT}}, {{SID}}, {{AID}} are substituted. The worklist is LOAD-BEARING (it is the
  * scope rule) — an override that omits {{WORKLIST}} gets it appended anyway.
+ * {{CLI}} and {{ROOT}} expand to absolute paths pasted into shell commands, so
+ * they are QUOTED at every use site below — an unquoted Windows path loses its
+ * backslashes in `sh` (same bug as `nodeCommand` in src/init.ts).
  * Trigger mechanics stay in code; only the prompt text is overridable. Merge
  * semantics when the shipped default evolves = none (the override wins
  * wholesale) — revisit before promoting past spike.
@@ -284,17 +287,17 @@ found wrong: {"op":"retract","id":"<id>","target":{"kind":"note"}} (as one array
   cat > /tmp/notes.json <<'JSON'
   [ {…note 1…}, {…note 2…} ]
 JSON
-  node {{CLI}} kb write /tmp/notes.json --root {{ROOT}} --session {{SID}} --agent {{AID}} --force
-  Full shapes: run \`node {{CLI}} kb write --root {{ROOT}}\` with no spec — it prints the guide.
+  node "{{CLI}}" kb write /tmp/notes.json --root "{{ROOT}}" --session {{SID}} --agent {{AID}} --force
+  Full shapes: run \`node "{{CLI}}" kb write --root "{{ROOT}}"\` with no spec — it prints the guide.
   (Keep --session/--agent exactly as written — they point coverage at THIS agent's worklist.)
 
 FLOW DECISION — record what you decided about FLOWS (created a new one, folded into an \
 existing one, or none) so the flow gate can be measured. Ride it on the SAME batch write — it \
 is a flag, not a second command:
-  node {{CLI}} kb write /tmp/notes.json --root {{ROOT}} --session {{SID}} --agent {{AID}} --force \\
+  node "{{CLI}}" kb write /tmp/notes.json --root "{{ROOT}}" --session {{SID}} --agent {{AID}} --force \\
     --decision <none|new|update> [--id <flow id>] --why "<one clause>"
 Only when you wrote NO notes at all is there no write to carry it, and then run it alone:
-  node {{CLI}} kb flow-decision --decision none --why "<one clause>" --root {{ROOT}} --session {{SID}}`;
+  node "{{CLI}}" kb flow-decision --decision none --why "<one clause>" --root "{{ROOT}}" --session {{SID}}`;
 }
 
 /** Ensure the permanent instructions file exists and is current; return its

--- a/src/init.ts
+++ b/src/init.ts
@@ -109,6 +109,33 @@ function resolveHooksDir(): string {
   return path.join(installRoot(), 'hooks');
 }
 
+/**
+ * `node "<abs path>"` — the command string every host config and slash-command
+ * body is built from.
+ *
+ * **The quotes are load-bearing.** A hook `command` is a shell string, and the
+ * hosts hand it to a POSIX shell even on Windows (Claude Code runs hooks
+ * through Git Bash), which strips every backslash in an unquoted Windows path:
+ *
+ *   node C:\Users\me\...\hooks\find-nudge.mjs   →   node C:Usersme...find-nudge.mjs
+ *
+ * node then resolves that drive-relative remainder against the cwd, so EVERY
+ * fire dies with `Cannot find module`. Hooks fail open by design, so nothing
+ * ever surfaces it — the whole nudge/preguard/recall/capture layer is silently
+ * dead on Windows (5,555 fires / 0 successes over two weeks in the report that
+ * prompted this fix). Double quotes survive both `sh` and `cmd.exe`, and they
+ * also cover install paths containing spaces (`C:\Program Files\...`) on every
+ * platform.
+ *
+ * The idempotency detectors (`isColdstartHookEntry` and friends) match on the
+ * script FILENAME, not the whole string, so quoted and legacy-unquoted entries
+ * are both recognised: a re-run of `init` upgrades an existing broken entry in
+ * place, and `unwire` still strips it.
+ */
+function nodeCommand(scriptPath: string): string {
+  return `node "${scriptPath}"`;
+}
+
 // ---------------------------------------------------------------------------
 // Notebook (kb) setup — skeleton, git wiring, and the Claude recall/capture
 // hooks. Shared by `coldstart init` (always) and the `coldstart kb init` alias.
@@ -159,7 +186,7 @@ export function wireClaudeKbHooks(cwd: string): 'created' | 'updated' | { error:
   }
   const hooksCfg = (settings.hooks && typeof settings.hooks === 'object' ? settings.hooks : {}) as Record<string, unknown>;
   const stripOurs = (arr: unknown): unknown[] => (Array.isArray(arr) ? arr : []).filter((e) => !isKbHookEntry(e));
-  const entry = (file: string): unknown => ({ hooks: [{ type: 'command', command: `node ${path.join(hooksDir, file)}` }] });
+  const entry = (file: string): unknown => ({ hooks: [{ type: 'command', command: nodeCommand(path.join(hooksDir, file)) }] });
   hooksCfg.UserPromptSubmit = [...stripOurs(hooksCfg.UserPromptSubmit), entry(KB_HOOK_RECALL)];
   hooksCfg.Stop = [...stripOurs(hooksCfg.Stop), entry(KB_HOOK_ELICIT)];
   hooksCfg.SubagentStop = [...stripOurs(hooksCfg.SubagentStop), entry(KB_HOOK_ELICIT)];
@@ -381,8 +408,8 @@ export function isCodexHookEntry(entry: unknown): boolean {
  * regex `.*`. Everything else is identical — the shipped handlers are the same.
  */
 function coldstartHooks(hooksDir: string, postMatcher: string): HookSet {
-  const preCmd = `node ${path.join(hooksDir, HOOK_PRE)}`;
-  const postCmd = `node ${path.join(hooksDir, HOOK_POST)}`;
+  const preCmd = nodeCommand(path.join(hooksDir, HOOK_PRE));
+  const postCmd = nodeCommand(path.join(hooksDir, HOOK_POST));
   return {
     PreToolUse: [{ matcher: PRE_MATCHER, hooks: [{ type: 'command', command: preCmd }] }],
     PostToolUse: [{ matcher: postMatcher, hooks: [{ type: 'command', command: postCmd }] }],
@@ -474,7 +501,7 @@ export function wireCodexHooks(cwd: string): 'created' | 'updated' | { error: st
       : {};
   const stripOurs = (arr: unknown): unknown[] =>
     (Array.isArray(arr) ? arr : []).filter((entry) => !isCodexHookEntry(entry));
-  const command = (file: string): HookCommand => ({ type: 'command', command: `node ${path.join(hooksDir, file)}` });
+  const command = (file: string): HookCommand => ({ type: 'command', command: nodeCommand(path.join(hooksDir, file)) });
   hooksCfg.PreToolUse = [
     ...stripOurs(hooksCfg.PreToolUse),
     { matcher: PRE_MATCHER, hooks: [command(CODEX_HOOK_PRE)] },
@@ -553,7 +580,7 @@ export function wireCursorHooks(cwd: string): 'created' | 'updated' | { error: s
       : {};
   const stripOurs = (arr: unknown): unknown[] =>
     (Array.isArray(arr) ? arr : []).filter((entry) => !isCursorHookEntry(entry));
-  const command = (file: string): { command: string } => ({ command: `node ${path.join(hooksDir, file)}` });
+  const command = (file: string): { command: string } => ({ command: nodeCommand(path.join(hooksDir, file)) });
 
   hooksCfg.preToolUse = [...stripOurs(hooksCfg.preToolUse), command(CURSOR_HOOK_PRE)];
   hooksCfg.postToolUse = [...stripOurs(hooksCfg.postToolUse), command(CURSOR_HOOK_POST)];
@@ -660,7 +687,7 @@ export const USER_COMMANDS: Record<'capture' | 'repair' | 'repairAliases', UserC
     // REQUIRED — without it the hook refuses rather than guess a session
     // (kb-elicit.mjs --manual); Claude supplies it via ${CLAUDE_SESSION_ID}.
     invocation: (sessionExpr) =>
-      `node ${path.join(resolveHooksDir(), 'kb-elicit.mjs')} --manual`
+      `${nodeCommand(path.join(resolveHooksDir(), 'kb-elicit.mjs'))} --manual`
       + (sessionExpr ? ` --session "${sessionExpr}"` : ''),
     description: 'Capture notebook notes for the work done so far',
     skillDescription:
@@ -677,7 +704,7 @@ export const USER_COMMANDS: Record<'capture' | 'repair' | 'repairAliases', UserC
     name: REPAIR_COMMAND,
     // The CLI, not a hook: repair reads the notebook and nothing else, so it
     // needs no session and no index. `--root .` keeps it repo-agnostic.
-    invocation: () => `node ${path.join(installRoot(), 'dist', 'index.js')} kb repair --root .`,
+    invocation: () => `${nodeCommand(path.join(installRoot(), 'dist', 'index.js'))} kb repair --root .`,
     description: 'Repair notebook notes that are written but unfindable',
     skillDescription:
       'Repair coldstart notebook notes that are missing the fields which make them findable '
@@ -693,7 +720,7 @@ export const USER_COMMANDS: Record<'capture' | 'repair' | 'repairAliases', UserC
   },
   repairAliases: {
     name: REPAIR_ALIASES_COMMAND,
-    invocation: () => `node ${path.join(installRoot(), 'dist', 'index.js')} kb repair-aliases --root .`,
+    invocation: () => `${nodeCommand(path.join(installRoot(), 'dist', 'index.js'))} kb repair-aliases --root .`,
     description: 'Reconcile identityAliases that no longer describe the file/flow',
     skillDescription:
       'Reconcile coldstart notebook identityAliases against the current code — catches aliases that '

--- a/tests/hook-command-quoting.test.ts
+++ b/tests/hook-command-quoting.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Hook/command paths must be shell-quoted, or every hook is dead on Windows.
+ *
+ * A hook `command` is a shell string. The hosts hand it to a POSIX shell even
+ * on Windows (Claude Code runs hooks through Git Bash), which strips every
+ * backslash in an unquoted Windows path:
+ *
+ *   node C:\Users\me\...\hooks\find-nudge.mjs  ->  node C:Usersme...find-nudge.mjs
+ *
+ * node then resolves that drive-relative remainder against the cwd and the hook
+ * dies with `Cannot find module` on EVERY fire. Hooks fail open, so nothing
+ * surfaces — a real report had 5,555 fires and 0 successes across two weeks
+ * before anyone noticed the layer was gone.
+ *
+ * Two guards, in the spirit of windows-hide-coverage.test.ts:
+ *   1. behavioural — the wiring writers actually emit a quoted, resolvable path
+ *      (and it survives a real `sh` round-trip where one is available);
+ *   2. static — no new `node ${...}` command string can be added unquoted.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  wireClaudeHooks,
+  wireCodexHooks,
+  wireCursorHooks,
+  wireClaudeKbHooks,
+  USER_COMMANDS,
+} from '../src/init.js';
+
+const ROOT = path.resolve(path.dirname(__filename), '..');
+
+/** Every `command` string anywhere in a wired hooks config, at any nesting. */
+function allCommands(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const child of node) allCommands(child, out);
+  } else if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === 'command' && typeof value === 'string') out.push(value);
+      else allCommands(value, out);
+    }
+  }
+  return out;
+}
+
+/** `node "<path>"[ args]` -> the path, or null if it isn't quoted. */
+function quotedScript(command: string): string | null {
+  const m = /^node "([^"]+)"(\s|$)/.exec(command);
+  return m ? m[1] : null;
+}
+
+/** What a POSIX shell actually passes to node — the whole point of the fix.
+ *  Skipped (returns null) where no usable `sh` exists. */
+function shellArgv(command: string): string[] | null {
+  try {
+    const printer = command.replace(/^node\b/, 'printf "%s\\n"');
+    const raw = execFileSync('sh', ['-c', printer], { encoding: 'utf8', windowsHide: true });
+    return raw.split('\n').filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+describe('hook command paths are shell-quoted', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-quoting-test-'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const writers: Array<[string, (cwd: string) => unknown, string[]]> = [
+    ['wireClaudeHooks', wireClaudeHooks, ['.claude', 'settings.json']],
+    ["wireClaudeKbHooks", wireClaudeKbHooks, ['.claude', 'settings.json']],
+    ['wireCodexHooks', wireCodexHooks, ['.codex', 'hooks.json']],
+    ['wireCursorHooks', wireCursorHooks, ['.cursor', 'hooks.json']],
+  ];
+
+  for (const [name, wire, configPath] of writers) {
+    it(`${name} writes quoted paths that resolve to a real hook file`, () => {
+      wire(tempDir);
+      const config = JSON.parse(fs.readFileSync(path.join(tempDir, ...configPath), 'utf8'));
+      const commands = allCommands(config);
+      expect(commands.length).toBeGreaterThan(0);
+
+      for (const command of commands) {
+        const script = quotedScript(command);
+        expect(script, `unquoted hook command: ${command}`).not.toBeNull();
+        // A quoted path is only useful if it still points at a shipped hook.
+        expect(fs.existsSync(script as string), `hook script missing: ${script}`).toBe(true);
+      }
+    });
+
+    it(`${name} commands survive a POSIX shell intact`, () => {
+      wire(tempDir);
+      const config = JSON.parse(fs.readFileSync(path.join(tempDir, ...configPath), 'utf8'));
+      for (const command of allCommands(config)) {
+        const argv = shellArgv(command);
+        if (argv === null) return; // no usable `sh` here — the static guard still applies
+        expect(argv[0], `sh mangled the path in: ${command}`).toBe(quotedScript(command));
+        expect(fs.existsSync(argv[0])).toBe(true);
+      }
+    });
+  }
+
+  it('slash-command invocations quote their path too', () => {
+    for (const [key, cmd] of Object.entries(USER_COMMANDS)) {
+      const invocation = cmd.invocation('$SID');
+      expect(quotedScript(invocation), `unquoted invocation for ${key}: ${invocation}`).not.toBeNull();
+    }
+  });
+});
+
+describe('static guard: no unquoted node-command strings', () => {
+  const sources = ['src/init.ts', 'hooks/capture-payload.mjs'];
+
+  for (const rel of sources) {
+    it(`${rel}: every interpolated node command is quoted`, () => {
+      const content = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      // `node ${expr}` / `node {{PLACEHOLDER}}` with no opening quote before it.
+      const unquoted = [...content.matchAll(/(?<!")\bnode (\$\{|\{\{)/g)].map(
+        (m) => content.slice(0, m.index).split('\n').length,
+      );
+      expect(
+        unquoted,
+        `unquoted node command path at line(s): ${unquoted.join(', ')} — wrap it in double quotes`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -437,7 +437,7 @@ describe('/capture-notes command wiring', () => {
     expect(body).toContain('!`node ');
     // Claude passes the invoking session id so capture targets THIS session's
     // worklist, not the freshest marker in a concurrent-session repo.
-    expect(body).toContain('kb-elicit.mjs --manual --session "${CLAUDE_SESSION_ID}"`');
+    expect(body).toContain('kb-elicit.mjs" --manual --session "${CLAUDE_SESSION_ID}"`');
   });
 
   it('writes a Cursor command that asks the agent to run it (no ! expansion)', () => {
@@ -445,7 +445,7 @@ describe('/capture-notes command wiring', () => {
     const body = fs.readFileSync(cursorCmd(), 'utf8');
     expect(body).not.toContain('!`');
     // No verified session var for Cursor → plain --manual (freshest-marker fallback).
-    expect(body).toContain('kb-elicit.mjs --manual');
+    expect(body).toContain('kb-elicit.mjs" --manual');
     expect(body).not.toContain('CLAUDE_SESSION_ID');
   });
 
@@ -457,7 +457,7 @@ describe('/capture-notes command wiring', () => {
     expect(body).toMatch(/^---\n/);
     expect(body).toContain(`name: ${CAPTURE_COMMAND}`);
     expect(body).toContain('description: ');
-    expect(body).toContain('kb-elicit.mjs --manual');
+    expect(body).toContain('kb-elicit.mjs" --manual');
   });
 
   it('bakes no repo-specific path — only the install path — so it works from any cwd', () => {


### PR DESCRIPTION
## The bug

`coldstart init` writes hook commands as an **unquoted** path:

```js
const entry = (file) => ({ hooks: [{ type: 'command', command: `node ${path.join(hooksDir, file)}` }] });
```

A hook `command` is a shell string, and the hosts hand it to a POSIX shell even on Windows (Claude Code runs hooks through Git Bash), which eats every backslash:

```
$ echo node C:\Users\me\...\hooks\find-nudge.mjs
node C:Usersme...find-nudge.mjs
```

node resolves that drive-relative remainder against the cwd, so **every** fire dies:

```
Error: Cannot find module 'C:\Users\me\Documents\Dev\golc\Usersme...find-nudge.mjs'
```

Hooks fail open by design, so nothing ever surfaces it. The CLI keeps working perfectly while the entire nudge / preguard / recall / capture layer is silently absent — which is a nasty failure mode, because the notebook still gets *written* and just never gets *recalled*.

## How bad, measured

Counted from my own Claude Code transcripts on a ~1,550-file repo, over the two weeks since I wired coldstart in:

| hook | fires | successes |
|---|---:|---:|
| `find-nudge` | 3,389 | **0** |
| `find-preguard` | 1,820 | **0** |
| `kb-elicit` | 227 | **0** |
| `kb-recall` | 119 | **0** |

5,555 invocations, 5,555 `MODULE_NOT_FOUND`, across 14 sessions. I only found it because you asked me on #149 whether I was still using coldstart and I went digging for a real answer.

Present in 2.2.17 and still in 2.3.0.

## The fix

One helper, applied at all eight command-string sites:

```js
function nodeCommand(scriptPath) {
  return `node "${scriptPath}"`;
}
```

Double quotes survive both `sh` and `cmd.exe`, and they also fix install paths containing spaces (`C:\Program Files\...`) on **every** platform, not just Windows.

Also applied to `{{CLI}}` / `{{ROOT}}` in `hooks/capture-payload.mjs`, since those expand to absolute paths inside shell commands the agent is told to run verbatim.

**Idempotency is unaffected.** `isColdstartHookEntry` / `isKbHookEntry` / `isCodexHookEntry` / `isCursorHookEntry` all match on the script *filename*, not the whole string — so a quoted entry and a legacy unquoted one are both recognised. A re-run of `init` upgrades an existing broken entry in place, and `unwire` still strips it. Existing installs need one `coldstart init` re-run to pick the fix up; there's an argument for a `coldstart doctor` that spots the broken string, but I left that out of this PR.

## Tests

`tests/hook-command-quoting.test.ts`, modelled on your `tests/windows-hide-coverage.test.ts`:

1. **behavioural** — each of `wireClaudeHooks` / `wireClaudeKbHooks` / `wireCodexHooks` / `wireCursorHooks` must write a quoted path that (a) resolves to a real file in `hooks/` and (b) survives a round-trip through an actual `sh` (skipped where no `sh` exists, so it's safe on any runner); plus the three `USER_COMMANDS` invocations.
2. **static** — a scan that rejects any new unquoted `` `node ${...}` `` / `node {{...}}` command string in `src/init.ts` and `hooks/capture-payload.mjs`.

All 11 fail on the pre-fix tree and pass after. Three assertions in `tests/init.test.ts` that spelled out `kb-elicit.mjs --manual` were updated for the closing quote.

## Verification on real Windows

Windows 10, node 22.19.0, against a live repo (not a fixture):

**A/B through the same shell, same script:**

```
--- BEFORE (unquoted) ---
node:internal/modules/cjs/loader:1386
  throw err;
--- AFTER (quoted) ---
(silent, exit 0)
```

**After `coldstart init` with the patched build**, every wired hook executed with a real payload through `sh`:

```
Stop: ok           PreToolUse: ok       PostToolUse: ok
UserPromptSubmit: ok                    SubagentStop: ok
```

**And the layer actually does its job again** — `kb-recall` fed a matching prompt now surfaces the right note, which it had never once done on this machine:

```
- **OFL matrix/templateChannels fixtures cannot be imported at all ...**  [lesson/absence]
  → open: .coldstart/notebook/notes/ofl-matrix-templatechannels-fixtures-cannot-be-imported-at-a.md
```

## Test suite

`npm run build` clean. Full `npm test` on Windows: **44 failed / 754 passed** with the fix vs **46 failed / 741 passed** on unmodified `main` — i.e. +13 passing, no regressions. The failures are pre-existing on Windows and unrelated (rails/laravel/resolver extractors, kb-elicit transcript paths, a flaky `nudge-arming` case that passes 3/3 in isolation). Worth knowing: CI is ubuntu-only, so none of that is currently caught.
