### PR TITLE
fix(keeper): stop readers blocking on a rebuild they cannot outwait

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { resolve } from 'node:path';
 import { loadCachedIndex, saveCachedIndex, type LoadProfile } from './cache/disk-cache.js';
 import { getGitHead } from './indexer/git.js';
 import { handleGetStructure } from './server/tools.js';
-import { ensureKeeper, waitForKeeperCache, waitForCacheAdvance } from './keeper.js';
+import { ensureKeeper, waitForKeeperCache, waitForCacheHead } from './keeper.js';
 import type { CodebaseIndex } from './types.js';
 
 type BuildFn = (
@@ -103,9 +103,12 @@ export async function getIndex(
       // called by every CLI entry) spawned one, and its startup reconcile
       // re-saves the cache — give that a short window before serving stale.
       err('[coldstart] cache behind git HEAD — waiting for keeper reconcile');
-      if (await waitForCacheAdvance(root, cacheDir)) {
+      const wait = await waitForCacheHead(root, cacheDir, head);
+      if (wait === 'caught-up') {
         index = (await loadCachedIndex(root, cacheDir, profile)) ?? index;
         err(`[coldstart] cache refreshed (${Date.now() - t0}ms, ${index.files.size} files)`);
+      } else if (wait === 'rebuilding') {
+        err('[coldstart] keeper is rebuilding this repo (drift too large to patch) — serving previous index now');
       } else {
         err('[coldstart] keeper still reconciling — serving previous index (rerun shortly for fresh results)');
       }

--- a/src/index-manager.ts
+++ b/src/index-manager.ts
@@ -275,6 +275,7 @@ export class IndexManager {
     const threshold = patchThreshold(this.activeIndex.files.size);
     if (batch.size <= threshold) {
       this.log(`[coldstart] ${batch.size} file(s) changed — patching incrementally`);
+      await this.stamp({ inProgress: { kind: 'patch', at: Date.now(), detail: `${batch.size} file(s)` } });
       try {
         await patchIndex(this.activeIndex, batch, this.activeIndex.rootDir);
         // Invariant lint: a patch that left the graph inconsistent must not
@@ -287,7 +288,7 @@ export class IndexManager {
           return;
         }
         this.log('[coldstart] Incremental patch done');
-        void this.stamp({ lastPatch: { at: Date.now(), detail: `${batch.size} file(s)` } });
+        void this.stamp({ inProgress: null, lastPatch: { at: Date.now(), detail: `${batch.size} file(s)` } });
         this.scheduleCacheSave();
       } catch (err) {
         this.log(`[coldstart] Patch failed (${err}) — falling back to full rebuild`);
@@ -320,16 +321,23 @@ export class IndexManager {
   private async triggerRebuild(): Promise<void> {
     if (this.rebuilding) return;
     this.rebuilding = true;
+    // Published BEFORE the work, not after: the whole point is that a reader
+    // arriving mid-rebuild can see it and stop waiting. A stamp written on
+    // completion would tell it exactly when it no longer needed one.
+    await this.stamp({
+      inProgress: { kind: 'rebuild', at: Date.now(), detail: `${this.activeIndex.files.size} files` },
+    });
     try {
       const newIndex = await this.rebuild();
       this.activeIndex = newIndex; // atomic swap
       this.log(`[coldstart] Rebuild complete (${newIndex.files.size} files)`);
       this.rebuildFailures = 0;
-      void this.stamp({ lastRebuild: { at: Date.now(), detail: `${newIndex.files.size} files` } });
+      void this.stamp({ inProgress: null, lastRebuild: { at: Date.now(), detail: `${newIndex.files.size} files` } });
       this.scheduleCacheSave();
     } catch (err) {
       this.log(`[coldstart] Rebuild failed: ${err}`);
       void this.report('rebuild-failed', String(err));
+      void this.stamp({ inProgress: null });
       this.scheduleRebuildRetry();
     } finally {
       this.rebuilding = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,6 +469,13 @@ async function buildManager(
         }
       } else if (rec.changed.size <= threshold) {
         log(quiet, `[coldstart] Loaded from cache — patching ${rec.changed.size} drifted file(s) (${rec.reason})`);
+        if (!noCache) {
+          await updateKeeperState(
+            finalRoot,
+            { inProgress: { kind: 'patch', at: Date.now(), detail: `${rec.changed.size} file(s)` } },
+            cacheDir,
+          );
+        }
         try {
           await patchIndex(index, rec.changed, finalRoot);
           const problems = lintIndexInvariants(index);
@@ -489,19 +496,36 @@ async function buildManager(
         outcome = `${rec.reason} → over threshold, rebuild`;
         index = null;
       }
-      if (!noCache) await updateKeeperState(finalRoot, { lastReconcile: { at: Date.now(), detail: outcome } }, cacheDir);
+      if (!noCache) {
+        await updateKeeperState(
+          finalRoot,
+          { inProgress: null, lastReconcile: { at: Date.now(), detail: outcome } },
+          cacheDir,
+        );
+      }
     }
   }
 
   if (!index) {
-    index = await buildIndex(finalRoot, excludes, includes, quiet);
+    // This is the branch the reader-wait pathology hangs on: a reader saw the
+    // cache behind HEAD, spawned us, and is now blocking — while the drift
+    // turned out to be repo-scale and this build will take 30-100s. Say so
+    // before starting, so it can serve its stale index and get out.
     if (!noCache) {
-      try {
-        await saveCachedIndex(index, cacheDir);
-        log(quiet, '[coldstart] Index saved to cache');
-      } catch (err) {
-        log(quiet, `[coldstart] Warning: could not save cache: ${err}`);
+      await updateKeeperState(finalRoot, { inProgress: { kind: 'rebuild', at: Date.now() } }, cacheDir);
+    }
+    try {
+      index = await buildIndex(finalRoot, excludes, includes, quiet);
+      if (!noCache) {
+        try {
+          await saveCachedIndex(index, cacheDir);
+          log(quiet, '[coldstart] Index saved to cache');
+        } catch (err) {
+          log(quiet, `[coldstart] Warning: could not save cache: ${err}`);
+        }
       }
+    } finally {
+      if (!noCache) await updateKeeperState(finalRoot, { inProgress: null }, cacheDir);
     }
   }
 
@@ -556,7 +580,9 @@ async function runKeeper(
   // compatibility) on upgrade.
   await writeLock(finalRoot, process.pid, getCurrentVersion());
   log(quiet, `[coldstart] Keeper lock written (PID ${process.pid})`);
-  if (!noCache) await updateKeeperState(finalRoot, { startedAt: Date.now() }, cacheDir);
+  // inProgress: null — a keeper killed mid-rebuild leaves its stamp behind, and
+  // this is the one moment we know for certain no work is running.
+  if (!noCache) await updateKeeperState(finalRoot, { startedAt: Date.now(), inProgress: null }, cacheDir);
 
   // Auto-migrate legacy npx-based .mcp.json entries (non-fatal).
   try { await migrateLegacyMcpConfig(finalRoot); } catch { /* ignore */ }

--- a/src/keeper-state.ts
+++ b/src/keeper-state.ts
@@ -25,9 +25,25 @@ export interface KeeperEventStamp {
   detail: string;
 }
 
+/**
+ * What the keeper is doing RIGHT NOW, if anything. Readers use this to decide
+ * how long to stand still: a patch lands in seconds and is worth waiting for,
+ * a rebuild takes 30-100s on a large repo and never is.
+ *
+ * Present only while the work runs — cleared (set to null) when it finishes,
+ * including on failure. A lingering stamp from a keeper that died mid-rebuild
+ * is harmless: readers check the pid is alive before believing it.
+ */
+export interface KeeperWork {
+  kind: 'patch' | 'rebuild';
+  at: number;
+  detail?: string;
+}
+
 export interface KeeperState {
   pid: number;
   startedAt: number;
+  inProgress?: KeeperWork | null;
   lastReconcile?: KeeperEventStamp;
   lastPatch?: KeeperEventStamp;
   lastRebuild?: KeeperEventStamp;

--- a/src/keeper.ts
+++ b/src/keeper.ts
@@ -9,7 +9,7 @@
  * one already runs.
  */
 import { spawn } from 'node:child_process';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   readLock,
@@ -20,6 +20,7 @@ import {
   tryAcquireSpawnLock,
 } from './daemon-lock.js';
 import { getCacheDir } from './cache/disk-cache.js';
+import { readKeeperState } from './keeper-state.js';
 
 /**
  * Ensure a background keeper is running for `finalRoot`. Spawns one (detached)
@@ -97,24 +98,52 @@ export async function waitForKeeperCache(
   return existsSync(meta) ? 'ready' : 'timeout';
 }
 
+export type HeadWait = 'caught-up' | 'rebuilding' | 'timeout';
+
+/** The gitHead recorded in the cache's commit marker, or null if unreadable. */
+function cachedHead(rootDir: string, cacheDir: string | undefined): string | null {
+  try {
+    const meta = JSON.parse(readFileSync(metaPath(rootDir, cacheDir), 'utf8')) as { gitHead?: string };
+    return typeof meta.gitHead === 'string' ? meta.gitHead : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Wait for the cache to be REWRITTEN (meta.json mtime to advance past its
- * value at call time). Used when a reader sees the cache behind the current
- * git HEAD: the freshly ensured keeper reconciles and re-saves within a few
- * seconds. false = no rewrite within the window (serve the stale index).
+ * Wait for the keeper to bring the cache up to `wantHead`, but only for as long
+ * as that is plausible.
+ *
+ * Two things were wrong with waiting on meta.json's MTIME instead:
+ *
+ *  1. The baseline was read when the wait started, not when the index was
+ *     loaded. A save landing in between made the reader wait the full window
+ *     for a second save that was never coming.
+ *  2. Any save satisfied it, even one that left the cache still behind HEAD.
+ *
+ * The head is the condition the caller actually cares about, and it is exact.
+ *
+ * 'rebuilding' is the fix for the pathology itself: a keeper that has decided
+ * on a full rebuild publishes that decision, and 30-100s of work is not worth
+ * standing still for — the caller serves what it already holds. Absence of a
+ * stamp means keep waiting, NOT bail: a freshly spawned keeper needs a moment
+ * to load the cache and reconcile before it knows what it is doing, and the
+ * common patch case is worth the few seconds it takes.
  */
-export async function waitForCacheAdvance(
+export async function waitForCacheHead(
   rootDir: string,
   cacheDir: string | undefined,
+  wantHead: string,
   timeoutMs = 12_000,
-): Promise<boolean> {
-  const meta = metaPath(rootDir, cacheDir);
-  const mtime = (): number => { try { return statSync(meta).mtimeMs; } catch { return 0; } };
-  const baseline = mtime();
+): Promise<HeadWait> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (mtime() > baseline) return true;
+    if (cachedHead(rootDir, cacheDir) === wantHead) return 'caught-up';
+    const state = readKeeperState(rootDir, cacheDir);
+    // pid check: a keeper killed mid-rebuild leaves its stamp behind, and a
+    // stale stamp must not silently disable the wait forever.
+    if (state?.inProgress?.kind === 'rebuild' && isDaemonAlive(state.pid)) return 'rebuilding';
     await sleep(250);
   }
-  return mtime() > baseline;
+  return cachedHead(rootDir, cacheDir) === wantHead ? 'caught-up' : 'timeout';
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -170,7 +170,11 @@ export async function runStatus(): Promise<void> {
     const state = readKeeperState(root);
     const repairs = readRepairTail(root, 1);
     if (!state && repairs.length === 0) continue;
+    const work = state?.inProgress;
     const parts = [
+      // First, because it explains a stale index better than any of the
+      // "last X" stamps can — the answer is "it is working on it right now".
+      work ? `IN PROGRESS: ${work.kind}${work.detail ? ` (${work.detail})` : ''}, started ${relativeAge(Date.now() - work.at)}` : null,
       stampLine('reconcile', state?.lastReconcile),
       stampLine('patch', state?.lastPatch),
       stampLine('rebuild', state?.lastRebuild),

--- a/tests/freshness-b3b7.test.ts
+++ b/tests/freshness-b3b7.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../src/keeper-state.js';
 import { patchThreshold } from '../src/constants.js';
 import {
-  waitForKeeperCache, waitForCacheAdvance,
+  waitForKeeperCache, waitForCacheHead,
 } from '../src/keeper.js';
 import {
   saveCachedIndex, loadCachedIndex, getCacheDir,
@@ -537,7 +537,7 @@ describe('constants', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: keeper.ts — waitForKeeperCache + waitForCacheAdvance
+// Tests: keeper.ts — waitForKeeperCache + waitForCacheHead
 // ---------------------------------------------------------------------------
 
 describe('keeper waits', () => {
@@ -569,32 +569,83 @@ describe('keeper waits', () => {
     expect(result).toBe('no-keeper');
   });
 
-  it('waitForCacheAdvance: meta.json mtime advances → true', async () => {
-    const metaDir = getCacheDir(testRoot, cacheDir);
+  // -------------------------------------------------------------------------
+  // waitForCacheHead — the reader's HEAD-drift wait. It replaced an mtime
+  // watch that could not tell "the keeper caught up" from "the keeper saved
+  // something, anything" and re-baselined itself at the wrong moment.
+  // -------------------------------------------------------------------------
+
+  const writeMeta = (root: string, dir: string, gitHead: string): void => {
+    const metaDir = getCacheDir(root, dir);
     fs.mkdirSync(metaDir, { recursive: true });
+    fs.writeFileSync(path.join(metaDir, 'meta.json'), JSON.stringify({ version: '18.0.0', gitHead }));
+  };
 
-    const metaPath = path.join(metaDir, 'meta.json');
-    fs.writeFileSync(metaPath, JSON.stringify({ version: '18.0.0' }));
-
-    // Schedule a rewrite ~300ms in
-    const promise = waitForCacheAdvance(testRoot, cacheDir, 700);
-    setTimeout(() => {
-      fs.writeFileSync(metaPath, JSON.stringify({ version: '18.0.0', updated: true }));
-    }, 300);
-
-    const result = await promise;
-    expect(result).toBe(true);
+  it('waitForCacheHead: cache already at the wanted head → "caught-up" with no wait', async () => {
+    writeMeta(testRoot, cacheDir, 'abc123');
+    const started = Date.now();
+    expect(await waitForCacheHead(testRoot, cacheDir, 'abc123', 5000)).toBe('caught-up');
+    expect(Date.now() - started).toBeLessThan(500);
   });
 
-  it('waitForCacheAdvance: nothing changes → false', async () => {
-    const metaDir = getCacheDir(testRoot, cacheDir);
-    fs.mkdirSync(metaDir, { recursive: true });
-    const metaPath = path.join(metaDir, 'meta.json');
-    fs.writeFileSync(metaPath, JSON.stringify({ version: '18.0.0' }));
+  it('waitForCacheHead: keeper re-saves at the new head mid-wait → "caught-up"', async () => {
+    writeMeta(testRoot, cacheDir, 'old-head');
+    const promise = waitForCacheHead(testRoot, cacheDir, 'new-head', 3000);
+    setTimeout(() => writeMeta(testRoot, cacheDir, 'new-head'), 300);
+    expect(await promise).toBe('caught-up');
+  });
 
-    // Short timeout, no changes
-    const result = await waitForCacheAdvance(testRoot, cacheDir, 600);
-    expect(result).toBe(false);
+  it('waitForCacheHead: a save that leaves the cache BEHIND head is not caught-up', async () => {
+    // The mtime watch this replaced returned true here: the file was
+    // rewritten, so it declared success while the cache was still stale.
+    writeMeta(testRoot, cacheDir, 'old-head');
+    const promise = waitForCacheHead(testRoot, cacheDir, 'new-head', 1200);
+    setTimeout(() => writeMeta(testRoot, cacheDir, 'another-old-head'), 300);
+    expect(await promise).toBe('timeout');
+  });
+
+  it('waitForCacheHead: a live keeper stamped "rebuild" → bails immediately, well inside the window', async () => {
+    // The pathology: a rebuild takes 30-100s and the reader used to stand
+    // still for its full 12s ceiling before serving the index it already had.
+    writeMeta(testRoot, cacheDir, 'old-head');
+    await updateKeeperState(
+      testRoot,
+      { inProgress: { kind: 'rebuild', at: Date.now(), detail: '9913 files' } },
+      cacheDir,
+    );
+    const started = Date.now();
+    expect(await waitForCacheHead(testRoot, cacheDir, 'new-head', 10_000)).toBe('rebuilding');
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('waitForCacheHead: a "patch" stamp is NOT a reason to bail — that case is worth waiting for', async () => {
+    writeMeta(testRoot, cacheDir, 'old-head');
+    await updateKeeperState(
+      testRoot,
+      { inProgress: { kind: 'patch', at: Date.now(), detail: '4 file(s)' } },
+      cacheDir,
+    );
+    const promise = waitForCacheHead(testRoot, cacheDir, 'new-head', 3000);
+    setTimeout(() => writeMeta(testRoot, cacheDir, 'new-head'), 400);
+    expect(await promise).toBe('caught-up');
+  });
+
+  it('waitForCacheHead: a rebuild stamp from a DEAD keeper is ignored', async () => {
+    // A keeper killed mid-rebuild leaves its stamp behind forever. Believing
+    // it would silently disable the wait for every future reader.
+    writeMeta(testRoot, cacheDir, 'old-head');
+    await updateKeeperState(
+      testRoot,
+      { inProgress: { kind: 'rebuild', at: Date.now() } },
+      cacheDir,
+    );
+    // updateKeeperState always stamps the CURRENT pid; overwrite with a dead one.
+    const statePath = keeperStatePath(testRoot, cacheDir);
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    state.pid = 0x7ffffff0; // far above any real pid on either platform
+    fs.writeFileSync(statePath, JSON.stringify(state));
+
+    expect(await waitForCacheHead(testRoot, cacheDir, 'new-head', 800)).toBe('timeout');
   });
 });
 


### PR DESCRIPTION
## The problem

A CLI reader that finds the cache behind git HEAD spawns a keeper and blocks in `waitForCacheAdvance` for up to 12s, hoping for a re-save.

Meanwhile the keeper compares the drifted set against `patchThreshold` (`max(30, 20% of files)`) and, when the drift is repo-scale, starts a **full rebuild** — measured at **94.8s for 9,913 files**.

So the reader waits 12s for work that takes 30-100s. The wait always expires, and it then serves the exact stale index it already held in memory 12 seconds earlier. The cache stays behind HEAD until the keeper finishes, so every subsequent `find`/`gs` in that window pays its own 12s.

**The wait is longest and most futile precisely when the drift is largest.**

Reported independently on Windows (#149) and on macOS — it is platform-independent. This is the "tool feels slow, so the agent goes back to Grep" failure.

## The fix

The keeper publishes what it is doing *before* it starts, in `keeper-state.json`:

```json
"inProgress": { "kind": "rebuild", "at": 1756..., "detail": "9913 files" }
```

The reader bails the moment it sees `rebuild` and serves what it already has.

Absence of a stamp still means **keep waiting**, not bail — a freshly spawned keeper needs a beat to load the cache and reconcile before it knows what it is doing, and the common patch case is worth the few seconds it takes.

`waitForCacheAdvance` is replaced by `waitForCacheHead`, which polls `meta.json`'s `gitHead` rather than its mtime. The mtime watch was wrong twice over:

1. It baselined when the *wait* started, not when the *index was loaded*. A save landing in between made it wait the full window for a second save that was never coming.
2. Any save satisfied it — including one that left the cache still behind HEAD.

The head is the condition the caller actually cares about, and it is exact.

## Safety

- A rebuild stamp is only believed if the stamping **pid is alive**, so a keeper killed mid-rebuild cannot silently disable the wait for every future reader. A keeper also clears the field on startup.
- `inProgress` is cleared on success **and** on failure.
- `coldstart status` renders in-progress work first — it explains a stale index better than any "last X" stamp can.

**Untouched:** indexing, the patch-vs-rebuild decision, the cache format, and the atomic generation swap. Only how long a reader stands still before printing.

## Tests

Six cases in `tests/freshness-b3b7.test.ts`, including the two that pin the behaviour change: a live `rebuild` stamp returns in <1s of a 10s window, and a `patch` stamp does **not** bail. Also covered: a save that leaves the cache behind HEAD is not "caught up", and a stamp from a dead keeper is ignored.

Full suite green on Linux; on Windows it inherits the pre-existing `main` failures that #159 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)