### PR TITLE
Consolidate footer.css imports across page-shell stylesheets

### DIFF
--- a/site-astro/src/components/Footer.astro
+++ b/site-astro/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
-// Styling lives in styles/footer.css, which is pulled in by backdrop.css —
-// so a page gets the footer's chrome from the same import that gives it the
-// background field. See the comment at the top of footer.css.
+// Styling lives in styles/footer.css, imported by all three page-shell
+// stylesheets (landing.css, docs.css, backdrop.css) so every page that
+// renders this component gets it without a fourth per-page import.
 interface Props { variant?: 'home' | 'docs' | 'blog' | 'how' | 'live' }
 const { variant = 'docs' } = Astro.props;
 

--- a/site-astro/src/styles/backdrop.css
+++ b/site-astro/src/styles/backdrop.css
@@ -1,8 +1,10 @@
-/* The shared footer rides along here on purpose. Every page shell already
-   imports this file, and a per-page footer import would be a third thing a
-   new page can silently forget - /live/ shipped without this very file once.
-   footer.css defines no tokens, so being hoisted above the :root below is
-   harmless. */
+/* footer.css is ALSO imported directly by landing.css and docs.css, the
+   two page-shell stylesheets that DON'T import this file — this file
+   alone was not the universal footer carrier the original comment here
+   claimed: only demo/, live/, and BlogPostLayout import it, while every
+   page renders <Footer/>. A page that imports both this file and
+   landing.css/docs.css (demo, live, blog posts) gets footer.css twice;
+   harmless since the rules are identical, just redundant parsing. */
 @import "./footer.css";
 
 /* ============================================================

--- a/site-astro/src/styles/docs.css
+++ b/site-astro/src/styles/docs.css
@@ -1,6 +1,7 @@
 /* coldstart docs — dark design system, tokens matched to landing.css
    frost = navigation/index, ember = notebook/memory */
 @import './tokens.css';
+@import './footer.css';
 
 /* ============================================================
    THE FIELD — frost bleeding from left, ember from right, over dark ramp.

--- a/site-astro/src/styles/landing.css
+++ b/site-astro/src/styles/landing.css
@@ -3,6 +3,7 @@
    temperature = concept: frost = the cold exact index, ember = the warm memory.
    ============================================================ */
 @import './tokens.css';
+@import './footer.css';
 
 /* ============================================================
    THE FIELD — frost bleeding from left, ember from right, over dark ramp.


### PR DESCRIPTION
## Summary
Moves `footer.css` imports from being solely in `backdrop.css` to being imported directly by all three page-shell stylesheets (`landing.css`, `docs.css`, and `backdrop.css`). This ensures every page that renders the `<Footer/>` component has its styles available without relying on a single indirect import path.

## Changes
- **docs.css & landing.css**: Added direct `@import './footer.css'` statements to ensure footer styles are available on all pages using these stylesheets
- **backdrop.css**: Updated the comment to reflect the new import strategy and clarify that footer.css is now imported by multiple page-shell stylesheets, not just this one
- **Footer.astro**: Updated the component comment to document that footer.css is imported by all three page-shell stylesheets, eliminating the need for a fourth per-page import

## Implementation Details
- Pages that import multiple page-shell stylesheets (demo, live, blog posts) will now parse `footer.css` twice, but this is harmless since the rules are identical
- This change makes the footer styling more explicit and less dependent on a single shared import path, reducing the risk of pages silently shipping without footer styles (as mentioned in the original comment)
- The approach aligns with the principle that every page rendering `<Footer/>` should have its styles available through the stylesheet it already imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)