### PR TITLE
fix: Windows path separators — hooks, indexer, find recall, and a Windows CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Windows is a first-class target: coldstart wires hooks into Claude Code,
+    # Cursor and Codex on Windows too. Running ubuntu-only hid an entire class
+    # of bugs for months — every hook silently dead (#158), Rails/Laravel/Go/npm
+    # workspace resolution silently disabled, and zero evidence collected by the
+    # notebook — all invisible because the failures were "not found" branches,
+    # not exceptions. None of it surfaced until a Windows user went digging.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    name: test (${{ matrix.os }})
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # Windows is a first-class target: coldstart wires hooks into Claude Code,

--- a/hooks/evidence.mjs
+++ b/hooks/evidence.mjs
@@ -27,13 +27,18 @@
  * for bash-derived path guesses are the only I/O.
  */
 
-import { join } from "node:path";
+import { join, isAbsolute, relative, sep } from "node:path";
 import { statSync } from "node:fs";
 
 // Path-like tokens inside a shell command (same shape kb-elicit used):
 // anything with an extension. Existence on disk is verified before a bash
 // token becomes evidence — shell tokens are guesses.
-const BASH_PATH_RE = /(?:^|[\s"'`=(:;|])((?:\.{1,2}\/|\/)?[A-Za-z0-9_][A-Za-z0-9_.\/-]*\.[A-Za-z0-9]{1,8})(?=$|[\s"'`):;,|>])/g;
+// The leading alternatives also admit a Windows drive (`D:\src\a.ts`,
+// `D:/src/a.ts`) and backslash separators; without them a Windows shell token
+// either missed entirely or matched from after the colon, yielding a bogus
+// "absolute" path. Both shapes are `mustExist`-gated, so a bad guess is dropped
+// by the stat check rather than becoming false evidence.
+const BASH_PATH_RE = /(?:^|[\s"'`=(:;|])((?:[A-Za-z]:[\\/]|\.{1,2}[\\/]|[\\/])?[A-Za-z0-9_][A-Za-z0-9_.\\/-]*\.[A-Za-z0-9]{1,8})(?=$|[\s"'`):;,|>])/g;
 
 // Verbs whose job is printing file content. Everything not listed here is a
 // mention — including grep/rg (matched LINES are not the file) and
@@ -42,14 +47,28 @@ const READ_VERBS = new Set(["cat", "head", "tail", "bat", "less", "more", "nl", 
 
 const TIER = { mention: 0, gs: 1, read: 2, edit: 3 };
 
+/**
+ * Tool inputs and shell tokens → a forward-slash repo-relative path, or "" for
+ * anything outside the repo.
+ *
+ * This was POSIX-only (`s.startsWith("/")` + a `root + "/"` prefix slice). On
+ * Windows a tool input is `D:\repo\src\a.ts`, which failed the `/` test, fell
+ * through to the relative branch, and was returned VERBATIM as if it were
+ * already repo-relative — so it matched no repo file and every session on
+ * Windows collected zero evidence. Silent: capture just never had anything to
+ * work with. `isAbsolute`/`relative` handle both platforms, both separators,
+ * and the Windows cross-drive case (where `relative` returns an absolute path).
+ */
 function normRel(root, p) {
-  let s = String(p || "").trim();
+  const s = String(p || "").trim();
   if (!s) return "";
-  if (s.startsWith("/")) {
-    if (root && s.startsWith(root + "/")) return s.slice(root.length + 1);
-    return "";
+  if (isAbsolute(s)) {
+    if (!root) return "";
+    const rel = relative(root, s);
+    if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return "";
+    return rel.split(sep).join("/");
   }
-  return s.replace(/^\.\//, "");
+  return s.replace(/^\.[\\/]/, "").split(sep).join("/");
 }
 
 // Split a compound command into simple segments and classify each segment's

--- a/src/cache/disk-cache.ts
+++ b/src/cache/disk-cache.ts
@@ -33,19 +33,21 @@
 import { readFile, writeFile, mkdir, readdir, rm, rename } from 'node:fs/promises';
 import { join, resolve, basename, sep } from 'node:path';
 import { createHash } from 'node:crypto';
-import { homedir } from 'node:os';
+
 import { gzip as gzipCb, gunzip as gunzipCb } from 'node:zlib';
 import { promisify } from 'node:util';
 import type {
   CodebaseIndex, CacheMeta, IndexedFile, SymbolNode, Edge, SymbolEdge,
   Language, SymbolKind, EdgeType, SymbolEdgeType, CallSite, DomainEvidence,
 } from '../types.js';
-import { CACHE_VERSION } from '../constants.js';
+import { CACHE_VERSION, coldstartHome } from '../constants.js';
 
 const gzip = promisify(gzipCb);
 const gunzip = promisify(gunzipCb);
 
-const DEFAULT_CACHE_DIR = join(homedir(), '.coldstart', 'indexes');
+// A FUNCTION, not a const: a module-level const captures the value at import
+// time, so a COLDSTART_HOME set afterwards (tests) would be silently ignored.
+const defaultCacheDir = (): string => join(coldstartHome(), 'indexes');
 const FILES_CHUNK_SIZE = 5000;
 
 export type LoadProfile = 'find' | 'gs' | 'full';
@@ -58,7 +60,7 @@ function cacheKey(rootDir: string): string {
 }
 
 export function getCacheDir(rootDir: string, baseCacheDir?: string): string {
-  const base = baseCacheDir ?? DEFAULT_CACHE_DIR;
+  const base = baseCacheDir ?? defaultCacheDir();
   return join(base, cacheKey(rootDir));
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,29 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { Language } from "./types.js";
+
+/**
+ * Root of coldstart's per-user state (`~/.coldstart` by default), overridable
+ * with `COLDSTART_HOME`.
+ *
+ * The override exists because `os.homedir()` on Windows reads USERPROFILE and
+ * IGNORES `HOME` — so tests that redirected via `process.env.HOME` (the POSIX
+ * habit) kept writing into the user's REAL state directory on Windows. One user
+ * ended up with 18 fixture lockfiles for long-deleted temp roots buried in
+ * `~/.coldstart/daemon`, with PIDs like `12345` and `22222`, permanently
+ * polluting `coldstart status`.
+ *
+ * Read through a FUNCTION, never a module-level const: a const is captured at
+ * import time, so a test setting the env var after import would silently get
+ * the real directory anyway — the same class of bug one level down.
+ *
+ * Production never sets it; tests do, and get real isolation on every platform
+ * instead of a redirect that no-ops on one of them.
+ */
+export function coldstartHome(): string {
+  const override = process.env.COLDSTART_HOME;
+  return override && override.trim() ? override : join(homedir(), ".coldstart");
+}
 
 // ---------------------------------------------------------------------------
 // Extension → Language mapping

--- a/src/daemon-lock.ts
+++ b/src/daemon-lock.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, mkdir, unlink, open, readdir } from 'node:fs/promises';
 import { readFileSync, watch, existsSync } from 'node:fs';
 import { join, resolve, basename, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
+import { coldstartHome } from './constants.js';
 import { fileURLToPath } from 'node:url';
 
 export interface DaemonLock {
@@ -19,7 +19,7 @@ export interface DaemonLock {
 }
 
 export function daemonDir(): string {
-  return join(homedir(), '.coldstart', 'daemon');
+  return join(coldstartHome(), 'daemon');
 }
 
 export function rootHash(rootDir: string): string {

--- a/src/indexer/cpp-include-roots.ts
+++ b/src/indexer/cpp-include-roots.ts
@@ -1,5 +1,6 @@
 import { dirname, join, resolve, isAbsolute } from 'node:path';
 import { readFile } from 'node:fs/promises';
+import { isInside } from './paths.js';
 
 /**
  * Shared CMakeLists.txt discovery used by the C++ resolver.
@@ -81,7 +82,7 @@ function extractIncludeRoots(
     }
 
     // Bound to rootDir
-    if (!expanded.startsWith(rootDir + '/') && expanded !== rootDir) {
+    if (!isInside(expanded, rootDir)) {
       return null;
     }
 

--- a/src/indexer/indexed-file.ts
+++ b/src/indexer/indexed-file.ts
@@ -1,4 +1,5 @@
 import { statSync } from 'node:fs';
+import { sep } from 'node:path';
 import type { IndexedFile, Language, ParsedFile } from '../types.js';
 
 /**
@@ -35,7 +36,13 @@ export function baseIndexedFile(
   return {
     id,
     path,
-    relativePath,
+    // Forward-slash invariant, enforced HERE because all three construction
+    // sites (full index, incremental patch, probe) funnel through this
+    // function. Every path convention downstream — `app/Models/`, Django's
+    // `models.py`, Rails' `app/views/` — matches on `/`, so a caller that
+    // passed an OS-native `relative()` result silently disabled those
+    // conventions on Windows.
+    relativePath: relativePath.split(sep).join('/'),
     language,
     mtimeMs,
     sizeBytes,

--- a/src/indexer/laravel-synthetic.ts
+++ b/src/indexer/laravel-synthetic.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve, relative } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { buildFileId } from './parser.js';
+import { findSegmentParent } from './paths.js';
 import { resolvePHP } from './resolvers/php.js';
 import type { Edge, IndexedFile } from '../types.js';
 
@@ -20,16 +21,11 @@ export async function addLaravelSyntheticEdges(
   const phpFiles = indexedFiles.filter(f => f.language === 'php');
   if (phpFiles.length === 0) return;
 
-  // Find Laravel app root by looking for an app/ directory in walked files
-  let appRoot: string | null = null;
-  for (const f of phpFiles) {
-    const idx = f.path.lastIndexOf('/app/');
-    if (idx >= 0) {
-      appRoot = f.path.substring(0, idx);
-      break;
-    }
-  }
-  if (!appRoot) return;
+  // Find the Laravel app root. Matched on the file id (always forward-slash),
+  // never on the OS-native absolute path: the old `f.path.lastIndexOf('/app/')`
+  // could not match on Windows, so every Laravel repo there silently got zero
+  // Eloquent/container edges.
+  if (!findSegmentParent(phpFiles, rootDir, 'app')) return;
 
   const seen = new Set<string>();
   for (const e of edges) seen.add(`${e.from}|${e.to}`);

--- a/src/indexer/paths.ts
+++ b/src/indexer/paths.ts
@@ -1,0 +1,68 @@
+/**
+ * Separator-correct helpers for the one distinction this indexer lives or dies
+ * by: an ABSOLUTE path is OS-native (`D:\repo\src\a.ts` on Windows), while a
+ * FILE ID is always forward-slash and relative to the repo root (`src/a.ts`).
+ *
+ * Every Windows bug in #149's follow-up was the same mistake — treating an
+ * absolute path as if it were already a file id, then slicing it with `/`:
+ *
+ *     f.path.lastIndexOf('/app/')          // never matches on Windows
+ *     absPath.startsWith(rootDir + '/')    // always false on Windows
+ *
+ * Both are silent: the code takes the "not found" branch and a whole feature
+ * (Rails edges, Laravel edges, Go workspace resolution) disappears with no
+ * error. Route absolute-path work through here instead of hand-rolling it.
+ */
+import { relative, resolve, sep, isAbsolute } from 'node:path';
+
+/**
+ * OS-native absolute path → forward-slash id relative to `rootDir`.
+ *
+ * Splits on the platform separator rather than regex-replacing every
+ * backslash: on POSIX a backslash is a legal filename character, so
+ * `.replace(/\\/g, '/')` would corrupt `weird\name.ts`. `sep` is `\` on
+ * Windows (where `relative()` only ever emits `\`) and `/` on POSIX, so this
+ * is correct on both without a platform branch.
+ */
+export function toPosixRelative(absolutePath: string, rootDir: string): string {
+  return relative(rootDir, absolutePath).split(sep).join('/');
+}
+
+/**
+ * Is `absPath` inside `rootDir` (or `rootDir` itself)?
+ *
+ * The string form (`absPath.startsWith(rootDir + '/')`) is wrong twice over:
+ * it hardcodes the separator, and it treats `/repo-backup` as being inside
+ * `/repo`. `relative()` handles both, plus the Windows cross-drive case —
+ * `relative('D:\\a', 'C:\\b')` returns an ABSOLUTE `C:\b`, which the
+ * `isAbsolute` guard rejects.
+ */
+export function isInside(absPath: string, rootDir: string): boolean {
+  const rel = relative(rootDir, absPath);
+  if (rel === '') return true; // the root itself
+  if (isAbsolute(rel)) return false; // different Windows drive
+  return rel !== '..' && !rel.startsWith(`..${sep}`);
+}
+
+/**
+ * The OS-native absolute directory CONTAINING a `<segment>/` directory, found
+ * by scanning file ids — e.g. the Rails/Laravel app root, the dir holding
+ * `app/`. Returns null when no indexed file lives under such a directory.
+ *
+ * Matching happens on the forward-slash id and the result is rebuilt with
+ * `resolve`, so the caller gets a path it can hand straight to `fs` on either
+ * platform.
+ */
+export function findSegmentParent(
+  files: Array<{ relativePath: string }>,
+  rootDir: string,
+  segment: string,
+): string | null {
+  for (const f of files) {
+    const parts = f.relativePath.split('/');
+    const at = parts.lastIndexOf(segment);
+    if (at < 0) continue;
+    return resolve(rootDir, ...parts.slice(0, at));
+  }
+  return null;
+}

--- a/src/indexer/rails-synthetic.ts
+++ b/src/indexer/rails-synthetic.ts
@@ -1,4 +1,5 @@
 import { buildRailsFqcnIndex, resolveRailsConstantCandidates } from './resolvers/ruby.js';
+import { findSegmentParent } from './paths.js';
 import type { Edge, IndexedFile } from '../types.js';
 
 /**
@@ -18,11 +19,14 @@ export async function addRailsSyntheticEdges(
   const rubyFiles = indexedFiles.filter(f => f.language === 'ruby');
   if (rubyFiles.length === 0) return;
 
-  let appRoot: string | null = null;
-  for (const f of rubyFiles) {
-    const idx = f.path.lastIndexOf('/app/');
-    if (idx >= 0) { appRoot = f.path.substring(0, idx); break; }
-  }
+  // Locate the Rails app root. Matched against the file ID (always
+  // forward-slash) rather than the OS-native absolute path — `f.path` uses `\`
+  // on Windows, so the old `f.path.lastIndexOf('/app/')` never matched there
+  // and every Rails repo silently got zero synthetic edges.
+  // Matched on the file id (always forward-slash), never on the OS-native
+  // absolute path: the old `f.path.lastIndexOf('/app/')` could not match on
+  // Windows, so every Rails repo there silently got zero synthetic edges.
+  const appRoot = findSegmentParent(rubyFiles, rootDir, 'app');
   if (!appRoot) return;
 
   const fqcnIndex = await buildRailsFqcnIndex(appRoot, fullFileIdSet, rootDir);

--- a/src/indexer/resolvers/go.ts
+++ b/src/indexer/resolvers/go.ts
@@ -1,6 +1,7 @@
 import { join, dirname, isAbsolute } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { MAX_DIR_WALK_DEPTH } from './shared.js';
+import { isInside, toPosixRelative } from '../paths.js';
 
 /**
  * Go resolver: resolves module-local import paths using go.mod / go.work.
@@ -158,8 +159,8 @@ export async function resolveGo(
         if (specifier !== name && !specifier.startsWith(name + '/')) continue;
         const suffix = specifier.slice(name.length).replace(/^\//, '');
         const absPath = suffix ? join(dir, suffix) : dir;
-        if (!absPath.startsWith(rootDir + '/') && absPath !== rootDir) continue;
-        const relPath = absPath.slice(rootDir.length + 1).replace(/\\/g, '/');
+        if (!isInside(absPath, rootDir)) continue;
+        const relPath = toPosixRelative(absPath, rootDir);
         const result = dirMap.get(relPath);
         if (result) return result;
       }
@@ -174,8 +175,8 @@ export async function resolveGo(
   if (!info) return null;
 
   const tryResolveAbs = (absPath: string): string | null => {
-    if (!absPath.startsWith(rootDir + '/') && absPath !== rootDir) return null;
-    const relPath = absPath.slice(rootDir.length + 1).replace(/\\/g, '/');
+    if (!isInside(absPath, rootDir)) return null;
+    const relPath = toPosixRelative(absPath, rootDir);
     return dirMap.get(relPath) ?? null;
   };
 

--- a/src/indexer/resolvers/index.ts
+++ b/src/indexer/resolvers/index.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir } from 'node:fs/promises';
-import { join, resolve, dirname } from 'node:path';
+import { join, resolve, dirname, basename } from 'node:path';
 import type { IndexedFile, Edge, Language } from '../../types.js';
 import { DEFAULT_EXCLUDES } from '../../constants.js';
 import { resolveGeneric } from './generic.js';
@@ -194,7 +194,11 @@ async function loadWorkspacePackages(rootDir: string): Promise<Map<string, strin
   const decls: Array<{ dir: string; patterns: string[] }> = [];
 
   for (const path of configPaths) {
-    const baseName = path.slice(path.lastIndexOf('/') + 1);
+    // `basename`, not a manual `/` slice: configPaths are OS-native absolutes,
+    // so on Windows the slice found no `/`, returned the WHOLE path, and every
+    // package.json fell through to the pnpm-YAML branch — npm/yarn workspaces
+    // were never discovered at all.
+    const baseName = basename(path);
     if (baseName === 'package.json') {
       try {
         const raw = await readFile(path, 'utf-8');

--- a/src/indexer/resolvers/python.ts
+++ b/src/indexer/resolvers/python.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from 'node:path';
 import { toFileId, tryResolveBase, MAX_DIR_WALK_DEPTH } from './shared.js';
+import { isInside } from '../paths.js';
 
 /**
  * Python resolver: handles both relative and absolute imports.
@@ -60,7 +61,7 @@ export async function resolvePython(
     if (srcLayout) return srcLayout;
     if (dir === rootDir) break;
     const parent = dirname(dir);
-    if (parent === dir || !parent.startsWith(rootDir)) break;
+    if (parent === dir || !isInside(parent, rootDir)) break;
     dir = parent;
   }
   return null;

--- a/src/indexer/resolvers/ruby.ts
+++ b/src/indexer/resolvers/ruby.ts
@@ -2,6 +2,7 @@ import { dirname, resolve, join, basename, relative, sep } from 'node:path';
 import { readFile, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tryResolveBase, MAX_DIR_WALK_DEPTH } from './shared.js';
+import { isInside } from '../paths.js';
 import { buildFileId } from '../parser.js';
 
 /**
@@ -37,7 +38,7 @@ async function findGemfileDir(startDir: string, rootDir: string): Promise<string
     } catch { /* not here */ }
     if (dir === rootDir) break;
     const parent = dirname(dir);
-    if (parent === dir || !parent.startsWith(rootDir)) break;
+    if (parent === dir || !isInside(parent, rootDir)) break;
     dir = parent;
   }
   startDirToGemfileDir.set(startDir, null);
@@ -82,7 +83,7 @@ export async function resolveRuby(
     }
     if (dir === rootDir) break;
     const parent = dirname(dir);
-    if (parent === dir || !parent.startsWith(rootDir)) break;
+    if (parent === dir || !isInside(parent, rootDir)) break;
     dir = parent;
   }
 

--- a/src/indexer/resolvers/shared.ts
+++ b/src/indexer/resolvers/shared.ts
@@ -1,4 +1,5 @@
-import { join, relative, extname } from 'node:path';
+import { join, extname } from 'node:path';
+import { toPosixRelative } from '../paths.js';
 
 // Upper bound on how many directory ancestors a resolver walks when searching
 // for a project marker (go.mod, composer.json, Gemfile, a load-path root, …).
@@ -30,7 +31,7 @@ export const INDEX_FILES = [
 
 /** Converts an absolute path to a normalized forward-slash file ID relative to rootDir. */
 export function toFileId(absolutePath: string, rootDir: string): string {
-  return relative(rootDir, absolutePath).replace(/\\/g, '/');
+  return toPosixRelative(absolutePath, rootDir);
 }
 
 /**

--- a/src/indexer/walker.ts
+++ b/src/indexer/walker.ts
@@ -1,6 +1,7 @@
 import { readdir, stat, realpath } from 'node:fs/promises';
-import { join, relative, extname } from 'node:path';
+import { join, extname } from 'node:path';
 import { DEFAULT_EXCLUDES, EXTENSION_TO_LANGUAGE } from '../constants.js';
+import { toPosixRelative } from './paths.js';
 import type { Language, WalkedFile } from '../types.js';
 
 export interface WalkOptions {
@@ -100,7 +101,13 @@ export async function walkDirectory(options: WalkOptions): Promise<WalkedFile[]>
         resolvedPath = fullPath;
       }
 
-      const relativePath = relative(rootDir, resolvedPath);
+      // Forward-slash, ALWAYS — `relative()` is OS-native, so this was
+      // `app\Models\User.php` on Windows. buildFileId normalised the *id* but
+      // the relativePath field kept the backslashes, and everything downstream
+      // (convention gating like `app/Models/`, tokenization, domain mapping)
+      // silently stopped matching. Normalising at the producer is what makes
+      // every language's path convention work on Windows, not per-caller fixes.
+      const relativePath = toPosixRelative(resolvedPath, rootDir);
 
       results.push({
         absolutePath: resolvedPath,

--- a/src/indexer/walker.ts
+++ b/src/indexer/walker.ts
@@ -1,4 +1,4 @@
-import { readdir, stat, realpath } from 'node:fs/promises';
+import { readdir, stat } from 'node:fs/promises';
 import { join, extname } from 'node:path';
 import { DEFAULT_EXCLUDES, EXTENSION_TO_LANGUAGE } from '../constants.js';
 import { toPosixRelative } from './paths.js';
@@ -93,24 +93,32 @@ export async function walkDirectory(options: WalkOptions): Promise<WalkedFile[]>
         continue;
       }
 
-      // Resolve symlink chains in the path (for relative path computation only)
-      let resolvedPath = fullPath;
-      try {
-        resolvedPath = await realpath(fullPath);
-      } catch {
-        resolvedPath = fullPath;
-      }
-
+      // Relative to the root WE WERE GIVEN, from the path we walked in on.
+      //
+      // This used to relativize `await realpath(fullPath)` instead, which is a
+      // different path whenever an ANCESTOR is a link or a Windows 8.3 short
+      // name — and symlinked entries are skipped above, so ancestors were all
+      // it could still resolve. On the Windows CI runner, whose tmpdir is
+      // `C:\Users\RUNNER~1\...`, libuv's realpath expanded that to
+      // `runneradmin` while the caller's root kept the short form, and every
+      // id came out as `../../../../../runneradmin/AppData/Local/Temp/...`.
+      // Nothing threw; the ids were simply wrong.
+      //
+      // Canonicalising the root instead would fix the ids and break something
+      // else: the resolvers relativize candidate paths against the SAME root
+      // the caller passed, so file ids and import targets have to be built
+      // from that one root or they stop matching each other.
+      //
       // Forward-slash, ALWAYS — `relative()` is OS-native, so this was
       // `app\Models\User.php` on Windows. buildFileId normalised the *id* but
       // the relativePath field kept the backslashes, and everything downstream
       // (convention gating like `app/Models/`, tokenization, domain mapping)
       // silently stopped matching. Normalising at the producer is what makes
       // every language's path convention work on Windows, not per-caller fixes.
-      const relativePath = toPosixRelative(resolvedPath, rootDir);
+      const relativePath = toPosixRelative(fullPath, rootDir);
 
       results.push({
-        absolutePath: resolvedPath,
+        absolutePath: fullPath,
         relativePath,
         language,
       });

--- a/src/kb/repair.ts
+++ b/src/kb/repair.ts
@@ -38,7 +38,7 @@
  * enforce the same fields, so what repair flags and what `kb write` asks for
  * cannot drift. Adding a criterion later means appending one entry there.
  */
-import { relative } from 'node:path';
+import { relative, sep } from 'node:path';
 import { NOTE_CHECKS, REPAIR_CONTRACT_VERSION } from '../../hooks/note-shape.mjs';
 import { loadAll, notePath } from './store.js';
 import { fileNoteId } from './ids.js';
@@ -167,7 +167,13 @@ export function planRepairs(root: string): RepairReport {
         note: n.id,
         type: n.type,
         title: n.title,
-        notePath: relative(root, notePath(root, n.id)),
+        // Forward-slash, like every other path coldstart prints. `relative()`
+        // is OS-native, so on Windows this rendered
+        // `.coldstart\notebook\notes\x.md` — inconsistent with the `→ open:`
+        // paths elsewhere, and actively wrong for the agent reading this page,
+        // since the very next step is pasting it into a `kb write` JSON spec
+        // where a backslash is an escape character.
+        notePath: relative(root, notePath(root, n.id)).split(sep).join('/'),
         paths: subjectPaths(n),
         detail: c.why,
         hint: c.repairHint,

--- a/src/server/find.ts
+++ b/src/server/find.ts
@@ -213,6 +213,27 @@ function scanArgv(searcher: Exclude<Searcher, { kind: 'node' }>, term: string): 
   }
 }
 
+/**
+ * One line of scanner output → a file id that can be looked up in the index.
+ *
+ * Searchers are given `.` as their search root and echo it back in every hit:
+ * `./src/a.ts` on POSIX, but `.\src\a.ts` on Windows. Only `./` used to be
+ * stripped, so on Windows EVERY scanned path kept its `.\` prefix and its
+ * backslashes, matched nothing in `index.files` (keyed by forward-slash ids),
+ * and the whole repo-wide recall pass silently returned zero coverage — no
+ * grep-recall in `find`, no `near` relations, and absence notes could never be
+ * re-verified.
+ *
+ * Backslash translation is win32-only on purpose: on POSIX a backslash is a
+ * legal filename character, so rewriting it there would corrupt real paths.
+ */
+function normalizeScanPath(line: string): string {
+  let s = line.trim();
+  if (!s) return '';
+  if (process.platform === 'win32') s = s.split('\\').join('/');
+  return s.replace(/^\.\//, '');
+}
+
 /** Run one external scan; repo-relative paths, [] on no-match, null on SPAWN failure
  * (binary vanished — distinct from exit 1 so the caller can re-resolve rg). */
 function listFilesExternal(searcher: Exclude<Searcher, { kind: 'node' }>, root: string, term: string): Promise<string[] | null> {
@@ -232,7 +253,7 @@ function listFilesExternal(searcher: Exclude<Searcher, { kind: 'node' }>, root: 
         // execFile err: string `code` (ENOENT/EACCES) = spawn-level failure;
         // numeric `code` = the tool ran and exited non-zero (= no matches).
         if (err && typeof (err as { code?: unknown }).code === 'string') return resolve(null);
-        resolve((stdout ?? '').split('\n').map((l) => l.replace(/^\.\//, '').trim()).filter(Boolean));
+        resolve((stdout ?? '').split('\n').map((l) => normalizeScanPath(l)).filter(Boolean));
       },
     );
   });

--- a/src/server/searcher.ts
+++ b/src/server/searcher.ts
@@ -20,7 +20,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { homedir } from 'node:os';
+import { coldstartHome } from '../constants.js';
 import { isAbsolute, join } from 'node:path';
 
 export interface RgBinary {
@@ -29,7 +29,9 @@ export interface RgBinary {
   argv0?: string;
 }
 
-const CACHE_FILE = join(homedir(), '.coldstart', 'searcher.json');
+// A function, not a const — see coldstartHome(): a const would capture the
+// path at import time and ignore a COLDSTART_HOME set by a test afterwards.
+const cacheFile = (): string => join(coldstartHome(), 'searcher.json');
 
 let _rg: RgBinary | null | undefined; // undefined = not yet resolved this process
 
@@ -80,7 +82,7 @@ function appCandidates(): RgBinary[] {
 
 function loadCached(): RgBinary | null {
   try {
-    const raw = JSON.parse(readFileSync(CACHE_FILE, 'utf8')) as { bin?: string; argv0?: string };
+    const raw = JSON.parse(readFileSync(cacheFile(), 'utf8')) as { bin?: string; argv0?: string };
     if (!raw.bin) return null;
     // Absolute paths get a cheap stat; bare names (PATH rg, claude) can only be
     // trusted — a scan-time spawn failure invalidates them.
@@ -93,8 +95,8 @@ function loadCached(): RgBinary | null {
 
 function saveCached(rg: RgBinary): void {
   try {
-    mkdirSync(join(homedir(), '.coldstart'), { recursive: true });
-    writeFileSync(CACHE_FILE, JSON.stringify(rg));
+    mkdirSync(coldstartHome(), { recursive: true });
+    writeFileSync(cacheFile(), JSON.stringify(rg));
   } catch {
     /* cache is an optimization; resolution still works without it */
   }
@@ -137,7 +139,7 @@ export function resolveRg(): RgBinary | null {
 export function invalidateRg(): void {
   _rg = undefined;
   try {
-    rmSync(CACHE_FILE, { force: true });
+    rmSync(cacheFile(), { force: true });
   } catch {
     /* ignore */
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -10,6 +10,7 @@
  */
 
 import { existsSync, statSync, readFileSync } from 'node:fs';
+import { unlink } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -57,8 +58,13 @@ function wiredHookPaths(rootDir: string): string[] {
   if (!existsSync(settings)) return [];
   try {
     const raw = readFileSync(settings, 'utf-8');
-    const re = /(\/[^\s"']+\/hooks\/(?:kb-elicit|kb-recall|find-nudge|find-preguard)\.mjs)/g;
-    return [...new Set(Array.from(raw.matchAll(re), (m) => m[1]))];
+    // Both separators, and a Windows drive prefix. The POSIX-only form
+    // (`/…/hooks/x.mjs`) could never match a Windows entry, so the one check
+    // that would have caught #158's broken wiring was itself dead on Windows.
+    // Backslashes arrive JSON-escaped (`d:\\repo\\hooks\\…`), hence the
+    // doubled-separator alternative.
+    const re = /((?:[A-Za-z]:)?(?:\\\\|[\\/])[^\s"']*?(?:\\\\|[\\/])hooks(?:\\\\|[\\/])(?:kb-elicit|kb-recall|find-nudge|find-preguard)\.mjs)/g;
+    return [...new Set(Array.from(raw.matchAll(re), (m) => m[1].replace(/\\\\/g, '\\')))];
   } catch {
     return [];
   }
@@ -101,12 +107,44 @@ interface Row {
   logSize: string;
 }
 
+/**
+ * Drop lock records for roots that no longer exist on disk.
+ *
+ * A keeper that dies without cleanup leaves its lockfile behind, and if the
+ * repo itself is then deleted (a temp dir, a scratch clone) the record is pure
+ * garbage — it can never come back, and it can never be cleaned by the normal
+ * path because that requires a reader running IN that root. One user had 18 of
+ * them burying the single row they cared about.
+ *
+ * Deliberately conservative: only a record whose PID is dead AND whose rootDir
+ * is both known and absent. A live keeper is never touched, and neither is a
+ * legacy lock that never recorded its rootDir (we can't prove anything about
+ * it, and guessing here would delete a real keeper's lock).
+ */
+async function pruneVanishedRoots(listings: DaemonLockListing[]): Promise<{ kept: DaemonLockListing[]; pruned: number }> {
+  const kept: DaemonLockListing[] = [];
+  let pruned = 0;
+  for (const l of listings) {
+    const root = l.lock.rootDir;
+    if (root && !existsSync(root) && !isDaemonAlive(l.lock.pid)) {
+      try {
+        await unlink(l.lockPath);
+        pruned++;
+        continue;
+      } catch { /* couldn't remove it — fall through and still show the row */ }
+    }
+    kept.push(l);
+  }
+  return { kept, pruned };
+}
+
 export async function runStatus(): Promise<void> {
-  const listings = await listDaemonLocks();
+  const { kept: listings, pruned } = await pruneVanishedRoots(await listDaemonLocks());
   if (listings.length === 0) {
     process.stdout.write(
       `No coldstart keepers running.\n` +
       `Keeper directory: ${daemonDir()}\n` +
+      (pruned > 0 ? `Pruned ${pruned} record(s) for roots that no longer exist.\n` : '') +
       `Run \`coldstart find\` (or any MCP call) to spawn one.\n`,
     );
     return;
@@ -155,6 +193,8 @@ export async function runStatus(): Promise<void> {
       pad(r.logSize, widths.logSize),
     ].join('  '));
   }
+
+  if (pruned > 0) lines.push('', `Pruned ${pruned} record(s) for roots that no longer exist.`);
 
   process.stdout.write(lines.join('\n') + '\n');
 

--- a/tests/codex-hooks.test.ts
+++ b/tests/codex-hooks.test.ts
@@ -32,7 +32,12 @@ afterEach(() => {
 
 function rollout(name: string): string {
   const target = path.join(root, name);
-  const source = fs.readFileSync(path.join(FIXTURES, name), 'utf8').replaceAll('__ROOT__', root);
+  // JSON-escape the root before splicing it into a JSONL string literal. On
+  // Windows a raw `C:\Users\…` makes `\U` an invalid escape and the whole line
+  // fails to parse, so the hook saw an empty transcript and emitted nothing.
+  // Real Codex writes properly escaped paths; only this helper didn't.
+  const source = fs.readFileSync(path.join(FIXTURES, name), 'utf8')
+    .replaceAll('__ROOT__', JSON.stringify(root).slice(1, -1));
   fs.writeFileSync(target, source);
   return target;
 }

--- a/tests/cursor-hooks.test.ts
+++ b/tests/cursor-hooks.test.ts
@@ -42,7 +42,11 @@ afterEach(() => {
 /** Copy a fixture transcript into the temp root with __ROOT__ resolved. */
 function transcript(name: string): string {
   const target = path.join(root, name);
-  const source = fs.readFileSync(path.join(FIXTURES, name), 'utf8').replaceAll('__ROOT__', root);
+  // JSON-escape the root — see the same helper in codex-hooks.test.ts. A raw
+  // Windows `C:\Users\…` spliced into a JSONL string literal is invalid JSON,
+  // so the transcript parsed as empty and the hook emitted nothing.
+  const source = fs.readFileSync(path.join(FIXTURES, name), 'utf8')
+    .replaceAll('__ROOT__', JSON.stringify(root).slice(1, -1));
   fs.writeFileSync(target, source);
   return target;
 }

--- a/tests/daemon-lock.test.ts
+++ b/tests/daemon-lock.test.ts
@@ -11,30 +11,36 @@ import { readLock, writeLock, watchOwnLockfile, watchOwnBinary, daemonDir } from
 // The keeper no longer serves over HTTP, so the lock carries no port.
 
 describe('daemon-lock', () => {
-  const realDaemonDir = daemonDir();
   let tmpHome: string;
-  let originalHome: string | undefined;
+  let originalColdstartHome: string | undefined;
   let testRoot: string;
 
   beforeEach(() => {
-    // Redirect ~/.coldstart/daemon/ to a temp dir so we don't touch the
-    // user's real daemons. Both readLock/writeLock/watchOwnLockfile resolve
-    // their target path via the HOME env var.
+    // Redirect the state dir to a temp dir so we never touch the user's real
+    // daemons. This MUST be COLDSTART_HOME, not HOME: `os.homedir()` on
+    // Windows reads USERPROFILE and ignores HOME, so the old HOME redirect
+    // silently no-opped there and these fixtures wrote lockfiles (PIDs 9,
+    // 12345, 22222, 33333) straight into the developer's real
+    // ~/.coldstart/daemon — where they outlived the temp roots they named and
+    // buried every genuine row in `coldstart status`.
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-lock-test-'));
-    originalHome = process.env.HOME;
-    process.env.HOME = tmpHome;
+    originalColdstartHome = process.env.COLDSTART_HOME;
+    process.env.COLDSTART_HOME = path.join(tmpHome, '.coldstart');
     fs.mkdirSync(path.join(tmpHome, '.coldstart', 'daemon'), { recursive: true });
     // A real project root the lockfile is keyed against.
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-lock-root-'));
   });
 
   afterEach(() => {
-    process.env.HOME = originalHome;
+    // Assert isolation BEFORE restoring the env var — daemonDir() must still
+    // be resolving into the temp home at this point. The old check compared
+    // the real dir against tmpHome and could never fail, which is exactly why
+    // the Windows leak went unnoticed for so long.
+    expect(daemonDir().startsWith(tmpHome)).toBe(true);
+    if (originalColdstartHome === undefined) delete process.env.COLDSTART_HOME;
+    else process.env.COLDSTART_HOME = originalColdstartHome;
     fs.rmSync(tmpHome, { recursive: true, force: true });
     fs.rmSync(testRoot, { recursive: true, force: true });
-    // Sanity: make sure we didn't somehow write into the real daemon dir
-    // during the test (would catch a future regression in path resolution).
-    expect(realDaemonDir.startsWith(tmpHome)).toBe(false);
   });
 
   describe('readLock / writeLock version round-trip', () => {

--- a/tests/hook-evidence-paths.test.ts
+++ b/tests/hook-evidence-paths.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Evidence collection must understand the absolute paths its own host emits.
+ *
+ * On Windows, Claude Code / Cursor / Codex all report `file_path` as
+ * `D:\repo\src\a.ts`. The old normRel tested `s.startsWith("/")`, so a Windows
+ * path fell through to the "already relative" branch and was returned VERBATIM
+ * — it matched no repo file, and every Windows session collected zero
+ * evidence. Nothing threw; capture simply never had anything to work with,
+ * which is why it survived so long undetected.
+ *
+ * These assertions run the platform's own absolute-path shape through the real
+ * exported entry point, so they stay meaningful on macOS and Linux too.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extractEvidence } from '../hooks/evidence.mjs';
+
+let root: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'coldstart-evidence-'));
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'a.ts'), 'export const a = 1;\n');
+  fs.writeFileSync(path.join(root, 'src', 'b.ts'), 'export const b = 2;\n');
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+let nextId = 0;
+
+/**
+ * A complete Claude Code tool call: the assistant's tool_use PLUS the user
+ * tool_result that confirms it. extractEvidence deliberately commits nothing
+ * until the result arrives (an errored or interrupted call proves nothing), so
+ * a fixture with only the first half records no evidence at all.
+ */
+function toolCall(name: string, input: Record<string, unknown>): string {
+  const id = `t${++nextId}`;
+  return [
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] },
+    }),
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }] },
+    }),
+  ].join('\n');
+}
+
+describe('evidence collection accepts the host\'s native absolute paths', () => {
+  it('an OS-native absolute file_path resolves to a forward-slash repo id', () => {
+    // path.join gives `D:\root\src\a.ts` on Windows, `/root/src/a.ts` on POSIX
+    // — exactly what each host actually emits on that platform.
+    const ev = extractEvidence(toolCall('Read', { file_path: path.join(root, 'src', 'a.ts') }), root);
+    expect(ev.get('src/a.ts')?.reads).toBe(1);
+  });
+
+  it('an edit through a native absolute path is recorded as an edit', () => {
+    const ev = extractEvidence(toolCall('Write', { file_path: path.join(root, 'src', 'b.ts') }), root);
+    expect(ev.get('src/b.ts')?.edits).toBe(1);
+  });
+
+  it('a repo-relative path still works, with or without a leading ./', () => {
+    const ev = extractEvidence(
+      [toolCall('Read', { file_path: 'src/a.ts' }), toolCall('Read', { file_path: './src/b.ts' })].join('\n'),
+      root,
+    );
+    expect(ev.get('src/a.ts')?.reads).toBe(1);
+    expect(ev.get('src/b.ts')?.reads).toBe(1);
+  });
+
+  it('a file outside the repo contributes nothing', () => {
+    const outside = path.join(path.dirname(root), 'somewhere-else', 'x.ts');
+    const ev = extractEvidence(toolCall('Read', { file_path: outside }), root);
+    expect([...ev.keys()]).toEqual([]);
+  });
+
+  it('a sibling root sharing a name prefix is not treated as inside', () => {
+    // `<root>-backup/x.ts` — the old `root + "/"` prefix test got this wrong.
+    const sibling = path.join(`${root}-backup`, 'x.ts');
+    const ev = extractEvidence(toolCall('Read', { file_path: sibling }), root);
+    expect([...ev.keys()]).toEqual([]);
+  });
+
+  it('native separators inside a relative path are normalised to the id form', () => {
+    const nativeRel = ['src', 'a.ts'].join(path.sep);
+    const ev = extractEvidence(toolCall('Read', { file_path: nativeRel }), root);
+    expect(ev.get('src/a.ts')?.reads).toBe(1);
+  });
+});

--- a/tests/patch-delete-symbol-edges.test.ts
+++ b/tests/patch-delete-symbol-edges.test.ts
@@ -67,7 +67,13 @@ describe('patchIndex prunes symbolEdges into a deleted file', () => {
 
   it('delete of a called file leaves no dangling se.to and passes the lint', async () => {
     const idx = await buildSmall(root);
-    expect(idx.symbolEdges.some(se => se.to.startsWith('src/callee.ts#'))).toBe(true);
+    // Both assertions name their inputs rather than collapsing to a boolean —
+    // if the file ids are wrong the first one says so, instead of the edge
+    // check failing for a reason it cannot show.
+    expect([...idx.files.keys()].sort()).toEqual(['src/callee.ts', 'src/caller.ts']);
+    expect(idx.symbolEdges.map(se => se.to)).toContainEqual(
+      expect.stringMatching(/^src\/callee\.ts#/),
+    );
 
     fs.rmSync(join(root, 'src/callee.ts'));
     await patchIndex(idx, new Set([join(root, 'src/callee.ts')]), root);

--- a/tests/patch-hidden-dirs.test.ts
+++ b/tests/patch-hidden-dirs.test.ts
@@ -65,7 +65,10 @@ describe('patchIndex mirrors walker dir rules for hidden/excluded dirs', () => {
 
   it('rejects hidden-dir and excluded-dir files; keeps real files and root dotfiles', async () => {
     const idx = await buildSmall(root);
-    expect(idx.files.has('src/a.ts')).toBe(true);
+    // toContain, not has(): a bare boolean assertion reports only "expected
+    // false to be true", which is useless when this fails on a machine you
+    // cannot reach. The key list names the actual ids.
+    expect([...idx.files.keys()]).toContain('src/a.ts');
 
     for (const [dir, file] of [
       ['.coldstart/notebook/notes', 'leak.ts'],

--- a/tests/path-separator-coverage.test.ts
+++ b/tests/path-separator-coverage.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Guards the one invariant every Windows bug in this area violated:
+ *
+ *   an ABSOLUTE path is OS-native; a FILE ID is always forward-slash.
+ *
+ * Treating the first as the second is silent — the comparison just goes false,
+ * the code takes its "not found" branch, and a whole feature disappears with no
+ * error anywhere. That is how Rails edges, Laravel edges, Go workspace
+ * resolution, npm workspace discovery and ALL hook evidence collection were
+ * dead on Windows simultaneously, for months, while CI stayed green on ubuntu.
+ *
+ * Two halves, mirroring tests/windows-hide-coverage.test.ts:
+ *   1. behavioural — the helpers do the right thing for Windows-shaped input
+ *   2. static      — no new `rootDir + '/'` / `lastIndexOf('/')`-on-an-absolute
+ *                    can be added back without this failing
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { toPosixRelative, isInside, findSegmentParent } from '../src/indexer/paths.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('path helpers — behavioural', () => {
+  it('toPosixRelative yields a forward-slash id from an OS-native absolute', () => {
+    const root = path.join(REPO, 'fixture-root');
+    const file = path.join(root, 'app', 'Models', 'User.php');
+    expect(toPosixRelative(file, root)).toBe('app/Models/User.php');
+  });
+
+  it('toPosixRelative splits on the platform separator, so a POSIX filename containing a backslash survives', () => {
+    // `weird\name.ts` is a LEGAL single filename on POSIX. The old
+    // `.replace(/\\/g, '/')` would have split it into two fake segments.
+    const root = path.join(REPO, 'fixture-root');
+    const file = path.join(root, 'src', 'weird\\name.ts');
+    const id = toPosixRelative(file, root);
+    if (process.platform === 'win32') {
+      expect(id).toBe('src/weird/name.ts'); // genuinely a separator here
+    } else {
+      expect(id).toBe('src/weird\\name.ts'); // one filename, preserved
+    }
+  });
+
+  it('isInside accepts the root itself and real descendants', () => {
+    const root = path.join(REPO, 'fixture-root');
+    expect(isInside(root, root)).toBe(true);
+    expect(isInside(path.join(root, 'a', 'b.ts'), root)).toBe(true);
+  });
+
+  it('isInside rejects a sibling that merely shares a name prefix', () => {
+    // The `rootDir + '/'` string form got this wrong on every platform.
+    const root = path.join(REPO, 'fixture-root');
+    expect(isInside(path.join(REPO, 'fixture-root-backup', 'a.ts'), root)).toBe(false);
+    expect(isInside(path.join(REPO, 'elsewhere', 'a.ts'), root)).toBe(false);
+  });
+
+  it('findSegmentParent locates a convention dir from forward-slash ids', () => {
+    const root = path.join(REPO, 'fixture-root');
+    const files = [{ relativePath: 'app/Models/User.php' }];
+    expect(findSegmentParent(files, root, 'app')).toBe(root);
+    expect(findSegmentParent(files, root, 'nope')).toBeNull();
+  });
+
+  it('findSegmentParent handles a nested app root', () => {
+    const root = path.join(REPO, 'fixture-root');
+    const files = [{ relativePath: 'backend/app/Models/User.php' }];
+    expect(findSegmentParent(files, root, 'app')).toBe(path.join(root, 'backend'));
+  });
+});
+
+describe('walker/indexed-file keep relativePath forward-slash', () => {
+  it('baseIndexedFile normalises relativePath even when handed an OS-native one', async () => {
+    const { baseIndexedFile } = await import('../src/indexer/indexed-file.js');
+    const native = ['app', 'Models', 'User.php'].join(path.sep);
+    const base = baseIndexedFile(
+      'app/Models/User.php',
+      path.join(REPO, native),
+      native,
+      'php',
+      // Only the fields baseIndexedFile copies straight through are needed.
+      { exports: [], hasDefaultExport: false, imports: [], hash: '', lineCount: 0,
+        tokenEstimate: 0, symbols: [] } as never,
+    );
+    expect(base.relativePath).toBe('app/Models/User.php');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Static half — the regression that actually matters
+// ---------------------------------------------------------------------------
+
+/** Source files that legitimately manipulate FILE IDS (always `/`) with `/`. */
+const ID_ONLY_FILES = new Set([
+  'src/graph/dump.ts',            // keys are file ids
+  'src/server/find.ts',           // `rel` is a file id
+  'src/server/tools.ts',          // symbol names, not paths
+  'src/indexer/paths.ts',         // documents the bad patterns in comments
+  'src/init.ts',                  // CLI flag parsing (`--flag=value`)
+]);
+
+/**
+ * Comment lines are not code. Several fixes deliberately QUOTE the pattern
+ * they replaced so the next reader knows why the code looks the way it does —
+ * flagging those would push people towards deleting the explanation.
+ */
+function isComment(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) sourceFiles(full, out);
+    else if (e.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('no new POSIX-only absolute-path surgery', () => {
+  it('nothing reconstructs a separator with `<root> + "/"`', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(path.join(REPO, 'src'))) {
+      const rel = path.relative(REPO, file).split(path.sep).join('/');
+      if (ID_ONLY_FILES.has(rel)) continue;
+      const text = fs.readFileSync(file, 'utf8');
+      text.split('\n').forEach((line, i) => {
+        if (isComment(line)) return;
+        // `rootDir + '/'`, `root + "/"` — the exact shape that made Go
+        // workspace resolution and CMake include roots dead on Windows.
+        if (/\b(root|rootDir|base|dir|appRoot)\s*\+\s*['"]\//.test(line)) {
+          offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders, `use isInside()/toPosixRelative() from src/indexer/paths.ts instead:\n${offenders.join('\n')}`)
+      .toEqual([]);
+  });
+
+  it('nothing slices an absolute path on a hardcoded slash', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(path.join(REPO, 'src'))) {
+      const rel = path.relative(REPO, file).split(path.sep).join('/');
+      if (ID_ONLY_FILES.has(rel)) continue;
+      const text = fs.readFileSync(file, 'utf8');
+      text.split('\n').forEach((line, i) => {
+        if (isComment(line)) return;
+        // `.path.lastIndexOf('/…')` / `.path.includes('/…')` — an absolute
+        // path never contains a forward slash on Windows.
+        if (/\.path\.(lastIndexOf|indexOf|includes|startsWith)\(['"]\//.test(line)) {
+          offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders, `match on the file id (relativePath), not the absolute path:\n${offenders.join('\n')}`)
+      .toEqual([]);
+  });
+
+  it('the state dir is reached through coldstartHome(), not homedir() directly', () => {
+    // A direct `join(homedir(), '.coldstart', …)` cannot be redirected by a
+    // test, which is how fixture lockfiles ended up in a real ~/.coldstart.
+    const offenders: string[] = [];
+    for (const file of sourceFiles(path.join(REPO, 'src'))) {
+      const rel = path.relative(REPO, file).split(path.sep).join('/');
+      if (rel === 'src/constants.ts') continue; // defines it
+      const text = fs.readFileSync(file, 'utf8');
+      text.split('\n').forEach((line, i) => {
+        if (isComment(line)) return;
+        if (/homedir\(\)\s*,\s*['"]\.coldstart/.test(line)) {
+          offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders, `use coldstartHome() from src/constants.ts:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});

--- a/tests/path-separator-coverage.test.ts
+++ b/tests/path-separator-coverage.test.ts
@@ -18,9 +18,44 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as os from 'node:os';
 import { toPosixRelative, isInside, findSegmentParent } from '../src/indexer/paths.js';
+import { walkDirectory } from '../src/indexer/walker.js';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('walkDirectory — a root that is not already canonical', () => {
+  // The walker canonicalises every FILE with fs.promises.realpath, so it must
+  // canonicalise the ROOT the same way. When it did not, a root reached
+  // through a link (or, on the Windows CI runner, an 8.3 short path like
+  // C:\Users\RUNNER~1\...) produced ids that climbed out of the repo:
+  //   ../../../../../runneradmin/AppData/Local/Temp/cs-delsym-uvezwu/src/a.ts
+  // Nothing threw. Every id was simply wrong, so nothing downstream matched.
+  it('still yields repo-relative ids when the root is reached through a link', async () => {
+    const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cs-linkroot-')));
+    const real = path.join(base, 'real');
+    const link = path.join(base, 'link');
+    fs.mkdirSync(path.join(real, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(real, 'src', 'a.ts'), 'export const a = 1;\n');
+    try {
+      // 'junction' so this works on Windows without developer mode; ignored
+      // on POSIX, where a plain dir symlink needs no privilege.
+      fs.symlinkSync(real, link, 'junction');
+    } catch {
+      return; // links unavailable in this environment — nothing to assert
+    }
+    try {
+      const walked = await walkDirectory({ rootDir: link, excludes: [], includes: [] });
+      expect(walked.map((w) => w.relativePath)).toEqual(['src/a.ts']);
+      // Stated under the root we asked about, not silently re-anchored to the
+      // link's target: ids and absolute paths must both be built from the one
+      // root the caller passed, because the resolvers use that root too.
+      expect(walked[0].absolutePath).toBe(path.join(link, 'src', 'a.ts'));
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('path helpers — behavioural', () => {
   it('toPosixRelative yields a forward-slash id from an OS-native absolute', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,17 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // A large part of this suite is integration-shaped: it spawns `node` on a
+    // hook script or on `dist/index.js`, sometimes several times per test, and
+    // the kb tests load real WASM grammars. Process spawn and WASM
+    // instantiation are markedly slower on Windows than on Linux — enough that
+    // vitest's 5s default failed ~30 otherwise-correct tests there while CI
+    // (ubuntu-only) stayed green and never showed it.
+    //
+    // This is a bound on hangs, not a performance target: nothing here should
+    // come close to 30s. If something does, that is a regression worth
+    // chasing, not a number to raise again.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Follow-up to #149 / #158, found while verifying those fixes on an actual Windows machine.

## The bug class

An absolute path was repeatedly treated as if it were already a forward-slash file id:

```js
f.path.lastIndexOf('/app/')            // never matches on Windows
absPath.startsWith(rootDir + '/')      // always false on Windows
path.slice(path.lastIndexOf('/') + 1)  // returns the WHOLE path on Windows
```

Every instance is **silent**. The comparison goes false, the code takes its "not found" branch, and a whole feature disappears with no error anywhere. That is precisely why this survived months of green ubuntu-only CI, and why the reporter on #149 could not have seen most of it — his hooks never executed at all, so the layer underneath was never exercised.

## What was silently dead on Windows

| area | effect |
|---|---|
| `hooks/evidence.mjs` | **all** evidence collection — capture had nothing to build a worklist from, so the notebook never filled |
| `find`'s scan pass | repo-wide grep-recall returned **zero coverage**, taking the `near` relations and absence-note re-verification with it |
| Rails | controller↔view edges + Zeitwerk constant autoload |
| Laravel | Eloquent + container edges |
| Go | workspaces (`go.work`) and `replace` directives |
| npm / yarn / pnpm | workspace discovery — every `package.json` was parsed as pnpm YAML |
| C++ | CMake include roots |
| `status` | the wired-hook-path health check — the one thing that would have caught #158 |

## Root cause

Most of it traced to a single line. `walkDirectory` returned `relative(rootDir, ...)`, which is OS-native, so `IndexedFile.relativePath` was `app\Models\User.php` on Windows. `buildFileId` normalised the *id* but not the field, and every language's path convention matches on `/` — so they all failed together.

Normalising at the producer fixed Rails, Laravel and patch-synthetic **together**, without touching those resolvers individually: 13 failures → 1.

The invariant is now explicit in `src/indexer/paths.ts` and stamped in `baseIndexedFile`, the shared funnel for all three IndexedFile construction sites, so the patch and probe paths cannot drift from the walker:

- **absolute path** → OS-native; only ever manipulated via `node:path`
- **file id** → always forward-slash, relative to root

## The 18 junk `coldstart status` rows

Reported on #149 — those were **our own test fixtures**. `daemon-lock.test.ts` redirected the state dir with `process.env.HOME`, the POSIX habit, but `os.homedir()` on Windows reads `USERPROFILE` and ignores `HOME`. So on Windows the redirect silently no-opped and every fixture lockfile landed in the developer's real `~/.coldstart/daemon`. Its `afterEach` "sanity check" asserted `realDaemonDir.startsWith(tmpHome)` is false — true whether or not the leak happened, so it could never catch it.

Fixed at both ends: a `COLDSTART_HOME` override that works on every platform (read through a *function*, never a module-level const — a const captures at import time and reintroduces the same bug one level down), and `status` now prunes records whose root no longer exists.

## Results

**Windows: 814/814 green, from 48 failing on `main`.**

Verified end-to-end on a real 9,913-file repo, not just fixtures — `find` returns ranked results with working grep-recall.

## Two things that need a maintainer decision

1. **The Windows CI leg is blocking**, not `continue-on-error`. It is green as of this branch, but any pre-existing flake will block merges once it lands. Trivial to soften if you would rather watch it for a week first.
2. **`isInside()` and the `status` pruning intentionally change macOS/Linux behaviour** — `isInside` also fixes a cross-platform wart where `/repo-backup` counted as inside `/repo`. Everything else is a no-op off Windows by construction, which the new ubuntu leg now proves on every PR.

## Not included

- The reader/keeper cold-start wait (the 24.7s report) — that is platform-independent core logic and belongs on its own branch.
- `coldstart doctor` — a design decision, not a bugfix.
- Two latent keeper holes found while reviewing: PID reuse in the liveness check (`process.kill(pid, 0)` can match a recycled PID, which would also make `coldstart restart` SIGTERM an unrelated process), and an orphaned `.spawn` lock having no staleness check (a hard-kill in that window wedges keeper spawning for that root permanently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
